### PR TITLE
Block additional script MIMETypes (audio, video, csv)

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1497,10 +1497,12 @@ run these steps:
 
  <li><p>Let <var>type</var> be <var>request</var>'s <span title=concept-request-type>type</span>.
 
- <li><p>If <var>type</var> is "<code title>script</code>", and <var>MIMEType</var> starts with
- `<code title>audio/</code>`, `<code title>image/</code>` or `<code title>video/</code>`, then return <b title>blocked</b>.
+ <li><p>If <var>type</var> is "<code title>script</code>", and any of the following statements are true, then return <b title>blocked</b>:
 
- <li><p>If <var>type</var> is "<code title>script</code>", and <var>MIMEType</var> is `<code title>text/csv</code>`, then return <b title>blocked</b>.
+   <ul class="brief">
+   <li><var>MIMEType</var> starts with `<code title>audio/</code>`, `<code title>image/</code>`, or `<code title>video/</code>`.
+   <li><var>MIMEType</var> is `<code title>text/csv</code>`.
+   </ul>
 
  <li><p>Return <b title>allowed</b>.
 </ol>
@@ -5620,6 +5622,7 @@ Surya Ismail,
 Thomas Roessler,
 Thomas Wisniewski,
 Tobie Langel,
+Tom Schuster,
 Tomás Aparicio,
 保呂毅 (Tsuyoshi Horo),
 Tyler Close,

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1498,7 +1498,9 @@ run these steps:
  <li><p>Let <var>type</var> be <var>request</var>'s <span title=concept-request-type>type</span>.
 
  <li><p>If <var>type</var> is "<code title>script</code>", and <var>MIMEType</var> starts with
- `<code title>image/</code>`, then return <b title>blocked</b>.
+ `<code title>audio/</code>`, `<code title>image/</code>` or `<code title>video/</code>`, then return <b title>blocked</b>.
+
+ <li><p>If <var>type</var> is "<code title>script</code>", and <var>MIMEType</var> is `<code title>text/csv</code>`, then return <b title>blocked</b>.
 
  <li><p>Return <b title>allowed</b>.
 </ol>


### PR DESCRIPTION
Closes  #337.
I also added audio/video, because per telemetry they are probably unused. I think it makes sense to block them alongside of `image/`. `text/csv` is blocked to mitigate the issue described in [Bug 1048535](https://bugzilla.mozilla.org/show_bug.cgi?id=1048535).

@mikewest Are you on board with this?