### PR TITLE
Fix ReadableStream operations

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-23-august-2016">Living Standard — Last Updated 23 August 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-24-august-2016">Living Standard — Last Updated 24 August 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -1628,7 +1628,10 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Call <a href="https://streams.spec.whatwg.org/#enqueue-in-readable-stream"><code class="external" data-anolis-spec="streams">EnqueueInReadableStream</code></a>(<var>stream</var>,
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue</a>(<var>controller</var>,
  <var>chunk</var>). Rethrow any exceptions.
 </ol>
 
@@ -1636,7 +1639,10 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Call <a href="https://streams.spec.whatwg.org/#close-readable-stream"><code class="external" data-anolis-spec="streams">CloseReadableStream</code></a>(<var>stream</var>).
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-close">ReadableStreamDefaultControllerClose</a>(<var>controller</var>).
  Rethrow any exceptions.
 </ol>
 
@@ -1645,14 +1651,17 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <var>reason</var>, run these steps:
 
 <ol>
- <li><p>Call <a href="https://streams.spec.whatwg.org/#error-readable-stream"><code class="external" data-anolis-spec="streams">ErrorReadableStream</code></a>(<var>stream</var>,
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-error">ReadableStreamDefaultControllerError</a>(<var>controller</var>,
  <var>reason</var>). Rethrow any exceptions.
 </ol>
 
 <p>To
-<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-readablestream" title="concept-construct-ReadableStream">construct a <code title="concept-ReadableStream">ReadableStream</code> object</dfn>
-with given<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which
-are optional, run these steps:
+<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-readablestream" title="concept-construct-ReadableStream">construct a
+<code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given<var>strategy</var>,
+<var>pull</var> action and <var>cancel</var> action, all of which are optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.
@@ -1671,8 +1680,9 @@ are optional, run these steps:
 </ol>
 
 <p>To
-<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-fixed-readablestream" title="concept-construct-fixed-ReadableStream">construct a fixed <code title="concept-ReadableStream">ReadableStream</code> object</dfn>
-with given <var>chunks</var>, run these steps:
+<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-fixed-readablestream" title="concept-construct-fixed-ReadableStream">construct
+a fixed <code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given
+<var>chunks</var>, run these steps:
 
 <ol>
  <li><p>Let <var>stream</var> be the result of
@@ -1695,7 +1705,7 @@ steps:
 
 <ol>
  <li><p>Let <var>reader</var> be the result of calling
- <a href="https://streams.spec.whatwg.org/#acquire-readable-stream-reader"><code class="external" data-anolis-spec="streams">AcquireReadableStreamReader</code></a>(<var>stream</var>).
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#acquire-readable-stream-reader">AcquireReadableStreamDefaultReader</a>(<var>stream</var>).
  Rethrow any exceptions.
 
  <li><p>Return <var>reader</var>.
@@ -1705,7 +1715,7 @@ steps:
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-read-chunk-from-readablestream" title="concept-read-chunk-from-ReadableStream">read a chunk</dfn>
 from a <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object with <var>reader</var>,
 return the result of calling
-<a href="https://streams.spec.whatwg.org/#read-from-readable-stream-reader"><code class="external" data-anolis-spec="streams">ReadFromReadableStreamReader</code></a>(<var>reader</var>).
+<a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-reader-read">ReadableStreamDefaultReaderRead</a>(<var>reader</var>).
 
 <p>To
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-read-all-bytes-from-readablestream" title="concept-read-all-bytes-from-ReadableStream">read all bytes</dfn>
@@ -1719,7 +1729,7 @@ these steps:
 
  <li>
  <p>Let <var>read</var> be the result of calling
- <a href="https://streams.spec.whatwg.org/#read-from-readable-stream-reader"><code class="external" data-anolis-spec="streams">ReadFromReadableStreamReader</code></a>(<var>reader</var>).
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-reader-read">ReadableStreamDefaultReaderRead</a>(<var>reader</var>).
 
  <ul>
   <li><p>When <var>read</var> is fulfilled with an object whose <code title="">done</code>
@@ -1743,8 +1753,7 @@ these steps:
 <p>To <dfn data-dfn-for="ReadableStream" data-export="" id="concept-cancel-readablestream" title="concept-cancel-ReadableStream">cancel</dfn>
 a <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object with <var>reader</var> and
 <var>reason</var>, return the result of calling
-<a href="https://streams.spec.whatwg.org/#readable-stream-reader-cancel"><code class="external" data-anolis-spec="streams">ReadableStreamReaderGenericCancel</code></a>(<var>reader</var>,
-<var>reason</var>).
+<a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-cancel">ReadableStreamCancel</a>(<var>reader</var>, <var>reason</var>).
 
 <p class="note no-backref">Because the reader grants exclusive access, the actual mechanism of how
 to read cannot be observed. Implementations could use more direct mechanism if convenient.
@@ -1754,7 +1763,7 @@ to read cannot be observed. Implementations could use more direct mechanism if c
 
 <ol>
  <li><p>Return the result of calling
- <a href="https://streams.spec.whatwg.org/#tee-readable-stream"><code class="external" data-anolis-spec="streams">TeeReadableStream</code></a>(<var>stream</var>, true).
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-tee">ReadableStreamTee</a>(<var>stream</var>, true).
  Rethrow any exception.
 </ol>
 
@@ -1768,19 +1777,19 @@ to read cannot be observed. Implementations could use more direct mechanism if c
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to be
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-readablestream-readable" title="concept-ReadableStream-readable">readable</dfn> if
-<var>stream</var>@[[state]] is "readable".
+<var>stream</var>.[[state]] is "readable".
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to be
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-readablestream-closed" title="concept-ReadableStream-closed">closed</dfn> if
-<var>stream</var>@[[state]] is "closed".
+<var>stream</var>.[[state]] is "closed".
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to be
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-readablestream-errored" title="concept-ReadableStream-errored">errored</dfn> if
-<var>stream</var>@[[state]] is "errored".
+<var>stream</var>.[[state]] is "errored".
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to be
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-readablestream-locked" title="concept-ReadableStream-locked">locked</dfn> if the
-result of calling <a href="https://streams.spec.whatwg.org/#is-readable-stream-locked"><code class="external" data-anolis-spec="streams">IsReadableStreamLocked</code></a>(<var>stream</var>) is
+result of calling <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#is-readable-stream-locked">IsReadableStreamLocked</a>(<var>stream</var>) is
 true.
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to
@@ -1791,14 +1800,14 @@ if the following conditions hold:
  <li><p><var>stream</var> is <a href="#concept-readablestream-readable" title="concept-ReadableStream-readable">readable</a>.
 
  <li><p>The result of calling
- <a href="https://streams.spec.whatwg.org/#get-readable-stream-desired-size"><code class="external" data-anolis-spec="streams">GetReadableStreamDesiredSize</code></a>(<var>stream</var>) is
- positive.
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize</a>(<var>controller</var>)
+ is positive.
 </ul>
 
 <p>A <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var> is said to be
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-readablestream-disturbed" title="concept-ReadableStream-disturbed">disturbed</dfn>
 if the result of calling
-<a href="https://streams.spec.whatwg.org/#is-readable-stream-disturbed"><code class="external" data-anolis-spec="streams">IsReadableStreamDisturbed</code></a>(<var>stream</var>) is true.
+<a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#is-readable-stream-disturbed">IsReadableStreamDisturbed</a>(<var>stream</var>) is true.
 
 
 

--- a/Overview.html
+++ b/Overview.html
@@ -1660,8 +1660,9 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 
 <p>To
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-readablestream" title="concept-construct-ReadableStream">construct a
-<code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given<var>strategy</var>,
-<var>pull</var> action and <var>cancel</var> action, all of which are optional, run these steps:
+<code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given
+<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which are
+optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.

--- a/Overview.html
+++ b/Overview.html
@@ -13,8 +13,7 @@
  <dt>Participate:
  <dd><a href="https://github.com/whatwg/fetch">GitHub whatwg/fetch</a>
  (<a href="https://github.com/whatwg/fetch/issues/new">file an issue</a>,
- <a href="https://github.com/whatwg/fetch/issues">open issues</a>,
- <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WHATWG&amp;component=Fetch&amp;resolution=---">legacy open bugs</a>)
+ <a href="https://github.com/whatwg/fetch/issues">open issues</a>)
  <dd><a href="https://wiki.whatwg.org/wiki/IRC">IRC: #whatwg on Freenode</a>
 
  <dt>Commits:
@@ -1620,7 +1619,9 @@ each of which is one of `<code title="">dpr</code>`,
 
 <p>A <dfn data-dfn-type="interface" data-export="" id="concept-readablestream" title="concept-ReadableStream">ReadableStream</dfn>
 object represents a <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#rs-class" title="readablestream">stream of data</a>. In
-this section, we define common operations for ReadableStream. <a href="#refsSTREAMS">[STREAMS]</a>
+this section, we define common operations for
+<a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> objects.
+<a href="#refsSTREAMS">[STREAMS]</a>
 
 <p>To
 <dfn data-dfn-for="ReadableStream" data-export="" id="concept-enqueue-readablestream" title="concept-enqueue-ReadableStream">enqueue</dfn>
@@ -1653,10 +1654,9 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 </ol>
 
 <p>To
-<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-readablestream" title="concept-construct-ReadableStream">construct a
-<code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given
-<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which are
-optional, run these steps:
+<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-readablestream" title="concept-construct-ReadableStream">construct a <code>ReadableStream</code> object</dfn>
+with given <var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which
+are optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.
@@ -1675,9 +1675,8 @@ optional, run these steps:
 </ol>
 
 <p>To
-<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-fixed-readablestream" title="concept-construct-fixed-ReadableStream">construct
-a fixed <code title="concept-ReadableStream">ReadableStream</code> object</dfn> with given
-<var>chunks</var>, run these steps:
+<dfn data-dfn-for="ReadableStream" data-export="" id="concept-construct-fixed-readablestream" title="concept-construct-fixed-ReadableStream">construct a fixed <code>ReadableStream</code> object</dfn>
+with given <var>chunks</var>, run these steps:
 
 <ol>
  <li><p>Let <var>stream</var> be the result of

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-24-august-2016">Living Standard — Last Updated 24 August 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-25-august-2016">Living Standard — Last Updated 25 August 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -1628,10 +1628,8 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue</a>(<var>stream</var>.[[readableStreamController]],
  <var>chunk</var>). Rethrow any exceptions.
 </ol>
 
@@ -1639,10 +1637,8 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <a href="#concept-readablestream"><code title="concept-ReadableStream">ReadableStream</code></a> object <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-close">ReadableStreamDefaultControllerClose</a>(<var>controller</var>).
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-close">ReadableStreamDefaultControllerClose</a>(<var>stream</var>.[[readableStreamController]]).
  Rethrow any exceptions.
 </ol>
 
@@ -1651,10 +1647,8 @@ this section, we define common operations for ReadableStream. <a href="#refsSTRE
 <var>reason</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-error">ReadableStreamDefaultControllerError</a>(<var>controller</var>,
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-error">ReadableStreamDefaultControllerError</a>(<var>stream</var>.[[readableStreamController]]).
  <var>reason</var>). Rethrow any exceptions.
 </ol>
 
@@ -1801,7 +1795,7 @@ if the following conditions hold:
  <li><p><var>stream</var> is <a href="#concept-readablestream-readable" title="concept-ReadableStream-readable">readable</a>.
 
  <li><p>The result of calling
- <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize</a>(<var>controller</var>)
+ <a class="external" data-anolis-spec="streams" href="https://streams.spec.whatwg.org/#readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize</a>(<var>stream</var>.[[readableStreamController]]).
  is positive.
 </ul>
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -15,8 +15,7 @@
  <dt>Participate:
  <dd><a href=https://github.com/whatwg/fetch>GitHub whatwg/fetch</a>
  (<a href=https://github.com/whatwg/fetch/issues/new>file an issue</a>,
- <a href=https://github.com/whatwg/fetch/issues>open issues</a>,
- <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WHATWG&amp;component=Fetch&amp;resolution=---">legacy open bugs</a>)
+ <a href=https://github.com/whatwg/fetch/issues>open issues</a>)
  <dd><a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>
 
  <dt>Commits:
@@ -1549,7 +1548,9 @@ each of which is one of `<code title>dpr</code>`,
 
 <p>A <dfn title=concept-ReadableStream data-export data-dfn-type=interface>ReadableStream</dfn>
 object represents a <span data-anolis-spec=streams title=readablestream>stream of data</span>. In
-this section, we define common operations for ReadableStream. <span data-anolis-ref>STREAMS</span>
+this section, we define common operations for
+<code title=concept-ReadableStream>ReadableStream</code> objects.
+<span data-anolis-ref>STREAMS</span>
 
 <p>To
 <dfn title=concept-enqueue-ReadableStream data-export data-dfn-for=ReadableStream>enqueue</dfn>
@@ -1582,10 +1583,9 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 </ol>
 
 <p>To
-<dfn title=concept-construct-ReadableStream data-export data-dfn-for=ReadableStream>construct a
-<code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given
-<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which are
-optional, run these steps:
+<dfn title=concept-construct-ReadableStream data-export data-dfn-for=ReadableStream>construct a <code>ReadableStream</code> object</dfn>
+with given <var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which
+are optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.
@@ -1604,9 +1604,8 @@ optional, run these steps:
 </ol>
 
 <p>To
-<dfn title=concept-construct-fixed-ReadableStream data-export data-dfn-for=ReadableStream>construct
-a fixed <code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given
-<var>chunks</var>, run these steps:
+<dfn title=concept-construct-fixed-ReadableStream data-export data-dfn-for=ReadableStream>construct a fixed <code>ReadableStream</code> object</dfn>
+with given <var>chunks</var>, run these steps:
 
 <ol>
  <li><p>Let <var>stream</var> be the result of

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1589,8 +1589,9 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 
 <p>To
 <dfn title=concept-construct-ReadableStream data-export data-dfn-for=ReadableStream>construct a
-<code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given<var>strategy</var>,
-<var>pull</var> action and <var>cancel</var> action, all of which are optional, run these steps:
+<code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given
+<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which are
+optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1557,7 +1557,10 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Call <code data-anolis-spec=streams>EnqueueInReadableStream</code>(<var>stream</var>,
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerEnqueue</span>(<var>controller</var>,
  <var>chunk</var>). Rethrow any exceptions.
 </ol>
 
@@ -1565,7 +1568,10 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Call <code data-anolis-spec=streams>CloseReadableStream</code>(<var>stream</var>).
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerClose</span>(<var>controller</var>).
  Rethrow any exceptions.
 </ol>
 
@@ -1574,14 +1580,17 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <var>reason</var>, run these steps:
 
 <ol>
- <li><p>Call <code data-anolis-spec=streams>ErrorReadableStream</code>(<var>stream</var>,
+ <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
+
+ <li><p>Call
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerError</span>(<var>controller</var>,
  <var>reason</var>). Rethrow any exceptions.
 </ol>
 
 <p>To
-<dfn title=concept-construct-ReadableStream data-export data-dfn-for=ReadableStream>construct a <code title=concept-ReadableStream>ReadableStream</code> object</dfn>
-with given<var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which
-are optional, run these steps:
+<dfn title=concept-construct-ReadableStream data-export data-dfn-for=ReadableStream>construct a
+<code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given<var>strategy</var>,
+<var>pull</var> action and <var>cancel</var> action, all of which are optional, run these steps:
 
 <ol>
  <li><p>Let <var>init</var> be a new object.
@@ -1600,8 +1609,9 @@ are optional, run these steps:
 </ol>
 
 <p>To
-<dfn title=concept-construct-fixed-ReadableStream data-export data-dfn-for=ReadableStream>construct a fixed <code title=concept-ReadableStream>ReadableStream</code> object</dfn>
-with given <var>chunks</var>, run these steps:
+<dfn title=concept-construct-fixed-ReadableStream data-export data-dfn-for=ReadableStream>construct
+a fixed <code title=concept-ReadableStream>ReadableStream</code> object</dfn> with given
+<var>chunks</var>, run these steps:
 
 <ol>
  <li><p>Let <var>stream</var> be the result of
@@ -1624,7 +1634,7 @@ steps:
 
 <ol>
  <li><p>Let <var>reader</var> be the result of calling
- <code data-anolis-spec=streams>AcquireReadableStreamReader</code>(<var>stream</var>).
+ <span data-anolis-spec=streams>AcquireReadableStreamDefaultReader</span>(<var>stream</var>).
  Rethrow any exceptions.
 
  <li><p>Return <var>reader</var>.
@@ -1634,7 +1644,7 @@ steps:
 <dfn title=concept-read-chunk-from-ReadableStream data-export data-dfn-for=ReadableStream>read a chunk</dfn>
 from a <code title=concept-ReadableStream>ReadableStream</code> object with <var>reader</var>,
 return the result of calling
-<code data-anolis-spec=streams>ReadFromReadableStreamReader</code>(<var>reader</var>).
+<span data-anolis-spec=streams>ReadableStreamDefaultReaderRead</span>(<var>reader</var>).
 
 <p>To
 <dfn title=concept-read-all-bytes-from-ReadableStream data-export data-dfn-for=ReadableStream>read all bytes</dfn>
@@ -1648,7 +1658,7 @@ these steps:
 
  <li>
  <p>Let <var>read</var> be the result of calling
- <code data-anolis-spec=streams>ReadFromReadableStreamReader</code>(<var>reader</var>).
+ <span data-anolis-spec=streams>ReadableStreamDefaultReaderRead</span>(<var>reader</var>).
 
  <ul>
   <li><p>When <var>read</var> is fulfilled with an object whose <code title>done</code>
@@ -1672,8 +1682,7 @@ these steps:
 <p>To <dfn title=concept-cancel-ReadableStream data-export data-dfn-for=ReadableStream>cancel</dfn>
 a <code title=concept-ReadableStream>ReadableStream</code> object with <var>reader</var> and
 <var>reason</var>, return the result of calling
-<code data-anolis-spec=streams>ReadableStreamReaderGenericCancel</code>(<var>reader</var>,
-<var>reason</var>).
+<span data-anolis-spec=streams>ReadableStreamCancel</span>(<var>reader</var>, <var>reason</var>).
 
 <p class="note no-backref">Because the reader grants exclusive access, the actual mechanism of how
 to read cannot be observed. Implementations could use more direct mechanism if convenient.
@@ -1683,7 +1692,7 @@ to read cannot be observed. Implementations could use more direct mechanism if c
 
 <ol>
  <li><p>Return the result of calling
- <code data-anolis-spec=streams>TeeReadableStream</code>(<var>stream</var>, true).
+ <span data-anolis-spec=streams>ReadableStreamTee</span>(<var>stream</var>, true).
  Rethrow any exception.
 </ol>
 
@@ -1697,19 +1706,19 @@ to read cannot be observed. Implementations could use more direct mechanism if c
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to be
 <dfn title=concept-ReadableStream-readable data-export data-dfn-for=ReadableStream>readable</dfn> if
-<var>stream</var>@[[state]] is "readable".
+<var>stream</var>.[[state]] is "readable".
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to be
 <dfn title=concept-ReadableStream-closed data-export data-dfn-for=ReadableStream>closed</dfn> if
-<var>stream</var>@[[state]] is "closed".
+<var>stream</var>.[[state]] is "closed".
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to be
 <dfn title=concept-ReadableStream-errored data-export data-dfn-for=ReadableStream>errored</dfn> if
-<var>stream</var>@[[state]] is "errored".
+<var>stream</var>.[[state]] is "errored".
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to be
 <dfn title=concept-ReadableStream-locked data-export data-dfn-for=ReadableStream>locked</dfn> if the
-result of calling <code data-anolis-spec=streams>IsReadableStreamLocked</code>(<var>stream</var>) is
+result of calling <span data-anolis-spec=streams>IsReadableStreamLocked</span>(<var>stream</var>) is
 true.
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to
@@ -1720,14 +1729,14 @@ if the following conditions hold:
  <li><p><var>stream</var> is <span title=concept-ReadableStream-readable>readable</span>.
 
  <li><p>The result of calling
- <code data-anolis-spec=streams>GetReadableStreamDesiredSize</code>(<var>stream</var>) is
- positive.
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerGetDesiredSize</span>(<var>controller</var>)
+ is positive.
 </ul>
 
 <p>A <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var> is said to be
 <dfn title=concept-ReadableStream-disturbed data-export data-dfn-for=ReadableStream>disturbed</dfn>
 if the result of calling
-<code data-anolis-spec=streams>IsReadableStreamDisturbed</code>(<var>stream</var>) is true.
+<span data-anolis-spec=streams>IsReadableStreamDisturbed</span>(<var>stream</var>) is true.
 
 
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1557,10 +1557,8 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <span data-anolis-spec=streams>ReadableStreamDefaultControllerEnqueue</span>(<var>controller</var>,
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerEnqueue</span>(<var>stream</var>.[[readableStreamController]],
  <var>chunk</var>). Rethrow any exceptions.
 </ol>
 
@@ -1568,10 +1566,8 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <code title=concept-ReadableStream>ReadableStream</code> object <var>stream</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <span data-anolis-spec=streams>ReadableStreamDefaultControllerClose</span>(<var>controller</var>).
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerClose</span>(<var>stream</var>.[[readableStreamController]]).
  Rethrow any exceptions.
 </ol>
 
@@ -1580,10 +1576,8 @@ this section, we define common operations for ReadableStream. <span data-anolis-
 <var>reason</var>, run these steps:
 
 <ol>
- <li><p>Let <var>controller</var> be <var>stream</var>.[[readableStreamController]].
-
  <li><p>Call
- <span data-anolis-spec=streams>ReadableStreamDefaultControllerError</span>(<var>controller</var>,
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerError</span>(<var>stream</var>.[[readableStreamController]]).
  <var>reason</var>). Rethrow any exceptions.
 </ol>
 
@@ -1730,7 +1724,7 @@ if the following conditions hold:
  <li><p><var>stream</var> is <span title=concept-ReadableStream-readable>readable</span>.
 
  <li><p>The result of calling
- <span data-anolis-spec=streams>ReadableStreamDefaultControllerGetDesiredSize</span>(<var>controller</var>)
+ <span data-anolis-spec=streams>ReadableStreamDefaultControllerGetDesiredSize</span>(<var>stream</var>.[[readableStreamController]]).
  is positive.
 </ul>
 


### PR DESCRIPTION
This change fixes ReadableStream abstract operation markup and names. Fixes #361.