### PR TITLE
Vary:-header refers to request headers, not response headers

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -4608,7 +4608,7 @@ however, it is perfectly fine to do so.
 <span data-anolis-ref>HTML</span>
 <span data-anolis-ref>HTTP</span>
 
-<pre class=example>Vary: Access-Control-Allow-Origin</pre>
+<pre class=example>Vary: Origin</pre>
 
 
 
@@ -4682,6 +4682,7 @@ Lachlan Hunt,
 Lucas Gonze,
 呂康豪 (Kang-Hao Lu),
 Maciej Stachowiak,
+Manfred Stock,
 Manish Goregaokar,
 Marc Silbey,
 Marcos Caceres,


### PR DESCRIPTION
If I understand the [`Vary:`-header specification](http://tools.ietf.org/html/rfc7231#section-7.1.4) and [a blog post about "Caching with CORS"](https://www.fastly.com/blog/caching-cors) correctly, the header refers to request headers like `Accept-Encoding`, and not response headers. So the example should `Vary` on the `Origin` request header, not the `Access-Control-Allow-Origin` response header.