### PR TITLE
Make sure all responses have a URL list

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-7-june-2016">Living Standard — Last Updated 7 June 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-9-june-2016">Living Standard — Last Updated 9 June 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -2556,6 +2556,18 @@ with a <i title="">CORS flag</i> and <i title="">recursive flag</i>, run these s
  <a href="#concept-internal-response" title="concept-internal-response">internal response</a> otherwise.
 
  <li>
+  <p>If <var>internalResponse</var>'s <a href="#concept-response-url-list" title="concept-response-url-list">url list</a> is
+  empty, then set it to a copy of <var>request</var>'s
+  <a href="#concept-request-url-list" title="concept-request-url-list">url list</a>.
+
+  <p class="note">A <a href="#concept-response" title="concept-response">response</a>'s
+  <a href="#concept-response-url-list" title="concept-response-url-list">url list</a> will typically be empty at this point,
+  unless it came from a service worker, in which case it will only be empty if it was created
+  through <a href="#dom-response"><code title="dom-response">new Response()</code></a>.
+ <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
+      blob URLs, service workers, HTTP cache, HTTP network, etc. -->
+
+ <li>
   <p>If <var>response</var> is not a <a href="#concept-network-error" title="concept-network-error">network error</a> and any
   of the following algorithms returns <b title="">blocked</b>, then set <var>response</var> and
   <var>internalResponse</var> to a <a href="#concept-network-error" title="concept-network-error">network error</a>:
@@ -2836,10 +2848,6 @@ indicates an attempt to authenticate.
      "<code title="">follow</code>" and <var>response</var>'s
      <a href="#concept-response-url-list" title="concept-response-url-list">url list</a> has more than one item.
     </ul>
-
-   <li><p>If <var>actualResponse</var>'s <a href="#concept-response-url-list" title="concept-response-url-list">url list</a> is
-   empty, set it to a copy of <var>request</var>'s
-   <a href="#concept-request-url-list" title="concept-request-url-list">url list</a>.
 
    <li><p>Execute
    <a href="https://w3c.github.io/webappsec-csp/#set-response-csp-list">set <var>response</var>'s CSP list</a>
@@ -3538,9 +3546,6 @@ The <i title="">credentials flag</i> is one too.
   <p class="XXX">Gecko
   <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1030660">bug 1030660</a> looks
   into whether this quirk can be removed.
-
- <li><p>Set <var>response</var>'s <a href="#concept-response-url-list" title="concept-response-url-list">url list</a> to a copy of
- <var>request</var>'s <a href="#concept-request-url-list" title="concept-request-url-list">url list</a>.
 
  <li><p>Execute
  <a href="https://w3c.github.io/webappsec-csp/#set-response-csp-list">set <var>response</var>'s CSP list</a>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2484,6 +2484,18 @@ with a <i title>CORS flag</i> and <i title>recursive flag</i>, run these steps:
  <span title=concept-internal-response>internal response</span> otherwise.
 
  <li>
+  <p>If <var>internalResponse</var>'s <span title=concept-response-url-list>url list</span> is
+  empty, then set it to a copy of <var>request</var>'s
+  <span title=concept-request-url-list>url list</span>.
+
+  <p class="note">A <span title=concept-response>response</span>'s
+  <span title=concept-response-url-list>url list</span> will typically be empty at this point,
+  unless it came from a service worker, in which case it will only be empty if it was created
+  through <code title=dom-response>new Response()</code>.
+ <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
+      blob URLs, service workers, HTTP cache, HTTP network, etc. -->
+
+ <li>
   <p>If <var>response</var> is not a <span title=concept-network-error>network error</span> and any
   of the following algorithms returns <b title>blocked</b>, then set <var>response</var> and
   <var>internalResponse</var> to a <span title=concept-network-error>network error</span>:
@@ -2764,10 +2776,6 @@ indicates an attempt to authenticate.
      "<code title>follow</code>" and <var>response</var>'s
      <span title=concept-response-url-list>url list</span> has more than one item.
     </ul>
-
-   <li><p>If <var>actualResponse</var>'s <span title=concept-response-url-list>url list</span> is
-   empty, set it to a copy of <var>request</var>'s
-   <span title=concept-request-url-list>url list</span>.
 
    <li><p>Execute
    <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
@@ -3466,9 +3474,6 @@ The <i title>credentials flag</i> is one too.
   <p class=XXX>Gecko
   <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1030660">bug 1030660</a> looks
   into whether this quirk can be removed.
-
- <li><p>Set <var>response</var>'s <span title=concept-response-url-list>url list</span> to a copy of
- <var>request</var>'s <span title=concept-request-url-list>url list</span>.
 
  <li><p>Execute
  <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>


### PR DESCRIPTION
In #146 I tried to let service worker responses that were not synthetic
to keep their url list. However, the way I fixed that regressed url
lists for a number of responses: HTTP cache responses, about URL
responses, etc.

This fix instead tries to keep the old setup and only overwrites the
url list of a response if it’s empty.

Fixes #312.