### PR TITLE
Issue #269: Add 'cryptographic nonce metadata' to requests.

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-31-march-2016">Living Standard — Last Updated 31 March 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-5-april-2016">Living Standard — Last Updated 5 April 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -957,6 +957,16 @@ Unless stated otherwise, it is "<code title="">follow</code>".
 <p>A <a href="#concept-request" title="concept-request">request</a> has associated
 <dfn id="concept-request-integrity-metadata" title="concept-request-integrity-metadata">integrity metadata</dfn> (a string). Unless
 stated otherwise, it is the empty string.
+
+<p>A <a href="#concept-request" title="concept-request">request</a> has associated
+<dfn id="concept-request-nonce-metadata" title="concept-request-nonce-metadata">cryptographic nonce metadata</dfn> (a string). Unless
+stated otherwise, it is the empty string.
+
+<p class="note no-backref">A <a href="#concept-request" title="concept-request">request</a>'s
+<a href="#concept-request-url-list" title="concept-request-url-list">cryptographic nonce metadata</a> is generally populated
+from a <a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nonce"><code class="external" data-anolis-spec="html" title="attr-script-nonce">nonce</code></a> attribute on the element
+responsible for triggering a fetch. It is used by various algorithms in
+<a href="#refsCSP">[CSP]</a> to determine whether requests should be blocked in a given context.
 
 <hr>
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -889,6 +889,16 @@ Unless stated otherwise, it is "<code title>follow</code>".
 <dfn title=concept-request-integrity-metadata>integrity metadata</dfn> (a string). Unless
 stated otherwise, it is the empty string.
 
+<p>A <span title=concept-request>request</span> has associated
+<dfn title=concept-request-nonce-metadata>cryptographic nonce metadata</dfn> (a string). Unless
+stated otherwise, it is the empty string.
+
+<p class="note no-backref">A <span title=concept-request>request</span>'s
+<span title=concept-request-url-list>cryptographic nonce metadata</span> is generally populated
+from a <code title=attr-script-nonce data-anolis-spec=html>nonce</code> attribute on the element
+responsible for triggering a fetch. It is used by various algorithms in
+<span data-anolis-ref>CSP</span> to determine whether requests should be blocked in a given context.
+
 <hr>
 
 <p>A <span title=concept-request>request</span> has an associated


### PR DESCRIPTION
This will enable CSP to correctly handle nonce checks during Fetch, which
it fails to do today. We'll need to make some changes to HTML to support
this new mechanism, but that will come in a separate patch.