### PR TITLE
Update request's referrer policy when fetching

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-12-april-2016">Living Standard — Last Updated 12 April 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-13-april-2016">Living Standard — Last Updated 13 April 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -2103,14 +2103,18 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
 
  <li><p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>
  is the empty string and <var>request</var>'s
- <a href="#concept-request-client" title="concept-request-client">client</a> is non-null, set <var>request</var>'s
+ <a href="#concept-request-client" title="concept-request-client">client</a> is non-null, then set <var>request</var>'s
  <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to <var>request</var>'s
  <a href="#concept-request-client" title="concept-request-client">client</a>'s associated referrer policy.
 
- <li><p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>
- is the empty string, set <var>request</var>'s
- <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to
- "<code>no-referrer-when-downgrade</code>".
+ <li>
+  <p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>
+  is the empty string, then set <var>request</var>'s
+  <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to
+  "<code>no-referrer-when-downgrade</code>".
+
+  <p class="note no-backref">We use "<code>no-referrer-when-downgrade</code>" because it is the
+  historical default.
 
  <li>
   <p>If <var>request</var>'s <a href="#concept-request-referrer" title="concept-request-referrer">referrer</a>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-10-april-2016">Living Standard — Last Updated 10 April 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-12-april-2016">Living Standard — Last Updated 12 April 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -2100,6 +2100,17 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
  <a href="#concept-network-error" title="concept-network-error">network error</a>.
  <a href="#refsMIX">[MIX]</a>
  <a href="#refsCSP">[CSP]</a>
+
+ <li><p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>
+ is the empty string and <var>request</var>'s
+ <a href="#concept-request-client" title="concept-request-client">client</a> is non-null, set <var>request</var>'s
+ <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to <var>request</var>'s
+ <a href="#concept-request-client" title="concept-request-client">client</a>'s associated referrer policy.
+
+ <li><p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>
+ is the empty string, set <var>request</var>'s
+ <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to
+ "<code>no-referrer-when-downgrade</code>".
 
  <li>
   <p>If <var>request</var>'s <a href="#concept-request-referrer" title="concept-request-referrer">referrer</a>

--- a/Overview.html
+++ b/Overview.html
@@ -2105,7 +2105,9 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
  is the empty string and <var>request</var>'s
  <a href="#concept-request-client" title="concept-request-client">client</a> is non-null, then set <var>request</var>'s
  <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> to <var>request</var>'s
- <a href="#concept-request-client" title="concept-request-client">client</a>'s associated referrer policy.
+ <a href="#concept-request-client" title="concept-request-client">client</a>'s
+ <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">associated referrer policy</a>.
+ <a href="#refsREFERRER">[REFERRER]</a>
 
  <li>
   <p>If <var>request</var>'s <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2035,7 +2035,9 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
  is the empty string and <var>request</var>'s
  <span title=concept-request-client>client</span> is non-null, then set <var>request</var>'s
  <span title=concept-request-referrer-policy>referrer policy</span> to <var>request</var>'s
- <span title=concept-request-client>client</span>'s associated referrer policy.
+ <span title=concept-request-client>client</span>'s
+ <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">associated referrer policy</a>.
+ <span data-anolis-ref>REFERRER</span>
 
  <li>
   <p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2033,14 +2033,18 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
 
  <li><p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>
  is the empty string and <var>request</var>'s
- <span title=concept-request-client>client</span> is non-null, set <var>request</var>'s
+ <span title=concept-request-client>client</span> is non-null, then set <var>request</var>'s
  <span title=concept-request-referrer-policy>referrer policy</span> to <var>request</var>'s
  <span title=concept-request-client>client</span>'s associated referrer policy.
 
- <li><p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>
- is the empty string, set <var>request</var>'s
- <span title=concept-request-referrer-policy>referrer policy</span> to
- "<code>no-referrer-when-downgrade</code>".
+ <li>
+  <p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>
+  is the empty string, then set <var>request</var>'s
+  <span title=concept-request-referrer-policy>referrer policy</span> to
+  "<code>no-referrer-when-downgrade</code>".
+
+  <p class="note no-backref">We use "<code>no-referrer-when-downgrade</code>" because it is the
+  historical default.
 
  <li>
   <p>If <var>request</var>'s <span title=concept-request-referrer>referrer</span>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2031,6 +2031,17 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
  <span data-anolis-ref>MIX</span>
  <span data-anolis-ref>CSP</span>
 
+ <li><p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>
+ is the empty string and <var>request</var>'s
+ <span title=concept-request-client>client</span> is non-null, set <var>request</var>'s
+ <span title=concept-request-referrer-policy>referrer policy</span> to <var>request</var>'s
+ <span title=concept-request-client>client</span>'s associated referrer policy.
+
+ <li><p>If <var>request</var>'s <span title=concept-request-referrer-policy>referrer policy</span>
+ is the empty string, set <var>request</var>'s
+ <span title=concept-request-referrer-policy>referrer policy</span> to
+ "<code>no-referrer-when-downgrade</code>".
+
  <li>
   <p>If <var>request</var>'s <span title=concept-request-referrer>referrer</span>
   is not "<code>no-referrer</code>", set <var>request</var>'s


### PR DESCRIPTION
With this change request's referrer policy is updated before calculating referrer so that the referrer policy actually used for the referrer calculation is transferred to the service worker and the default referrer policy is not transferred to the service worker.

This change fixes #266.