### PR TITLE
Treat data URLs as same-origin, except for workers

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -952,10 +952,6 @@ changed during redirects too.
 otherwise it is unset.
 
 <p>A <a href="#concept-request" title="concept-request">request</a> has an associated
-<dfn data-dfn-for="request" data-export="" id="same-origin-data-url-flag">same-origin data-URL flag</dfn>. Unless stated otherwise it is
-unset.
-
-<p>A <a href="#concept-request" title="concept-request">request</a> has an associated
 <dfn data-dfn-for="request" data-export="" id="concept-request-referrer" title="concept-request-referrer">referrer</dfn>, which is
 "<code>no-referrer</code>", "<code>client</code>", or a
 <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a>. Unless stated otherwise it is
@@ -2484,9 +2480,10 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <a href="#concept-request-origin" title="concept-request-origin">origin</a> and <i>CORS flag</i> is unset
    <dt><var>request</var>'s
    <a href="#concept-request-current-url" title="concept-request-current-url">current url</a>'s
-   <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is
-   "<code title="">data</code>" and <var>request</var>'s
-   <a href="#same-origin-data-url-flag">same-origin data-URL flag</a> is set
+   <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>" and
+   <var>request</var>'s <a href="#concept-request-destination" title="concept-request-destination">destination</a> is not
+   "<code>sharedworker</code>" or "<code>worker</code>"
+   <!-- "serviceworker" already prevents anything non-HTTP(S) -->
    <dt><var>request</var>'s <a href="#concept-request-mode" title="concept-request-mode">mode</a> is
    "<code title="">navigate</code>" or "<code title="">websocket</code>"
 
@@ -3058,8 +3055,6 @@ in addition to <a href="#concept-http-fetch" title="concept-http-fetch">HTTP fet
 
  <li><p>Increase <var>request</var>'s
  <a href="#concept-request-redirect-count" title="concept-request-redirect-count">redirect count</a> by one.
-
- <li><p>Unset <var title="">request</var>'s <a href="#same-origin-data-url-flag">same-origin data-URL flag</a>.
 
  <li><p>If <var>request</var>'s <a href="#concept-request-mode" title="concept-request-mode">mode</a> is "<code>cors</code>",
  <var>request</var>'s <a href="#concept-request-origin" title="concept-request-origin">origin</a> is <em>not</em>
@@ -4683,7 +4678,6 @@ constructor must run these steps:
  <a href="#concept-request-origin" title="concept-request-origin">origin</a> is "<code>client</code>",
  <a href="#omit-origin-header-flag">omit-<code>Origin</code>-header flag</a> is <var>request</var>'s
  <a href="#omit-origin-header-flag">omit-<code>Origin</code>-header flag</a>,
- <a href="#same-origin-data-url-flag">same-origin data-URL flag</a> is set,
  <a href="#concept-request-referrer" title="concept-request-referrer">referrer</a> is <var>request</var>'s
  <a href="#concept-request-referrer" title="concept-request-referrer">referrer</a>,
  <a href="#concept-request-referrer-policy" title="concept-request-referrer-policy">referrer policy</a> is

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg" width="100"></a>
 <h1 id="cors">Fetch</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-14-september-2016">Living Standard — Last Updated 14 September 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-15-september-2016">Living Standard — Last Updated 15 September 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -2480,10 +2480,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <a href="#concept-request-origin" title="concept-request-origin">origin</a> and <i>CORS flag</i> is unset
    <dt><var>request</var>'s
    <a href="#concept-request-current-url" title="concept-request-current-url">current url</a>'s
-   <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>" and
-   <var>request</var>'s <a href="#concept-request-destination" title="concept-request-destination">destination</a> is not
-   "<code>sharedworker</code>" or "<code>worker</code>"
-   <!-- "serviceworker" already prevents anything non-HTTP(S) -->
+   <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>"
    <dt><var>request</var>'s <a href="#concept-request-mode" title="concept-request-mode">mode</a> is
    "<code title="">navigate</code>" or "<code title="">websocket</code>"
 
@@ -2495,6 +2492,16 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      <li><p>Return the result of performing a <a href="#concept-basic-fetch" title="concept-basic-fetch">basic fetch</a>
      using <var>request</var>.
     </ol>
+
+    <p class="note no-backref">HTML will assign any documents and dedicated workers created from a
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a> whose
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>" an
+    <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a> and it prevents creation of shared workers from
+    such a <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a>. Service workers can only be
+    created from <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a> whose
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is an
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#http-scheme">HTTP(S) scheme</a>.
+    <a href="#refsHTML">[HTML]</a> <a href="#refsSW">[SW]</a>
 
    <dt><var>request</var>'s <a href="#concept-request-mode" title="concept-request-mode">mode</a> is
    "<code title="">same-origin</code>"

--- a/Overview.html
+++ b/Overview.html
@@ -2493,12 +2493,12 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      using <var>request</var>.
     </ol>
 
-    <p class="note no-backref">HTML will assign any documents and dedicated workers created from a
-    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a> whose
-    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>" an
-    <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a> and it prevents creation of shared workers from
-    such a <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a>. Service workers can only be
-    created from <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URL</a> whose
+    <p class="note no-backref">HTML assigns any documents and dedicated workers created from
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URLs</a> whose
+    <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is "<code>data</code>" a
+    unique <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>, and prevents creation of shared workers
+    from such <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URLs</a>. Service workers can only be
+    created from <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url" title="concept-url">URLs</a> whose
     <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#concept-url-scheme" title="concept-url-scheme">scheme</a> is an
     <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#http-scheme">HTTP(S) scheme</a>.
     <a href="#refsHTML">[HTML]</a> <a href="#refsSW">[SW]</a>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2410,10 +2410,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <span title=concept-request-origin>origin</span> and <i>CORS flag</i> is unset
    <dt><var>request</var>'s
    <span title=concept-request-current-url>current url</span>'s
-   <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>" and
-   <var>request</var>'s <span title=concept-request-destination>destination</span> is not
-   "<code>sharedworker</code>" or "<code>worker</code>"
-   <!-- "serviceworker" already prevents anything non-HTTP(S) -->
+   <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>"
    <dt><var>request</var>'s <span title=concept-request-mode>mode</span> is
    "<code title>navigate</code>" or "<code title>websocket</code>"
 
@@ -2425,6 +2422,16 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      <li><p>Return the result of performing a <span title=concept-basic-fetch>basic fetch</span>
      using <var>request</var>.
     </ol>
+
+    <p class="note no-backref">HTML will assign any documents and dedicated workers created from a
+    <span data-anolis-spec=url title=concept-url>URL</span> whose
+    <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>" an
+    <span data-anolis-spec=html>opaque origin</span> and it prevents creation of shared workers from
+    such a <span data-anolis-spec=url title=concept-url>URL</span>. Service workers can only be
+    created from <span data-anolis-spec=url title=concept-url>URL</span> whose
+    <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is an
+    <span data-anolis-spec=url>HTTP(S) scheme</span>.
+    <span data-anolis-ref>HTML</span> <span data-anolis-ref>SW</span>
 
    <dt><var>request</var>'s <span title=concept-request-mode>mode</span> is
    "<code title>same-origin</code>"

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -882,10 +882,6 @@ changed during redirects too.
 otherwise it is unset.
 
 <p>A <span title=concept-request>request</span> has an associated
-<dfn data-export data-dfn-for=request>same-origin data-URL flag</dfn>. Unless stated otherwise it is
-unset.
-
-<p>A <span title=concept-request>request</span> has an associated
 <dfn title=concept-request-referrer data-export data-dfn-for=request>referrer</dfn>, which is
 "<code>no-referrer</code>", "<code>client</code>", or a
 <span data-anolis-spec=url title=concept-url>URL</span>. Unless stated otherwise it is
@@ -2414,9 +2410,10 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <span title=concept-request-origin>origin</span> and <i>CORS flag</i> is unset
    <dt><var>request</var>'s
    <span title=concept-request-current-url>current url</span>'s
-   <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is
-   "<code title>data</code>" and <var>request</var>'s
-   <span>same-origin data-URL flag</span> is set
+   <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>" and
+   <var>request</var>'s <span title=concept-request-destination>destination</span> is not
+   "<code>sharedworker</code>" or "<code>worker</code>"
+   <!-- "serviceworker" already prevents anything non-HTTP(S) -->
    <dt><var>request</var>'s <span title=concept-request-mode>mode</span> is
    "<code title>navigate</code>" or "<code title>websocket</code>"
 
@@ -2988,8 +2985,6 @@ in addition to <span title=concept-http-fetch>HTTP fetch</span> above.
 
  <li><p>Increase <var>request</var>'s
  <span title=concept-request-redirect-count>redirect count</span> by one.
-
- <li><p>Unset <var title>request</var>'s <span>same-origin data-URL flag</span>.
 
  <li><p>If <var>request</var>'s <span title=concept-request-mode>mode</span> is "<code>cors</code>",
  <var>request</var>'s <span title=concept-request-origin>origin</span> is <em>not</em>
@@ -4613,7 +4608,6 @@ constructor must run these steps:
  <span title=concept-request-origin>origin</span> is "<code>client</code>",
  <span>omit-<code>Origin</code>-header flag</span> is <var>request</var>'s
  <span>omit-<code>Origin</code>-header flag</span>,
- <span>same-origin data-URL flag</span> is set,
  <span title=concept-request-referrer>referrer</span> is <var>request</var>'s
  <span title=concept-request-referrer>referrer</span>,
  <span title=concept-request-referrer-policy>referrer policy</span> is

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2423,12 +2423,12 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      using <var>request</var>.
     </ol>
 
-    <p class="note no-backref">HTML will assign any documents and dedicated workers created from a
-    <span data-anolis-spec=url title=concept-url>URL</span> whose
-    <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>" an
-    <span data-anolis-spec=html>opaque origin</span> and it prevents creation of shared workers from
-    such a <span data-anolis-spec=url title=concept-url>URL</span>. Service workers can only be
-    created from <span data-anolis-spec=url title=concept-url>URL</span> whose
+    <p class="note no-backref">HTML assigns any documents and dedicated workers created from
+    <span data-anolis-spec=url title=concept-url>URLs</span> whose
+    <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is "<code>data</code>" a
+    unique <span data-anolis-spec=html>opaque origin</span>, and prevents creation of shared workers
+    from such <span data-anolis-spec=url title=concept-url>URLs</span>. Service workers can only be
+    created from <span data-anolis-spec=url title=concept-url>URLs</span> whose
     <span data-anolis-spec=url title=concept-url-scheme>scheme</span> is an
     <span data-anolis-spec=url>HTTP(S) scheme</span>.
     <span data-anolis-ref>HTML</span> <span data-anolis-ref>SW</span>


### PR DESCRIPTION
HTML gives data URLs a unique origin when navigating to them to prevent
a class of XSS attacks.

Since browsers already largely allow data URLs in all other contexts
this commit aligns with that, opting them into being same-origin
elsewhere.

Workers however are still prevented. It would create problems for
shared workers and potentially also for dedicated workers.

Fixes #381.