### PR TITLE
Removed promise antipattern from code example

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -3263,20 +3263,17 @@ fetch(url).then(/* &hellip; */)</pre>
 
  <pre>function consume(reader) {
   var total = 0
-  return new Promise((resolve, reject) => {
-    function pump() {
-      reader.read().then(({done, value}) => {
-        if (done) {
-          resolve()
-          return
-        }
-        total += value.byteLength
-        log(`received ${value.byteLength} bytes (${total} bytes in total)`)
-        pump()
-      }).catch(reject)
-    }
-    pump()
-  })
+  return pump()
+  function pump() {
+    return reader.read().then(({done, value}) => {
+      if (done) {
+        return
+      }
+      total += value.byteLength
+      log(`received ${value.byteLength} bytes (${total} bytes in total)`)
+      return pump()
+    })
+  }
 }
 
 fetch("/music/pk/altes-kamuffel.flac")


### PR DESCRIPTION
See [What is the explicit promise construction antipattern and how do I avoid it?](https://stackoverflow.com/questions/23803743/what-is-the-explicit-promise-construction-antipattern-and-how-do-i-avoid-it) on StackOverflow.
Promise evangelists say it should be burned with fire, and not appear in any possibly educational code examples :-)