### PR TITLE
Add request's reserved client and target client id

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-17-october-2016">Living Standard — Last Updated 17 October 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-24-october-2016">Living Standard — Last Updated 24 October 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -732,6 +732,26 @@ outlawing <a href="#forbidden-method" title="forbidden method">forbidden methods
 <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>).
 
 <p>A <a href="#concept-request" title="concept-request">request</a> has an associated
+<dfn data-dfn-for="request" data-export="" id="concept-request-reserved-client" title="concept-request-reserved-client">reserved client</dfn>
+(null, an <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a>, or an
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>). Unless stated otherwise it is null.
+
+<p class="note no-backref">This is only used by <span>navigation requests</span> and worker
+requests, but not service worker requests. It references an
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> for a <a href="#navigation-request">navigation request</a> and an
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for a worker request.
+
+<p>A <a href="#concept-request" title="concept-request">request</a> has an associated
+<dfn data-dfn-for="request" data-export="" id="concept-request-target-client-id" title="concept-request-target-client-id">target client id</dfn>
+(a string). Unless stated otherwise it is the empty string.
+
+<p class="note no-backref">This is only used by <span>navigation requests</span>. It is the
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" title="concept-environment-id">id</a> of the
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">target browsing context</a>'s
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>'s
+<a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>.
+
+<p>A <a href="#concept-request" title="concept-request">request</a> has an associated
 <dfn data-dfn-for="request" data-export="" id="concept-request-window" title="concept-request-window">window</dfn>
 ("<code>no-window</code>", "<code>client</code>", or an
 <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> whose
@@ -744,10 +764,6 @@ outlawing <a href="#forbidden-method" title="forbidden method">forbidden methods
 <a href="#concept-fetch" title="concept-fetch">fetching</a>. It provides a convenient way for standards to not have to
 explicitly set <a href="#concept-request" title="concept-request">request</a>'s
 <a href="#concept-request-window" title="concept-request-window">window</a>.
-
-<p>A <a href="#concept-request" title="concept-request">request</a> has an associated
-<dfn data-dfn-for="request" data-export="" id="concept-request-target-browsing-context" title="concept-request-target-browsing-context">target browsing context</dfn>
-(null or a <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>). Unless stated otherwise it is null.
 
 <p id="keep-alive-flag">A <a href="#concept-request" title="concept-request">request</a> has an associated
 <dfn id="keepalive-flag">keepalive flag</dfn>. Unless stated otherwise it is unset.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -662,8 +662,9 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 <span data-anolis-spec=html>environment settings object</span>).
 
 <p>A <span title=concept-request>request</span> has an associated
-<dfn title=concept-request-reserved-client-id data-export data-dfn-for=request>reserved client
-id</dfn> (null or a string). Unless stated otherwise it is null.
+<dfn title=concept-request-reserved-client data-export data-dfn-for=request>reserved client</dfn>
+(null or an <span data-anolis-spec=html>environment</span> or an
+<span data-anolis-spec=html>environment settings object</span>). Unless stated otherwise it is null.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-target-client-id data-export data-dfn-for=request>target client id</dfn>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -663,12 +663,12 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-reserved-client data-export data-dfn-for=request>reserved client</dfn>
-(null or an <span data-anolis-spec=html>environment</span> or an
+(null, an <span data-anolis-spec=html>environment</span>, or an
 <span data-anolis-spec=html>environment settings object</span>). Unless stated otherwise it is null.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-target-client-id data-export data-dfn-for=request>target client id</dfn>
-(null or a string). Unless stated otherwise it is null.
+(a string). Unless stated otherwise it is the empty string.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-window data-export data-dfn-for=request>window</dfn>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -684,10 +684,6 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 explicitly set <span title=concept-request>request</span>'s
 <span title=concept-request-window>window</span>.
 
-<p>A <span title=concept-request>request</span> has an associated
-<dfn title=concept-request-target-browsing-context data-export data-dfn-for=request>target browsing context</dfn>
-(null or a <span data-anolis-spec=html>browsing context</span>). Unless stated otherwise it is null.
-
 <p id=keep-alive-flag>A <span title=concept-request>request</span> has an associated
 <dfn>keepalive flag</dfn>. Unless stated otherwise it is unset.
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -662,6 +662,14 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 <span data-anolis-spec=html>environment settings object</span>).
 
 <p>A <span title=concept-request>request</span> has an associated
+<dfn title=concept-request-reserved-client-id data-export data-dfn-for=request>reserved client
+id</dfn> (null or a string). Unless stated otherwise it is null.
+
+<p>A <span title=concept-request>request</span> has an associated
+<dfn title=concept-request-target-client-id data-export data-dfn-for=request>target client id</dfn>
+(null or a string). Unless stated otherwise it is null.
+
+<p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-window data-export data-dfn-for=request>window</dfn>
 ("<code>no-window</code>", "<code>client</code>", or an
 <span data-anolis-spec=html>environment settings object</span> whose

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -666,20 +666,20 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 (null, an <span data-anolis-spec=html>environment</span>, or an
 <span data-anolis-spec=html>environment settings object</span>). Unless stated otherwise it is null.
 
-<p class="note no-backref">This is only used by <span>navigation requests</span> and worker requests
-(except service worker requests). It references an <span data-anolis-spec=html>environment</span>
-for a <span>navigation request</span> and an <span data-anolis-spec=html>environment settings
-object</span> for a worker request.
+<p class="note no-backref">This is only used by <span>navigation requests</span> and worker
+requests, but not service worker requests. It references an
+<span data-anolis-spec=html>environment</span> for a <span>navigation request</span> and an
+<span data-anolis-spec=html>environment settings object</span> for a worker request.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-target-client-id data-export data-dfn-for=request>target client id</dfn>
 (a string). Unless stated otherwise it is the empty string.
 
-<p class="note no-backref">This is only used by <span>navigation requests</span>. It has the
-<span data-anolis-spec=html>id</span> of the <span data-anolis-spec=html>target browsing
-context</span>'s <span data-anolis-spec=html>active document</span>'s
-<span data-anolis-spec=html>environment settings object</span> captured before entering the
-<span title=concept-fetch>fetch</span> algorithm.
+<p class="note no-backref">This is only used by <span>navigation requests</span>. It is the
+<span title=concept-environment-id data-anolis-spec=html>id</span> of the
+<span data-anolis-spec=html>target browsing context</span>'s
+<span data-anolis-spec=html>active document</span>'s
+<span data-anolis-spec=html>environment settings object</span>.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-window data-export data-dfn-for=request>window</dfn>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -666,9 +666,20 @@ outlawing <span title="forbidden method">forbidden methods</span> and
 (null, an <span data-anolis-spec=html>environment</span>, or an
 <span data-anolis-spec=html>environment settings object</span>). Unless stated otherwise it is null.
 
+<p class="note no-backref">This is only used by <span>navigation requests</span> and worker requests
+(except service worker requests). It references an <span data-anolis-spec=html>environment</span>
+for a <span>navigation request</span> and an <span data-anolis-spec=html>environment settings
+object</span> for a worker request.
+
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-target-client-id data-export data-dfn-for=request>target client id</dfn>
 (a string). Unless stated otherwise it is the empty string.
+
+<p class="note no-backref">This is only used by <span>navigation requests</span>. It has the
+<span data-anolis-spec=html>id</span> of the <span data-anolis-spec=html>target browsing
+context</span>'s <span data-anolis-spec=html>active document</span>'s
+<span data-anolis-spec=html>environment settings object</span> captured before entering the
+<span title=concept-fetch>fetch</span> algorithm.
 
 <p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-window data-export data-dfn-for=request>window</dfn>


### PR DESCRIPTION
Add request's reserved client and target client id

This patch defines the request's reserved client and the target client
id. The reserved client of a request is set to an environment or an
environment settings object during a navigation or a worker creation
request, respectively. The target client id of a request is set to the
target browsing context's active document's environment settings
object's id during a navigation. The given values are primarily used
to provide the reserved client's id and target client's id to service
workers' fetch event handlers.

This removes the request's target browsing context as the reserved
client provides the same information.

Related issue: https://github.com/w3c/ServiceWorker/issues/870
Related change: https://github.com/whatwg/html/pull/1776