### PR TITLE
improve example

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -3073,7 +3073,8 @@ currently lacking when it comes to request progression (not response progression
 
  <pre>fetch("https://pk.example/berlin-calling.json", {mode:"cors"})
   .then(res => {
-    if(res.headers.get("content-type") == "application/json") {
+    if(res.headers.get("content-type") &amp;&amp;
+       res.headers.get("content-type").toLowerCase().indexOf("application/json") >= 0) {
       return res.json()
     } else {
       throw new TypeError()
@@ -4620,6 +4621,7 @@ Philip Jägenstedt,
 R. Auburn,
 Ryan Sleevi,
 Sébastien Cevey,
+Shao-xuan Kang,
 Sharath Udupa,
 Shivakumar Jagalur Matt,
 Simon Pieters,


### PR DESCRIPTION
`res.headers.get("content-type")` could be `null` or `Application/json; Charset=utf-8`