### PR TITLE
Fix "nosniff?" link in order to avoid anolis bug.

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-7-september-2015">Living Standard — Last Updated 7 September 2015</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-9-september-2015">Living Standard — Last Updated 9 September 2015</h2>
 
 <dl>
  <dt>Participate:
@@ -67,7 +67,8 @@ fetching.
      <li><a href="#http-new-header-syntax"><span class="secno">4.2.4 </span>HTTP new-header syntax</a></ol></li>
    <li><a href="#x-content-type-options-header"><span class="secno">4.3 </span>`<code title="">X-Content-Type-Options</code>` header</a>
     <ol>
-     <li><a href="#should-response-to-request-be-blocked-due-to-nosniff?"><span class="secno">4.3.1 </span>Should <var title="">response</var> to <var title="">request</var> be blocked due to nosniff?</a></ol></ol></li>
+     <li><a href="#should-response-to-request-be-blocked-due-to-nosniff"><span class="secno">4.3.1 </span>Should
+<var title="">response</var> to <var title="">request</var> be blocked due to nosniff?</a></ol></ol></li>
  <li><a href="#fetching"><span class="secno">5 </span>Fetching</a>
   <ol>
    <li><a href="#main-fetch"><span class="secno">5.1 </span>Main fetch</a></li>
@@ -1287,7 +1288,8 @@ response <a href="#concept-header" title="concept-header">header</a> can be used
 
 <pre>X-Content-Type-Options           = "nosniff" ; case-insensitive</pre>
 
-<h4 id="should-response-to-request-be-blocked-due-to-nosniff?"><span class="secno">4.3.1 </span><dfn>Should <var title="">response</var> to <var title="">request</var> be blocked due to nosniff?</dfn></h4>
+<h4 id="should-response-to-request-be-blocked-due-to-nosniff"><span class="secno">4.3.1 </span><dfn title="should response to request be blocked due to nosniff">Should
+<var title="">response</var> to <var title="">request</var> be blocked due to nosniff?</dfn></h4>
 
 <p>Run these steps:
 
@@ -1622,7 +1624,7 @@ redirects.
  <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-response">should <var>internalResponse</var> to <var>request</var> be blocked as mixed content</a>,
  <span class="XXX">should <var>internalResponse</var> to <var title="">request</var> be blocked as content security</span>,
  or
- <a href="#should-response-to-request-be-blocked-due-to-nosniff?" title="should response to request be blocked due to nosniff?">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</a>
+ <a href="#should-response-to-request-be-blocked-due-to-nosniff" title="should response to request be blocked due to nosniff">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</a>
  returns <b title="">blocked</b>, set <var title="">response</var> to a
  <a href="#concept-network-error" title="concept-network-error">network error</a>.
  <a href="#refsMIX">[MIX]</a>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1232,7 +1232,8 @@ response <span title=concept-header>header</span> can be used to require checkin
 
 <pre>X-Content-Type-Options           = "nosniff" ; case-insensitive</pre>
 
-<h4><dfn>Should <var title>response</var> to <var title>request</var> be blocked due to nosniff?</dfn></h4>
+<h4><dfn title="should response to request be blocked due to nosniff">Should
+<var title>response</var> to <var title>request</var> be blocked due to nosniff?</dfn></h4>
 
 <p>Run these steps:
 
@@ -1567,7 +1568,7 @@ redirects.
  <a href=https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-response>should <var>internalResponse</var> to <var>request</var> be blocked as mixed content</a>,
  <span class=XXX>should <var>internalResponse</var> to <var title>request</var> be blocked as content security</span>,
  or
- <span title="should response to request be blocked due to nosniff?">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</span>
+ <span title="should response to request be blocked due to nosniff">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</span>
  returns <b title>blocked</b>, set <var title>response</var> to a
  <span title=concept-network-error>network error</span>.
  <span data-anolis-ref>MIX</span>


### PR DESCRIPTION
Anolis cannot treat definitions including "?" correctly in some environments. This change
replaces "...nosniff?" definition with "...nosniff" in order to avoid the bug. 

See https://github.com/whatwg/xref/pull/7 for details.