### PR TITLE
Add initial support for app: URL

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -621,7 +621,7 @@ parameter in other standards.
   <dl class=switch>
    <dt><var title>url</var>'s <span>origin</span> is <var title>origin</var> and the <i title>CORS flag</i> is unset
    <dt><var title>url</var>'s <span data-anolis-spec=url title=concept-url-scheme>scheme</span>
-   is one of "<code title>about</code>", "<code title>blob</code>", and "<code title>data</code>",
+   is one of "<code title>about</code>", "<code title>blob</code>", "<code title>app</code>", and "<code title>data</code>",
    and <var title>request</var>'s <span title=concept-request-redirect-count>redirect count</span> is zero
 
    <dd><p>The result of performing a <span title=concept-basic-fetch>basic fetch</span> using <var title>request</var>.
@@ -774,6 +774,20 @@ steps:
   <p class=XXX>It has been argued this should be handled outside of
   <span title=concept-fetch>fetching</span>.
 
+ <dt>"<code title>app</code>"
+ <dd>
+   <p>If <var title>request</var>'s <span title=concept-request-method>method</span> is
+  `<code title>GET</code>` and <a href="http://sysapps.github.io/app-uri/#obtaining-a-resource">
+   obtaining a resource</a> from <var title>request</var>'s 
+   <span title=concept-request-url>url</span> and origin does not return
+   failure, return a <span title=concept-response>response</span> whose
+   <span title=concept-response-headers>headers</span> consist of a single
+   <span title=concept-header>header</span> whose
+   <span title=concept-header-name>name</span> is `<code title>Content-Type</code>` and
+   <span title=concept-header-value>value</span> is the MIME type and parameters returned
+   from <a href="http://sysapps.github.io/app-uri/#obtaining-a-resource">obtaining a resource</a>, 
+   and <span title=concept-response-body>body</span> is the data returned from  obtaining a resource.
+   <p>Otherwise, return a <span title=concept-network-error>network error</span>.
  <dt>"<code title>data</code>"
  <dd>
   <p>If <var title>request</var>'s <span title=concept-request-method>method</span> is


### PR DESCRIPTION
The app: URL is used by FxOS and Intel's cross-walk. The SysApps WG would like to standardize this. Instead of [monkey patching](http://annevankesteren.nl/2014/02/monkey-patch), I thought I would try to add it here. 
