### PR TITLE
Change how CORS filtered response filters the headers.

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-25-march-2016">Living Standard — Last Updated 25 March 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-28-march-2016">Living Standard — Last Updated 28 March 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -451,7 +451,7 @@ from APIs using <a href="#concept-fetch" title="concept-fetch">fetch</a> that al
 </ul>
 
 <p>A <dfn id="cors-safelisted-response-header-name">CORS-safelisted response-header name</dfn>, given a
-<a href="#concept-response-header-list" title="concept-response-header-list">header list</a> <var>list</var>, is a
+<a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a> <var>list</var>, is a
 <a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">name</a> that is one of:
 
 <ul>
@@ -461,9 +461,7 @@ from APIs using <a href="#concept-fetch" title="concept-fetch">fetch</a> that al
  <li>`<code title="">Expires</code>`
  <li>`<code title="">Last-Modified</code>`
  <li>`<code title="">Pragma</code>`.
- <li>Any <a href="#concept-header-value" title="concept-header-value">value</a> resulting from
- <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
- `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in
+ <li>Any <a href="#concept-header-value" title="concept-header-value">value</a> in
  <var>list</var> that is not a <a href="#forbidden-response-header-name">forbidden response-header name</a>.
 </ul>
 
@@ -1111,6 +1109,12 @@ this specification.
 for the <a href="#concept-response" title="concept-response">response</a>. The list is empty unless otherwise
 specified. <a href="#refsCSP">[CSP]</a>
 
+<p>A <a href="#concept-response" title="concept-response">response</a> has an associated
+<dfn id="concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</dfn>
+(a list of zero or more
+<a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">names</a>).
+The list is empty unless otherwise specified.
+
 <hr>
 
 <p>A <a href="#concept-response" title="concept-response">response</a> whose
@@ -1162,7 +1166,7 @@ required, e.g., to feed image data to a decoder, the associated
 <a href="#concept-header-name" title="concept-header-name">name</a> is <em>not</em> a
 <a href="#cors-safelisted-response-header-name">CORS-safelisted response-header name</a>, given
 <a href="#concept-internal-response" title="concept-internal-response">internal response</a>'s
-<a href="#concept-response-header-list" title="concept-response-header-list">header list</a>.
+<a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a>.
 
 <p>An <dfn id="concept-filtered-response-opaque" title="concept-filtered-response-opaque">opaque filtered response</dfn> is a
 <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a> whose
@@ -2099,6 +2103,18 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
   </dl>
 
  <li><p>If the <i>recursive flag</i> is set, return <var>response</var>.
+
+ <li>
+  <p>If <var>response</var> is not a
+  <a href="#concept-network-error" title="concept-network-error">network error</a> and
+  <var>response</var> is not a
+  <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>, set
+  <var>response</var>'s
+  <a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a> to the result of
+  <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
+  `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in
+  <var>response</var>'s
+  <a href="#concept-response-header-list" title="concept-response-header-list">header list</a>.
 
  <li>
   <p>If <var>response</var> is not a
@@ -5205,6 +5221,7 @@ Manfred Stock,
 Manish Goregaokar,
 Marc Silbey,
 Marcos Caceres,
+Marijn Kruisselbrink,
 Mark Nottingham,
 Mark S. Miller,
 Martin Dürst,

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-28-march-2016">Living Standard — Last Updated 28 March 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-29-march-2016">Living Standard — Last Updated 29 March 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -451,7 +451,7 @@ from APIs using <a href="#concept-fetch" title="concept-fetch">fetch</a> that al
 </ul>
 
 <p>A <dfn id="cors-safelisted-response-header-name">CORS-safelisted response-header name</dfn>, given a
-<a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a> <var>list</var>, is a
+<a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a> <var>list</var>, is a
 <a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">name</a> that is one of:
 
 <ul>
@@ -1110,10 +1110,17 @@ for the <a href="#concept-response" title="concept-response">response</a>. The l
 specified. <a href="#refsCSP">[CSP]</a>
 
 <p>A <a href="#concept-response" title="concept-response">response</a> has an associated
-<dfn id="concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</dfn>
+<dfn id="concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</dfn>
 (a list of zero or more
 <a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">names</a>).
 The list is empty unless otherwise specified.
+
+<p class="note no-backref">A <a href="#concept-response" title="concept-response">response</a> will typically get its
+<a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a>
+set by <a href="#concept-header-parse" title="concept-header-parse">parsing</a> the
+`<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` header. This
+list is used by a <a href="#concept-filtered-response-cors" title="concept-filtered-response-cors">CORS filtered response</a> to
+determine which headers to expose.
 
 <hr>
 
@@ -1166,7 +1173,7 @@ required, e.g., to feed image data to a decoder, the associated
 <a href="#concept-header-name" title="concept-header-name">name</a> is <em>not</em> a
 <a href="#cors-safelisted-response-header-name">CORS-safelisted response-header name</a>, given
 <a href="#concept-internal-response" title="concept-internal-response">internal response</a>'s
-<a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a>.
+<a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a>.
 
 <p>An <dfn id="concept-filtered-response-opaque" title="concept-filtered-response-opaque">opaque filtered response</dfn> is a
 <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a> whose
@@ -2110,7 +2117,7 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
   <var>response</var> is not a
   <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>, set
   <var>response</var>'s
-  <a href="#concept-response-cors-exposed-headers-list" title="concept-response-cors-exposed-headers-list">CORS-exposed headers list</a> to the result of
+  <a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a> to the result of
   <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
   `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in
   <var>response</var>'s

--- a/Overview.html
+++ b/Overview.html
@@ -2115,34 +2115,34 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
   <p>If <var>response</var> is not a
   <a href="#concept-network-error" title="concept-network-error">network error</a> and
   <var>response</var> is not a
-  <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>, set
-  <var>response</var>'s
-  <a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a> to the result of
-  <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
-  `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in
-  <var>response</var>'s
-  <a href="#concept-response-header-list" title="concept-response-header-list">header list</a>.
+  <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>, run these substeps:
 
- <li>
-  <p>If <var>response</var> is not a
-  <a href="#concept-network-error" title="concept-network-error">network error</a> and
-  <var>response</var> is not a
-  <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a>, set
-  <var>response</var> to the following
-  <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a> with
-  <var>response</var> as its
-  <a href="#concept-internal-response" title="concept-internal-response">internal response</a>, depending on
-  <var>request</var>'s
-  <a href="#concept-request-response-tainting" title="concept-request-response-tainting">response tainting</a>:
+  <ol>
+   <li>
+    <p>Set <var>response</var>'s
+    <a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a>
+    to the result of <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
+    `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in
+    <var>response</var>'s
+    <a href="#concept-response-header-list" title="concept-response-header-list">header list</a>.
 
-  <dl class="switch compact">
-   <dt>"<code title="">basic</code>"
-   <dd><a href="#concept-filtered-response-basic" title="concept-filtered-response-basic">basic filtered response</a>
-   <dt>"<code title="">cors</code>"
-   <dd><a href="#concept-filtered-response-cors" title="concept-filtered-response-cors">CORS filtered response</a>
-   <dt>"<code title="">opaque</code>"
-   <dd><a href="#concept-filtered-response-opaque" title="concept-filtered-response-opaque">opaque filtered response</a>
-  </dl>
+   <li>
+    <p>Set <var>response</var> to the following
+    <a href="#concept-filtered-response" title="concept-filtered-response">filtered response</a> with
+    <var>response</var> as its
+    <a href="#concept-internal-response" title="concept-internal-response">internal response</a>, depending on
+    <var>request</var>'s
+    <a href="#concept-request-response-tainting" title="concept-request-response-tainting">response tainting</a>:
+
+    <dl class="switch compact">
+     <dt>"<code title="">basic</code>"
+     <dd><a href="#concept-filtered-response-basic" title="concept-filtered-response-basic">basic filtered response</a>
+     <dt>"<code title="">cors</code>"
+     <dd><a href="#concept-filtered-response-cors" title="concept-filtered-response-cors">CORS filtered response</a>
+     <dt>"<code title="">opaque</code>"
+     <dd><a href="#concept-filtered-response-opaque" title="concept-filtered-response-opaque">opaque filtered response</a>
+    </dl>
+  </ol>
 
  <li><p>Let <var>internalResponse</var> be <var>response</var>, if <var>response</var> is a
  <a href="#concept-network-error" title="concept-network-error">network error</a>, and <var>response</var>'s

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-29-march-2016">Living Standard — Last Updated 29 March 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-30-march-2016">Living Standard — Last Updated 30 March 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -2119,7 +2119,10 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
 
   <ol>
    <li>
-    <p>Set <var>response</var>'s
+    <p>If <var>request</var>'s
+    <a href="#concept-request-response-tainting" title="concept-request-response-tainting">response tainting</a> is
+    "<code title="">cors</code>", set
+    <var>response</var>'s
     <a href="#concept-response-cors-exposed-header-name-list" title="concept-response-cors-exposed-header-name-list">CORS-exposed header-name list</a>
     to the result of <a href="#concept-header-parse" title="concept-header-parse">parsing</a>
     `<a href="#http-access-control-expose-headers"><code title="http-access-control-expose-headers">Access-Control-Expose-Headers</code></a>` in

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -381,9 +381,9 @@ from APIs using <span title=concept-fetch>fetch</span> that allow control over
  <li>`<code title>Set-Cookie2</code>`
 </ul>
 
-<p>A <dfn id="cors-safelisted-response-header-name">CORS-safelisted response-header name</dfn>, given a
-<span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span> <var>list</var>, is a
-<a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">name</a> that is one of:
+<p>A <dfn>CORS-safelisted response-header name</dfn>, given a
+<span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span> <var>list</var>, is a
+<span title=concept-header>header</span> <span title=concept-header-name>name</span> that is one of:
 
 <ul>
  <li>`<code title>Cache-Control</code>`
@@ -392,8 +392,8 @@ from APIs using <span title=concept-fetch>fetch</span> that allow control over
  <li>`<code title>Expires</code>`
  <li>`<code title>Last-Modified</code>`
  <li>`<code title>Pragma</code>`.
- <li>Any <a href="#concept-header-value" title="concept-header-value">value</a> in
- <var>list</var> that is not a <a href="#forbidden-response-header-name">forbidden response-header name</a>.
+ <li>Any <span title=concept-header-value>value</span> in
+ <var>list</var> that is not a <span>forbidden response-header name</span>.
 </ul>
 
 <hr>
@@ -1041,10 +1041,17 @@ for the <span title=concept-response>response</span>. The list is empty unless o
 specified. <span data-anolis-ref>CSP</span>
 
 <p>A <span title=concept-response>response</span> has an associated
-<dfn title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</dfn>
+<dfn title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</dfn>
 (a list of zero or more
 <span title=concept-header>header</span> <span title=concept-header-name>names</span>).
 The list is empty unless otherwise specified.
+
+<p class="note no-backref">A <span title=concept-response>response</span> will typically get its
+<span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span>
+set by <span title=concept-header-parse>parsing</span> the
+`<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` header. This
+list is used by a <span title=concept-filtered-response-cors>CORS filtered response</span> to
+determine which headers to expose.
 
 <hr>
 
@@ -1097,7 +1104,7 @@ required, e.g., to feed image data to a decoder, the associated
 <span title=concept-header-name>name</span> is <em>not</em> a
 <span>CORS-safelisted response-header name</span>, given
 <span title=concept-internal-response>internal response</span>'s
-<span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span>.
+<span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span>.
 
 <p>An <dfn title=concept-filtered-response-opaque>opaque filtered response</dfn> is a
 <span title=concept-filtered-response>filtered response</span> whose
@@ -2041,7 +2048,7 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
   <var>response</var> is not a
   <span title=concept-filtered-response>filtered response</span>, set
   <var>response</var>'s
-  <span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span> to the result of
+  <span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span> to the result of
   <span title=concept-header-parse>parsing</span>
   `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in
   <var>response</var>'s

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2046,34 +2046,34 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
   <p>If <var>response</var> is not a
   <span title=concept-network-error>network error</span> and
   <var>response</var> is not a
-  <span title=concept-filtered-response>filtered response</span>, set
-  <var>response</var>'s
-  <span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span> to the result of
-  <span title=concept-header-parse>parsing</span>
-  `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in
-  <var>response</var>'s
-  <span title=concept-response-header-list>header list</span>.
+  <span title=concept-filtered-response>filtered response</span>, run these substeps:
 
- <li>
-  <p>If <var>response</var> is not a
-  <span title=concept-network-error>network error</span> and
-  <var>response</var> is not a
-  <span title=concept-filtered-response>filtered response</span>, set
-  <var>response</var> to the following
-  <span title=concept-filtered-response>filtered response</span> with
-  <var>response</var> as its
-  <span title=concept-internal-response>internal response</span>, depending on
-  <var>request</var>'s
-  <span title=concept-request-response-tainting>response tainting</span>:
+  <ol>
+   <li>
+    <p>Set <var>response</var>'s
+    <span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span>
+    to the result of <span title=concept-header-parse>parsing</span>
+    `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in
+    <var>response</var>'s
+    <span title=concept-response-header-list>header list</span>.
 
-  <dl class="switch compact">
-   <dt>"<code title>basic</code>"
-   <dd><span title=concept-filtered-response-basic>basic filtered response</span>
-   <dt>"<code title>cors</code>"
-   <dd><span title=concept-filtered-response-cors>CORS filtered response</span>
-   <dt>"<code title>opaque</code>"
-   <dd><span title=concept-filtered-response-opaque>opaque filtered response</span>
-  </dl>
+   <li>
+    <p>Set <var>response</var> to the following
+    <span title=concept-filtered-response>filtered response</span> with
+    <var>response</var> as its
+    <span title=concept-internal-response>internal response</span>, depending on
+    <var>request</var>'s
+    <span title=concept-request-response-tainting>response tainting</span>:
+
+    <dl class="switch compact">
+     <dt>"<code title>basic</code>"
+     <dd><span title=concept-filtered-response-basic>basic filtered response</span>
+     <dt>"<code title>cors</code>"
+     <dd><span title=concept-filtered-response-cors>CORS filtered response</span>
+     <dt>"<code title>opaque</code>"
+     <dd><span title=concept-filtered-response-opaque>opaque filtered response</span>
+    </dl>
+  </ol>
 
  <li><p>Let <var>internalResponse</var> be <var>response</var>, if <var>response</var> is a
  <span title=concept-network-error>network error</span>, and <var>response</var>'s

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2050,7 +2050,10 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
 
   <ol>
    <li>
-    <p>Set <var>response</var>'s
+    <p>If <var>request</var>'s
+    <span title=concept-request-response-tainting>response tainting</span> is
+    "<code title>cors</code>", set
+    <var>response</var>'s
     <span title=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</span>
     to the result of <span title=concept-header-parse>parsing</span>
     `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -381,9 +381,9 @@ from APIs using <span title=concept-fetch>fetch</span> that allow control over
  <li>`<code title>Set-Cookie2</code>`
 </ul>
 
-<p>A <dfn>CORS-safelisted response-header name</dfn>, given a
-<span title=concept-response-header-list>header list</span> <var>list</var>, is a
-<span title=concept-header>header</span> <span title=concept-header-name>name</span> that is one of:
+<p>A <dfn id="cors-safelisted-response-header-name">CORS-safelisted response-header name</dfn>, given a
+<span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span> <var>list</var>, is a
+<a href="#concept-header" title="concept-header">header</a> <a href="#concept-header-name" title="concept-header-name">name</a> that is one of:
 
 <ul>
  <li>`<code title>Cache-Control</code>`
@@ -392,10 +392,8 @@ from APIs using <span title=concept-fetch>fetch</span> that allow control over
  <li>`<code title>Expires</code>`
  <li>`<code title>Last-Modified</code>`
  <li>`<code title>Pragma</code>`.
- <li>Any <span title=concept-header-value>value</span> resulting from
- <span title=concept-header-parse>parsing</span>
- `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in
- <var>list</var> that is not a <span>forbidden response-header name</span>.
+ <li>Any <a href="#concept-header-value" title="concept-header-value">value</a> in
+ <var>list</var> that is not a <a href="#forbidden-response-header-name">forbidden response-header name</a>.
 </ul>
 
 <hr>
@@ -1042,6 +1040,12 @@ this specification.
 for the <span title=concept-response>response</span>. The list is empty unless otherwise
 specified. <span data-anolis-ref>CSP</span>
 
+<p>A <span title=concept-response>response</span> has an associated
+<dfn title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</dfn>
+(a list of zero or more
+<span title=concept-header>header</span> <span title=concept-header-name>names</span>).
+The list is empty unless otherwise specified.
+
 <hr>
 
 <p>A <span title=concept-response>response</span> whose
@@ -1093,7 +1097,7 @@ required, e.g., to feed image data to a decoder, the associated
 <span title=concept-header-name>name</span> is <em>not</em> a
 <span>CORS-safelisted response-header name</span>, given
 <span title=concept-internal-response>internal response</span>'s
-<span title=concept-response-header-list>header list</span>.
+<span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span>.
 
 <p>An <dfn title=concept-filtered-response-opaque>opaque filtered response</dfn> is a
 <span title=concept-filtered-response>filtered response</span> whose
@@ -2030,6 +2034,18 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
   </dl>
 
  <li><p>If the <i>recursive flag</i> is set, return <var>response</var>.
+
+ <li>
+  <p>If <var>response</var> is not a
+  <span title=concept-network-error>network error</span> and
+  <var>response</var> is not a
+  <span title=concept-filtered-response>filtered response</span>, set
+  <var>response</var>'s
+  <span title=concept-response-cors-exposed-headers-list>CORS-exposed headers list</span> to the result of
+  <span title=concept-header-parse>parsing</span>
+  `<code title=http-access-control-expose-headers>Access-Control-Expose-Headers</code>` in
+  <var>response</var>'s
+  <span title=concept-response-header-list>header list</span>.
 
  <li>
   <p>If <var>response</var> is not a
@@ -5047,6 +5063,7 @@ Manfred Stock,
 Manish Goregaokar,
 Marc Silbey,
 Marcos Caceres,
+Marijn Kruisselbrink,
 Mark Nottingham,
 Mark S. Miller,
 Martin D&uuml;rst,


### PR DESCRIPTION
Rather than just directling taking the exposed headers from the
`Access-Control-Expose-Headers` header, this adds a separate list of
exposed headers to a response, initialized from that header. This makes
it possible for foreign fetch to filter headers differently.

This will be used by foreign fetch in mkruisselbrink/ServiceWorker@bf4585bc6afb9e0b1cefdeff97f69595545a1af4