### PR TITLE
Referrer policies: add the missing policies (fixes #342)

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1475,15 +1475,19 @@ is listed in the first column of the following table.
 <h3>Referrer policies</h3>
 
 <p>A <dfn title=concept-referrer-policy>referrer policy</dfn> is the empty string,
-"<code>no-referrer</code>", "<code>no-referrer-when-downgrade</code>", "<code>origin</code>",
-"<code>origin-when-cross-origin</code>", or "<code>unsafe-url</code>".
+"<code>no-referrer</code>", "<code>no-referrer-when-downgrade</code>", "<code>same-origin</code>",
+"<code>origin</code>", "<code>strict-origin</code>", "<code>origin-when-cross-origin</code>",
+"<code>strict-origin-when-cross-origin</code>", or "<code>unsafe-url</code>".
 
 <pre class=idl>enum <dfn>ReferrerPolicy</dfn> {
   "",
   "no-referrer",
   "no-referrer-when-downgrade",
+  "same-origin",
   "origin",
+  "strict-origin",
   "origin-when-cross-origin",
+  "strict-origin-when-cross-origin",
   "unsafe-url"
 };</pre>
 
@@ -5437,6 +5441,7 @@ Doug Turner,
 Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,
+Fran&ccedil;ois Marier,
 Frank Ellerman,
 Frederick Hirsch,
 Gavin Carothers,


### PR DESCRIPTION
The following policy states were recently added to the Referrer Policy
specification:

* same-origin
* strict-origin
* strict-origin-when-cross-origin

They were originally added in
https://github.com/w3c/webappsec-referrer-policy/pull/19 and
https://github.com/w3c/webappsec-referrer-policy/pull/56,
and discussed on the W3C WebAppSec list at
https://lists.w3.org/Archives/Public/public-webappsec/2016Mar/0085.html.