### PR TITLE
Clarify main fetch recursive invocation from redirect-fetch#217

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -1829,7 +1829,11 @@ if the ongoing fetch is updating the response in the HTTP cache for the request.
 <h3 id="main-fetch"><span class="secno">5.1 </span>Main fetch</h3>
 
 <p>To perform a <dfn id="concept-main-fetch" title="concept-main-fetch">main fetch</dfn> using
-<var>request</var>, optionally with a <i title="">CORS flag</i>, run these steps:
+<var>request</var>, optionally with a <i title="">CORS flag</i> and <i title="">recursive flag</i>,
+run these steps:
+
+<p class="note">The <i title="">recursive flag</i> is set when the <a href="#concept-main-fetch">main fetch</a> has been
+invoked recursively
 
 <p class="note no-backref">The <i title="">CORS flag</i> is a bookkeeping detail for handling
 redirects.
@@ -1877,7 +1881,7 @@ redirects.
  <!-- Per Mike West HSTS happens "probably after" Referrer -->
 
  <li><p>If <var>request</var>'s <a href="#synchronous-flag">synchronous flag</a> is unset and
- <a href="#concept-main-fetch" title="concept-main-fetch">main fetch</a> is not invoked recursively, run the
+ <i>recursive flag</i> is unset, run the
  remaining steps <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
 
  <li>
@@ -1953,7 +1957,7 @@ redirects.
     <var>request</var> with the <i title="">CORS flag</i> set.
   </dl>
 
- <li><p>If <a href="#concept-main-fetch" title="concept-main-fetch">main fetch</a> is invoked recursively, return
+ <li><p>If the <i>recursive flag</i> is set, return
  <var>response</var>.
 
  <li>
@@ -2512,7 +2516,7 @@ in addition to <a href="#concept-http-fetch" title="concept-http-fetch">HTTP fet
 
  <li>
   <p>Return the result of performing a <a href="#concept-main-fetch" title="concept-main-fetch">main fetch</a> using
-  <var>request</var>, with the <i>CORS flag</i> set if set.
+  <var>request</var>, with the <i>CORS flag</i> set if previously set, and the <i>recursive flag</i> set.
 
   <p class="note no-backref">This has to invoke <a href="#concept-main-fetch" title="concept-main-fetch">main fetch</a> to
   get <a href="#concept-request-response-tainting" title="concept-request-response-tainting">response tainting</a> correct.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1767,7 +1767,11 @@ if the ongoing fetch is updating the response in the HTTP cache for the request.
 <h3>Main fetch</h3>
 
 <p>To perform a <dfn title=concept-main-fetch>main fetch</dfn> using
-<var>request</var>, optionally with a <i title>CORS flag</i>, run these steps:
+<var>request</var>, optionally with a <i title>CORS flag</i> and <i title>recursive flag</i>,
+run these steps:
+
+<p class="note">The <i title>recursive flag</i> is set when the <span title="concept-main-fetch">main fetch</span> has been
+invoked recursively
 
 <p class="note no-backref">The <i title>CORS flag</i> is a bookkeeping detail for handling
 redirects.
@@ -1815,8 +1819,7 @@ redirects.
  <!-- Per Mike West HSTS happens "probably after" Referrer -->
 
  <li><p>If <var>request</var>'s <span>synchronous flag</span> is unset and
- <span title=concept-main-fetch>main fetch</span> is not invoked recursively, run the
- remaining steps <span data-anolis-spec=html>in parallel</span>.
+ <i title>recursive flag</i> is unset, run the remaining steps <span data-anolis-spec=html>in parallel</span>.
 
  <li>
   <p>If <var>response</var> is null, set <var>response</var> to the value
@@ -1891,7 +1894,7 @@ redirects.
     <var>request</var> with the <i title>CORS flag</i> set.
   </dl>
 
- <li><p>If <span title=concept-main-fetch>main fetch</span> is invoked recursively, return
+ <li><p>If the <i>recursive flag</i> is set, return
  <var>response</var>.
 
  <li>
@@ -2450,7 +2453,7 @@ in addition to <span title=concept-http-fetch>HTTP fetch</span> above.
 
  <li>
   <p>Return the result of performing a <span title=concept-main-fetch>main fetch</span> using
-  <var>request</var>, with the <i>CORS flag</i> set if set.
+  <var>request</var>, with the <i>CORS flag</i> set if previously set, and the <i>recursive flag</i> set.
 
   <p class="note no-backref">This has to invoke <span title=concept-main-fetch>main fetch</span> to
   get <span title=concept-request-response-tainting>response tainting</span> correct.


### PR DESCRIPTION
Specification on main fetch should clarify the role of a `recursive flag` in the invocation of main fetch from redirect fetch.

Please let me know if you have any comments or critiques!

Fixes: #217 