### PR TITLE
Allowed header in CORS with Access-Control-Expose-Headers

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -418,6 +418,9 @@ each other by `<code title>,</code>`, in order.
 <p>and whose <span title=concept-header-value>value</span>,
 <span title=concept-header-parse>once parsed</span>, is not a failure.
 
+<p>or whose <span title=concept-header-name>header name</span> is in the commar seperated list of Access-Control-Expose-Headers 
+header of the response.
+
 <p>A <dfn data-export>CORS non-wildcard request-header name</dfn> is
 `<code title>Authorization</code>`.
 


### PR DESCRIPTION
allowed headers in CORS also depends on the response headers
http://stackoverflow.com/questions/38953864/how-to-get-headers-of-the-response-from-fetch/38954244#38954244