### PR TITLE
Mark passed Request object as disturbed

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-15-october-2015">Living Standard — Last Updated 15 October 2015</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-29-october-2015">Living Standard — Last Updated 29 October 2015</h2>
 
 <dl>
  <dt>Participate:
@@ -3999,7 +3999,7 @@ constructor must run these steps:
 
   <ol>
    <li><p>Set <var>input</var>'s <a href="#concept-request-request" title="concept-Request-request">request</a>'s
-   <a href="#concept-request-body" title="concept-request-body">body</a> to null.
+   <a href="#concept-request-body" title="concept-request-body">body</a> to an empty byte stream.
 
    <li><p>Set <var>input</var>'s
    <a href="#concept-request-disturbed-flag" title="concept-Request-disturbed-flag">disturbed flag</a>.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -3938,7 +3938,7 @@ constructor must run these steps:
 
   <ol>
    <li><p>Set <var>input</var>'s <span title=concept-Request-request>request</span>'s
-   <span title=concept-request-body>body</span> to null.
+   <span title=concept-request-body>body</span> to an empty byte stream.
 
    <li><p>Set <var>input</var>'s
    <span title=concept-Request-disturbed-flag>disturbed flag</span>.


### PR DESCRIPTION
Let `req` be a Request with a non-null body. When constructing a new Request
from it, it should be marked as disturbed so as not to confuse users. As a
Request with the null body cannot be disturbed, this change sets `req`'s body
to an empty byte stream.

This was discussed at #61. It is not yet decided whether we make it possible to disturb a Request with the null body or setting the body to a non-null stream in such cases, but they are indistinguishable until we expose Request.prototype.body. See https://github.com/yutakahirano/fetch-with-streams/issues/60.