### PR TITLE
Separate 'report-only' and 'enforce' CSP execution

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-4-november-2015">Living Standard — Last Updated 4 November 2015</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-6-november-2015">Living Standard — Last Updated 6 November 2015</h2>
 
 <dl>
  <dt>Participate:
@@ -1716,6 +1716,9 @@ redirects.
  <var>request</var>'s <a href="#concept-request-current-url" title="concept-request-current-url">current url</a> is
  not <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#is-local" title="is local">local</a>, set
  <var>response</var> to a <a href="#concept-network-error" title="concept-network-error">network error</a>.
+
+ <li><p>Execute <a href="https://w3c.github.io/webappsec-csp/#report-for-request">Report Content Security Policy violations for <var>request</var></a>.
+ <a href="#refsCSP">[CSP]</a>
 
  <li><p><a href="https://w3c.github.io/webappsec/specs/upgrade/#upgrade-request">Upgrade <var>request</var> to a potentially secure URL, if appropriate</a>.
  <a href="#refsUPGRADE">[UPGRADE]</a>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1656,6 +1656,9 @@ redirects.
  not <span data-anolis-spec=url title="is local">local</span>, set
  <var>response</var> to a <span title=concept-network-error>network error</span>.
 
+ <li><p>Execute <a href="https://w3c.github.io/webappsec-csp/#report-for-request">Report Content Security Policy violations for <var>request</var></a>.
+ <span data-anolis-ref>CSP</span>
+
  <li><p><a href="https://w3c.github.io/webappsec/specs/upgrade/#upgrade-request">Upgrade <var>request</var> to a potentially secure URL, if appropriate</a>.
  <span data-anolis-ref>UPGRADE</span>
 


### PR DESCRIPTION
We need to do CSP reporting before we do any upgrades or mixed content checks.
This patch adjusts Main Fetch accordingly.