### PR TITLE
Update Fetch with shiny, new CSP hooks

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-13-october-2015">Living Standard — Last Updated 13 October 2015</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-15-october-2015">Living Standard — Last Updated 15 October 2015</h2>
 
 <dl>
  <dt>Participate:
@@ -969,6 +969,12 @@ suites, certificates for an "Internal Name", or certificates with an overly long
 period. How exactly a user agent can use "<code title="">deprecated</code>" is not defined by
 this specification.
 
+<p>A <a href="#concept-response" title="concept-response">response</a> has an associated
+<dfn id="concept-response-csp-list" title="concept-response-csp-list">CSP list</dfn>, which is a list of
+<a href="https://w3c.github.io/webappsec-csp/#policy">Content Security Policy objects</a>
+for the <a href="#concept-response" title="concept-response">response</a>. The list is empty unless otherwise
+specified. <a href="#refsCSP">[CSP]</a>
+
 <hr>
 
 <p>A <a href="#concept-response" title="concept-response">response</a> whose
@@ -1724,7 +1730,7 @@ redirects.
  <li><p>If
  <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-fetch">should fetching <var title="">request</var> be blocked as mixed content</a>
  or
- <span class="XXX">should fetching <var title="">request</var> be blocked as content security</span>
+ <a href="https://w3c.github.io/webappsec-csp/#should-block-request">should fetching <var>request</var> be blocked by Content Security Policy</a>
  returns <b title="">blocked</b>, set <var title="">response</var> to a
  <a href="#concept-network-error" title="concept-network-error">network error</a>.
  <a href="#refsMIX">[MIX]</a>
@@ -1857,7 +1863,7 @@ redirects.
 
  <li><p>If
  <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-response">should <var>internalResponse</var> to <var>request</var> be blocked as mixed content</a>,
- <span class="XXX">should <var>internalResponse</var> to <var title="">request</var> be blocked as content security</span>,
+ <a href="https://w3c.github.io/webappsec-csp/#should-block-response">should <var>internalResponse</var> to <var>request</var> be blocked by Content Security Policy</a>,
  or
  <a href="#should-response-to-request-be-blocked-due-to-nosniff?" title="should response to request be blocked due to nosniff">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</a>
  returns <b title="">blocked</b>, set <var title="">response</var> to a
@@ -2148,6 +2154,14 @@ indicates an attempt to authenticate.
      "<code title="">manual</code>" and <var title="">response</var>'s
      <a href="#concept-response-type" title="concept-response-type">type</a> is "<code title="">opaqueredirect</code>".
     </ul>
+
+   <li>
+     <p>If <var>response</var> is a <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>,
+     then execute <a href="https://w3c.github.io/webappsec-csp/set-response-policy-list">set
+     <var>response</var>'s CSP list</a> on <var>response</var>'s
+     <a href="#concept-internal-response" title="concept-internal-response">internal response</a>. Otherwise, execute
+     <a href="https://w3c.github.io/webappsec-csp/set-response-policy-list">set
+     <var>response</var>'s CSP list</a> on <var>response</var>. <a href="#refsCSP">[CSP]</a>
   </ol>
 
  <li>
@@ -2793,6 +2807,9 @@ The <i title="">credentials flag</i> is one too.
   <p class="XXX">Gecko
   <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1030660">bug 1030660</a> looks
   into whether this quirk can be removed.
+
+ <li><p>Execute <a href="https://w3c.github.io/webappsec-csp/set-response-policy-list">set
+ <var>response</var>'s CSP list</a> on <var>response</var>. <a href="#refsCSP">[CSP]</a>
 
  <li><p>If <var title="">response</var> is not a
  <a href="#concept-network-error" title="concept-network-error">network error</a> and <var title="">request</var>'s
@@ -4620,6 +4637,8 @@ however, it is perfectly fine to do so.
 <dd><cite><a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a></cite>, Roy Fielding and Julian Reschke. IETF.
 
 <dd><cite><a href="https://tools.ietf.org/html/rfc7234">Hypertext Transfer Protocol (HTTP/1.1): Caching</a></cite>, Roy Fielding and Julian Reschke. IETF.
+
+<dd><cite><a href="https://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a></cite>, Roy Fielding and Julian Reschke. IETF.
 
 <dt id="refsHTTPVERBSEC">[HTTPVERBSEC]
 <dd>(Non-normative) <cite><a href="https://www.kb.cert.org/vuls/id/867593">Multiple vendors' web servers enable HTTP TRACE method by default</a></cite>. US-CERT.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -908,6 +908,12 @@ suites, certificates for an "Internal Name", or certificates with an overly long
 period. How exactly a user agent can use "<code title>deprecated</code>" is not defined by
 this specification.
 
+<p>A <span title=concept-response>response</span> has an associated
+<dfn title=concept-response-csp-list>CSP list</dfn>, which is a list of
+<a href=https://w3c.github.io/webappsec-csp/#policy>Content Security Policy objects</a>
+for the <span title=concept-response>response</span>. The list is empty unless otherwise
+specified. <span data-anolis-ref>CSP</span>
+
 <hr>
 
 <p>A <span title=concept-response>response</span> whose
@@ -1663,7 +1669,7 @@ redirects.
  <li><p>If
  <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-fetch">should fetching <var title>request</var> be blocked as mixed content</a>
  or
- <span class=XXX>should fetching <var title>request</var> be blocked as content security</span>
+ <a href="https://w3c.github.io/webappsec-csp/#should-block-request">should fetching <var>request</var> be blocked by Content Security Policy</a>
  returns <b title>blocked</b>, set <var title>response</var> to a
  <span title=concept-network-error>network error</span>.
  <span data-anolis-ref>MIX</span>
@@ -1796,7 +1802,7 @@ redirects.
 
  <li><p>If
  <a href=https://w3c.github.io/webappsec/specs/mixedcontent/#should-block-response>should <var>internalResponse</var> to <var>request</var> be blocked as mixed content</a>,
- <span class=XXX>should <var>internalResponse</var> to <var title>request</var> be blocked as content security</span>,
+ <a href=https://w3c.github.io/webappsec-csp/#should-block-response>should <var>internalResponse</var> to <var>request</var> be blocked by Content Security Policy</a>,
  or
  <span title="should response to request be blocked due to nosniff">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</span>
  returns <b title>blocked</b>, set <var title>response</var> to a
@@ -2087,6 +2093,14 @@ indicates an attempt to authenticate.
      "<code title>manual</code>" and <var title>response</var>'s
      <span title=concept-response-type>type</span> is "<code title>opaqueredirect</code>".
     </ul>
+
+   <li>
+     <p>If <var>response</var> is a <span title=concept-filtered-response>filtered response</span>,
+     then execute <a href=https://w3c.github.io/webappsec-csp/set-response-policy-list>set
+     <var>response</var>'s CSP list</a> on <var>response</var>'s
+     <span title=concept-internal-response>internal response</span>. Otherwise, execute
+     <a href=https://w3c.github.io/webappsec-csp/set-response-policy-list>set
+     <var>response</var>'s CSP list</a> on <var>response</var>. <span data-anolis-ref>CSP</span>
   </ol>
 
  <li>
@@ -2732,6 +2746,9 @@ The <i title>credentials flag</i> is one too.
   <p class=XXX>Gecko
   <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1030660">bug 1030660</a> looks
   into whether this quirk can be removed.
+
+ <li><p>Execute <a href=https://w3c.github.io/webappsec-csp/set-response-policy-list>set
+ <var>response</var>'s CSP list</a> on <var>response</var>. <span data-anolis-ref>CSP</span>
 
  <li><p>If <var title>response</var> is not a
  <span title=concept-network-error>network error</span> and <var title>request</var>'s


### PR DESCRIPTION
Content Security Policy has defined a set of integrations with Fetch
that make a little more sense than the hand-wavey "Whenever the
user agent requests a resource ..." descriptions in CSP1 and CSP2.
Finally.

This patch updates Fetch's placeholders to link to the new algorithms,
and adds a "policy list" attribute to response objects in order to
support those algorithms' requirements.