### PR TITLE
Call out to Referrer Policy to set policy on redirect

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -3071,6 +3071,10 @@ in addition to <span title=concept-http-fetch>HTTP fetch</span> above.
  <span title=concept-response-location-url>location URL</span> to <var>request</var>'s
  <span title=concept-request-url-list>url list</span>.
 
+ <li><p>Invoke
+ <a href=https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect>set <var>request</var>'s referrer policy on redirect</a>
+ on <var>request</var> and <var>actualResponse</var>.
+
  <li>
   <p>Return the result of performing a <span title=concept-main-fetch>main fetch</span> using
   <var>request</var>, with the <i>CORS flag</i> set if set, and the <i>recursive flag</i> set.
@@ -5464,6 +5468,7 @@ Domenic Denicola,
 Dean Jackson,
 Doug Turner,
 Ehsan Akhgari,
+Emily Stark,
 Eric Lawrence,
 Frank Ellerman,
 Frederick Hirsch,


### PR DESCRIPTION
Before following a redirect, Fetch should call out to Referrer Policy to
update the referrer policy on the request, if necessary. (In particular,
this applies when the redirect response contains a Referrer-Policy
header.)

This integration is described in
https://w3c.github.io/webappsec-referrer-policy/#integration-with-fetch,
though it needs to be updated per
https://github.com/w3c/webappsec-referrer-policy/issues/59.