### PR TITLE
fixed an outdated url in HTTP fetch spec

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2100,7 +2100,7 @@ indicates an attempt to authenticate.
    <span title=concept-request-url-list>url list</span>.
 
    <li><p>Execute
-   <a href=https://w3c.github.io/webappsec-csp/set-response-policy-list>set <var>response</var>'s CSP list</a>
+   <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
    on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
   </ol>
 
@@ -2730,7 +2730,7 @@ The <i title>credentials flag</i> is one too.
  <var>request</var>'s <span title=concept-request-url-list>url list</span>.
 
  <li><p>Execute
- <a href=https://w3c.github.io/webappsec-csp/set-response-policy-list>set <var>response</var>'s CSP list</a>
+ <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
  on <var>response</var>. <span data-anolis-ref>CSP</span>
 
  <li><p>If <var>response</var> is not a
@@ -4598,6 +4598,7 @@ Mike West,
 Mohamed Zergaoui,
 Ms2ger,
 Nikhil Marathe,
+Nikki Bee,
 Nikunj Mehta,
 Odin H&oslash;rthe Omdal,
 Ondřej Žára,


### PR DESCRIPTION
I noticed, in substep 5 of step 3 in the HTTP Fetch specification, that the "set response's CSP list" link is outdated, so I've changed it to what seems like the correct url.