### PR TITLE
Fix Response body IDL

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-14-december-2015">Living Standard — Last Updated 14 December 2015</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-15-december-2015">Living Standard — Last Updated 15 December 2015</h2>
 
 <dl>
  <dt>Participate:
@@ -4083,7 +4083,7 @@ interface <dfn id="response">Response</dfn> {
   readonly attribute boolean <a href="#dom-response-ok" title="dom-Response-ok">ok</a>;
   readonly attribute ByteString <a href="#dom-response-statustext" title="dom-Response-statusText">statusText</a>;
   [SameObject] readonly attribute <a href="#headers">Headers</a> <a href="#dom-response-headers" title="dom-Response-headers">headers</a>;
-  [SameObject] readonly attribute <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> <a href="#dom-response-body" title="dom-Response-body">body</a>;
+  readonly attribute <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a>? <a href="#dom-response-body" title="dom-Response-body">body</a>;
 
   [NewObject] <a href="#response">Response</a> <a href="#dom-response-clone" title="dom-Response-clone">clone</a>();
 };

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -4022,7 +4022,7 @@ interface <dfn>Response</dfn> {
   readonly attribute boolean <span title=dom-Response-ok>ok</span>;
   readonly attribute ByteString <span title=dom-Response-statusText>statusText</span>;
   [SameObject] readonly attribute <span>Headers</span> <span title=dom-Response-headers>headers</span>;
-  [SameObject] readonly attribute <code title=concept-ReadableStream>ReadableStream</code> <span title=dom-Response-body>body</span>;
+  readonly attribute <code title=concept-ReadableStream>ReadableStream</code>? <span title=dom-Response-body>body</span>;
 
   [NewObject] <span>Response</span> <span title=dom-Response-clone>clone</span>();
 };


### PR DESCRIPTION
This change fixes the type of Response.prototype.body.
 - It should not be [SameObject] as clone() will change the attribute.
 - It should be nullable.