### PR TITLE
Add steps to intercept requests using foreign fetch.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2767,8 +2767,11 @@ indicates an attempt to authenticate.
   </ol>
 
  <li>
-  <p>If <var>response</var> is null and <var>request</var>'s
-  <span>skip-service-worker flag</span> is unset, run these substeps:
+  <p>If <var>response</var> is null, <var>request</var>'s <span>skip-service-worker flag</span> is
+  unset, <var>request</var> is a <span>subresource request</span> and <var>request</var>'s
+  <span title=concept-request-origin>origin</span> is not the same as <var>request</var>'s
+  <span title=concept-request-url>url</span>'s <span data-anolis-spec=html>origin</span>,
+  run these substeps:
 
   <ol>
    <li>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2720,7 +2720,7 @@ indicates an attempt to authenticate.
  <li><p>Let <var>actualResponse</var> be null.
 
  <li>
-  <p>If <var>request</var>'s <span>skip-service-worker flag</span> is unset, run these substeps:
+  <p>If <var>request</var>'s <span>skip-service-worker flag</span> is unset, then run these substeps:
 
   <ol>
    <li>
@@ -2728,22 +2728,22 @@ indicates an attempt to authenticate.
     null or <var>request</var>'s <span title=concept-request-client>client</span>'s
     <span data-anolis-spec=html title=concept-settings-object-global>global object</span> is not a
     <code data-anolis-spec=sw>ServiceWorkerGlobalScope</code> object,
-    set <var>response</var> to the result of invoking
+    then set <var>response</var> to the result of invoking
     <span data-anolis-spec=sw>handle fetch</span> for <var>request</var>.
     <span data-anolis-ref>HTML</span>
     <span data-anolis-ref>SW</span>
 
    <li>
     <p>If <var>response</var> is null,
-    <var>request</var> is a <span>subresource request</span> and <var>request</var>'s
-    <span title=concept-request-origin>origin</span> is not the same as <var>request</var>'s
+    <var>request</var> is a <span>subresource request</span>, and <var>request</var>'s
+    <span title=concept-request-origin>origin</span> is not <span data-anolis-spec=html>same origin</span> with <var>request</var>'s
     <span title=concept-request-url>url</span>'s <span data-anolis-spec=html>origin</span>,
-    set <var>response</var> to the result of invoking
+    then set <var>response</var> to the result of invoking
     <span data-anolis-spec=sw>handle foreign fetch</span> for <var>request</var>.
     <span data-anolis-ref>SW</span>
 
    <li>
-    <p>If <var>response</var> is not null, run these substeps:
+    <p>If <var>response</var> is not null, then run these substeps:
 
     <ol>
      <li><p><span title="Read a request">Read <var>request</var></span>.
@@ -2753,7 +2753,7 @@ indicates an attempt to authenticate.
      <span title=concept-internal-response>internal response</span> otherwise.
 
      <li>
-      <p>If one of the following conditions is true, return a
+      <p>If one of the following conditions is true, then return a
       <span title=concept-network-error>network error</span>:
 
       <ul class=brief>
@@ -2776,7 +2776,6 @@ indicates an attempt to authenticate.
      <li><p>Execute
      <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
      on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
-
     </ol>
   </ol>
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2720,95 +2720,64 @@ indicates an attempt to authenticate.
  <li><p>Let <var>actualResponse</var> be null.
 
  <li>
-  <p>If <var>request</var>'s <span>skip-service-worker flag</span> is unset and
-  either <var>request</var>'s <span title=concept-request-client>client</span> is
-  null or <var>request</var>'s <span title=concept-request-client>client</span>'s
-  <span data-anolis-spec=html title=concept-settings-object-global>global object</span> is not a
-  <code data-anolis-spec=sw>ServiceWorkerGlobalScope</code> object, run these substeps:
-  <span data-anolis-ref>HTML</span>
-  <span data-anolis-ref>SW</span>
+  <p>If <var>request</var>'s <span>skip-service-worker flag</span> is unset, run these substeps:
 
   <ol>
    <li>
-    <p>Set <var>response</var> to the result of invoking
+    <p>If <var>request</var>'s <span title=concept-request-client>client</span> is
+    null or <var>request</var>'s <span title=concept-request-client>client</span>'s
+    <span data-anolis-spec=html title=concept-settings-object-global>global object</span> is not a
+    <code data-anolis-spec=sw>ServiceWorkerGlobalScope</code> object,
+    set <var>response</var> to the result of invoking
     <span data-anolis-spec=sw>handle fetch</span> for <var>request</var>.
+    <span data-anolis-ref>HTML</span>
     <span data-anolis-ref>SW</span>
 
-    <p><span title="Read a request">Read <var>request</var></span>.
-
-   <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
-   <span title=concept-filtered-response>filtered response</span>, and to <var>response</var>'s
-   <span title=concept-internal-response>internal response</span> otherwise.
-
    <li>
-    <p>If one of the following conditions is true, return a
-    <span title=concept-network-error>network error</span>:
-
-    <ul class=brief>
-     <li><var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>error</code>".
-
-     <li><var>request</var>'s <span title=concept-request-mode>mode</span> is not
-     "<code title>no-cors</code>" and <var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>opaque</code>".
-
-     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
-     "<code title>manual</code>" and <var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>opaqueredirect</code>".
-
-     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
-     "<code title>follow</code>" and <var>response</var>'s
-     <span title=concept-response-url-list>url list</span> has more than one item.
-    </ul>
-
-   <li><p>Execute
-   <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
-   on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
-  </ol>
-
- <li>
-  <p>If <var>response</var> is null, <var>request</var>'s <span>skip-service-worker flag</span> is
-  unset, <var>request</var> is a <span>subresource request</span> and <var>request</var>'s
-  <span title=concept-request-origin>origin</span> is not the same as <var>request</var>'s
-  <span title=concept-request-url>url</span>'s <span data-anolis-spec=html>origin</span>,
-  run these substeps:
-
-  <ol>
-   <li>
-    <p>Set <var>response</var> to the result of invoking
+    <p>If <var>response</var> is null,
+    <var>request</var> is a <span>subresource request</span> and <var>request</var>'s
+    <span title=concept-request-origin>origin</span> is not the same as <var>request</var>'s
+    <span title=concept-request-url>url</span>'s <span data-anolis-spec=html>origin</span>,
+    set <var>response</var> to the result of invoking
     <span data-anolis-spec=sw>handle foreign fetch</span> for <var>request</var>.
     <span data-anolis-ref>SW</span>
 
-    <p><span title="Read a request">Read <var>request</var></span>.
-
-   <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
-   <span title=concept-filtered-response>filtered response</span>, and to <var>response</var>'s
-   <span title=concept-internal-response>internal response</span> otherwise.
-
    <li>
-    <p>If one of the following conditions is true, return a
-    <span title=concept-network-error>network error</span>:
+    <p>If <var>response</var> is not null, run these substeps:
 
-    <ul class=brief>
-     <li><var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>error</code>".
+    <ol>
+     <li><p><span title="Read a request">Read <var>request</var></span>.
 
-     <li><var>request</var>'s <span title=concept-request-mode>mode</span> is not
-     "<code title>no-cors</code>" and <var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>opaque</code>".
+     <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
+     <span title=concept-filtered-response>filtered response</span>, and to <var>response</var>'s
+     <span title=concept-internal-response>internal response</span> otherwise.
 
-     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
-     "<code title>manual</code>" and <var>response</var>'s
-     <span title=concept-response-type>type</span> is "<code title>opaqueredirect</code>".
+     <li>
+      <p>If one of the following conditions is true, return a
+      <span title=concept-network-error>network error</span>:
 
-     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
-     "<code title>follow</code>" and <var>response</var>'s
-     <span title=concept-response-url-list>url list</span> has more than one item.
-    </ul>
+      <ul class=brief>
+       <li><var>response</var>'s
+       <span title=concept-response-type>type</span> is "<code title>error</code>".
 
-   <li><p>Execute
-   <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
-   on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
+       <li><var>request</var>'s <span title=concept-request-mode>mode</span> is not
+       "<code title>no-cors</code>" and <var>response</var>'s
+       <span title=concept-response-type>type</span> is "<code title>opaque</code>".
+
+       <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
+       "<code title>manual</code>" and <var>response</var>'s
+       <span title=concept-response-type>type</span> is "<code title>opaqueredirect</code>".
+
+       <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
+       "<code title>follow</code>" and <var>response</var>'s
+       <span title=concept-response-url-list>url list</span> has more than one item.
+      </ul>
+
+     <li><p>Execute
+     <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
+     on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
+
+    </ol>
   </ol>
 
  <li>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2767,6 +2767,48 @@ indicates an attempt to authenticate.
   </ol>
 
  <li>
+  <p>If <var>response</var> is null and <var>request</var>'s
+  <span>skip-service-worker flag</span> is unset, run these substeps:
+
+  <ol>
+   <li>
+    <p>Set <var>response</var> to the result of invoking
+    <span data-anolis-spec=sw>handle foreign fetch</span> for <var>request</var>.
+    <span data-anolis-ref>SW</span>
+
+    <p><span title="Read a request">Read <var>request</var></span>.
+
+   <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
+   <span title=concept-filtered-response>filtered response</span>, and to <var>response</var>'s
+   <span title=concept-internal-response>internal response</span> otherwise.
+
+   <li>
+    <p>If one of the following conditions is true, return a
+    <span title=concept-network-error>network error</span>:
+
+    <ul class=brief>
+     <li><var>response</var>'s
+     <span title=concept-response-type>type</span> is "<code title>error</code>".
+
+     <li><var>request</var>'s <span title=concept-request-mode>mode</span> is not
+     "<code title>no-cors</code>" and <var>response</var>'s
+     <span title=concept-response-type>type</span> is "<code title>opaque</code>".
+
+     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
+     "<code title>manual</code>" and <var>response</var>'s
+     <span title=concept-response-type>type</span> is "<code title>opaqueredirect</code>".
+
+     <li><var>request</var>'s <span title=concept-request-redirect-mode>redirect mode</span> is not
+     "<code title>follow</code>" and <var>response</var>'s
+     <span title=concept-response-url-list>url list</span> has more than one item.
+    </ul>
+
+   <li><p>Execute
+   <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
+   on <var>actualResponse</var>. <span data-anolis-ref>CSP</span>
+  </ol>
+
+ <li>
   <p>Let <var>credentials flag</var> be set if one of
 
   <ul class=brief>


### PR DESCRIPTION
If response is still null after a regular service worker has tried handling it
this gives a foreign fetch handler a chance to handle the request.