### PR TITLE
Add 'parser metadata' to requests.

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-13-april-2016">Living Standard — Last Updated 13 April 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-14-april-2016">Living Standard — Last Updated 14 April 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -990,11 +990,17 @@ stated otherwise, it is the empty string.
 <dfn id="concept-request-nonce-metadata" title="concept-request-nonce-metadata">cryptographic nonce metadata</dfn> (a string). Unless
 stated otherwise, it is the empty string.
 
+<p>A <a href="#concept-request" title="concept-request">request</a> has associated
+<dfn id="concept-request-parser-metadata" title="concept-request-parser-metadata">parser metadata</dfn> which is the empty string,
+"<code title="">parser-inserted</code>", or "<code title="">not-parser-inserted</code>". Unless
+otherwise stated, it is the empty string.
+
 <p class="note no-backref">A <a href="#concept-request" title="concept-request">request</a>'s
-<a href="#concept-request-url-list" title="concept-request-url-list">cryptographic nonce metadata</a> is generally populated
-from a <a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nonce"><code class="external" data-anolis-spec="html" title="attr-script-nonce">nonce</code></a> attribute on the element
-responsible for triggering a fetch. It is used by various algorithms in
-<a href="#refsCSP">[CSP]</a> to determine whether requests should be blocked in a given context.
+<a href="#concept-request-url-list" title="concept-request-url-list">cryptographic nonce metadata</a> and
+<a href="#concept-request-parser-metadata" title="concept-request-parser-metadata">parser metadata</a> are generally populated from
+attributes and flags on the HTML element responsible for triggering a fetch. They are used by
+various algorithms in <a href="#refsCSP">[CSP]</a> to determine whether requests or responses
+should be blocked in a given context.
 
 <hr>
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -920,11 +920,17 @@ stated otherwise, it is the empty string.
 <dfn title=concept-request-nonce-metadata>cryptographic nonce metadata</dfn> (a string). Unless
 stated otherwise, it is the empty string.
 
+<p>A <span title=concept-request>request</span> has associated
+<dfn title=concept-request-parser-metadata>parser metadata</dfn> which is the empty string,
+"<code title>parser-inserted</code>", or "<code title>not-parser-inserted</code>". Unless
+otherwise stated, it is the empty string.
+
 <p class="note no-backref">A <span title=concept-request>request</span>'s
-<span title=concept-request-url-list>cryptographic nonce metadata</span> is generally populated
-from a <code title=attr-script-nonce data-anolis-spec=html>nonce</code> attribute on the element
-responsible for triggering a fetch. It is used by various algorithms in
-<span data-anolis-ref>CSP</span> to determine whether requests should be blocked in a given context.
+<span title=concept-request-url-list>cryptographic nonce metadata</span> and
+<span title=concept-request-parser-metadata>parser metadata</span> are generally populated from
+attributes and flags on the HTML element responsible for triggering a fetch. They are used by
+various algorithms in <span data-anolis-ref>CSP</span> to determine whether requests or responses
+should be blocked in a given context.
 
 <hr>
 


### PR DESCRIPTION
This is in support of the 'unsafe-dynamic' source expression in
CSP3: https://w3c.github.io/webappsec-csp/#unsafe-dynamic-usage.

w3c/webappsec-csp#70