### PR TITLE
Reference RFC 7578 instead of RFC 2388

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4497,7 +4497,7 @@ runs the associated steps:
    `<code>boundary</code>` parameter from <var>MIME type</var> and
    <a spec=encoding>utf-8</a> as encoding, per the rules set forth
    in <cite>Returning Values from Forms: multipart/form-data</cite>.
-   [[!RFC2388]]
+   [[!RFC7578]]
 
    <li><p>If that fails for some reason, <a spec=webidl>throw</a> a
    <code>TypeError</code>.
@@ -5695,9 +5695,11 @@ Daniel Robertson,
 Daniel Veditz,
 David Håsäther,
 David Orchard,
-Domenic Denicola,
 Dean Jackson,
+Domenic Denicola,
+Dominique Hazaël-Massieux,
 Doug Turner,
+Eero Häkkinen,
 Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,

--- a/fetch.html
+++ b/fetch.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-fetch.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref" id="title">Fetch</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-27">27 October 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-28">28 October 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -1899,7 +1899,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps: </p>
   substeps: </p>
      <ol>
       <li>
-       <p>If <var>request</var>’s <a data-link-type="dfn" href="#concept-request-client">client</a> is null or <var>request</var>’s <a data-link-type="dfn" href="#concept-request-client">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> is not a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object, then set <var>response</var> to the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm">handle fetch</a> for <var>request</var>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> <a data-link-type="biblio" href="#biblio-sw">[SW]</a> </p>
+       <p>If <var>request</var>’s <a data-link-type="dfn" href="#concept-request-client">client</a> is null or <var>request</var>’s <a data-link-type="dfn" href="#concept-request-client">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> is not a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object, then set <var>response</var> to the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm">handle fetch</a> for <var>request</var>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> <a data-link-type="biblio" href="#biblio-sw">[SW]</a> </p>
       <li>
        <p>If <var>response</var> is null, <var>request</var> is a <a data-link-type="dfn" href="#subresource-request">subresource request</a>, and <var>request</var>’s <a data-link-type="dfn" href="#concept-request-origin">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> with <var>request</var>’s <a data-link-type="dfn" href="#concept-request-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>, then set <var>response</var> to the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#on-foreign-fetch-request-algorithm">handle foreign fetch</a> for <var>request</var>. <a data-link-type="biblio" href="#biblio-sw">[SW]</a> </p>
       <li>
@@ -2804,7 +2804,7 @@ runs the associated steps: </p>
       <li>
        <p>Parse <var>bytes</var>, using the value of the
    `<code>boundary</code>` parameter from <var>MIME type</var> and <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">utf-8</a> as encoding, per the rules set forth
-   in <cite>Returning Values from Forms: multipart/form-data</cite>. <a data-link-type="biblio" href="#biblio-rfc2388">[RFC2388]</a> </p>
+   in <cite>Returning Values from Forms: multipart/form-data</cite>. <a data-link-type="biblio" href="#biblio-rfc7578">[RFC7578]</a> </p>
       <li>
        <p>If that fails for some reason, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. </p>
       <li>
@@ -3481,13 +3481,13 @@ however, it is perfectly fine to do so. </p>
      <dt id="biblio-cookies">[COOKIES]
      <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6265">HTTP State Management Mechanism</a>. April 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
      <dt id="biblio-csp">[CSP]
-     <dd>Mike West. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 3</a>. 13 September 2016. WD. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+     <dd>Mike West. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 3</a>. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
      <dt id="biblio-dataurl">[DATAURL]
      <dd>Simon Sapin. <a href="https://simonsapin.github.io/data-urls/">The data URL scheme</a>. URL: <a href="https://simonsapin.github.io/data-urls/">https://simonsapin.github.io/data-urls/</a>
      <dt id="biblio-encoding">[ENCODING]
      <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
      <dt id="biblio-fileapi">[FileAPI]
-     <dd>Arun Ranganathan; Jonas Sicking. <a href="https://w3c.github.io/FileAPI/">File API</a>. 21 April 2015. WD. URL: <a href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
+     <dd>Arun Ranganathan; Jonas Sicking. <a href="https://w3c.github.io/FileAPI/">File API</a>. URL: <a href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
      <dt id="biblio-hsts">[HSTS]
      <dd>J. Hodges; C. Jackson; A. Barth. <a href="https://tools.ietf.org/html/rfc6797">HTTP Strict Transport Security (HSTS)</a>. November 2012. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6797">https://tools.ietf.org/html/rfc6797</a>
      <dt id="biblio-html">[HTML]
@@ -3503,29 +3503,29 @@ however, it is perfectly fine to do so. </p>
      <dt id="biblio-http-semantics">[HTTP-SEMANTICS]
      <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
      <dt id="biblio-mix">[MIX]
-     <dd>Mike West. <a href="https://w3c.github.io/webappsec-mixed-content/">Mixed Content</a>. 2 August 2016. CR. URL: <a href="https://w3c.github.io/webappsec-mixed-content/">https://w3c.github.io/webappsec-mixed-content/</a>
+     <dd>Mike West. <a href="https://w3c.github.io/webappsec-mixed-content/">Mixed Content</a>. URL: <a href="https://w3c.github.io/webappsec-mixed-content/">https://w3c.github.io/webappsec-mixed-content/</a>
      <dt id="biblio-referrer">[REFERRER]
-     <dd>Jochen Eisinger; Mike West. <a href="https://w3c.github.io/webappsec-referrer-policy/">Referrer Policy</a>. 16 October 2016. WD. URL: <a href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
+     <dd>Jochen Eisinger; Mike West. <a href="https://w3c.github.io/webappsec-referrer-policy/">Referrer Policy</a>. URL: <a href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
      <dt id="biblio-rfc2119">[RFC2119]
      <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-     <dt id="biblio-rfc2388">[RFC2388]
-     <dd>L. Masinter. <a href="https://tools.ietf.org/html/rfc2388">Returning Values from Forms: multipart/form-data</a>. August 1998. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc2388">https://tools.ietf.org/html/rfc2388</a>
      <dt id="biblio-rfc4648">[RFC4648]
      <dd>S. Josefsson. <a href="https://tools.ietf.org/html/rfc4648">The Base16, Base32, and Base64 Data Encodings</a>. October 2006. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc4648">https://tools.ietf.org/html/rfc4648</a>
+     <dt id="biblio-rfc7578">[RFC7578]
+     <dd>L. Masinter. <a href="https://tools.ietf.org/html/rfc7578">Returning Values from Forms: multipart/form-data</a>. July 2015. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7578">https://tools.ietf.org/html/rfc7578</a>
      <dt id="biblio-sri">[SRI]
-     <dd>Devdatta Akhawe; et al. <a href="https://w3c.github.io/webappsec-subresource-integrity/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://w3c.github.io/webappsec-subresource-integrity/">https://w3c.github.io/webappsec-subresource-integrity/</a>
+     <dd>Devdatta Akhawe; et al. <a href="https://w3c.github.io/webappsec-subresource-integrity/">Subresource Integrity</a>. URL: <a href="https://w3c.github.io/webappsec-subresource-integrity/">https://w3c.github.io/webappsec-subresource-integrity/</a>
      <dt id="biblio-streams">[STREAMS]
      <dd>Domenic Denicola. <a href="https://streams.spec.whatwg.org/">Streams Standard</a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
      <dt id="biblio-sw">[SW]
-     <dd>Alex Russell; et al. <a href="https://w3c.github.io/ServiceWorker/v1/">Service Workers 1</a>. 11 October 2016. WD. URL: <a href="https://w3c.github.io/ServiceWorker/v1/">https://w3c.github.io/ServiceWorker/v1/</a>
+     <dd>Alex Russell; et al. <a href="https://w3c.github.io/ServiceWorker/v1/">Service Workers 1</a>. URL: <a href="https://w3c.github.io/ServiceWorker/v1/">https://w3c.github.io/ServiceWorker/v1/</a>
      <dt id="biblio-tls">[TLS]
      <dd>T. Dierks; E. Rescorla. <a href="https://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>. August 2008. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5246">https://tools.ietf.org/html/rfc5246</a>
      <dt id="biblio-upgrade">[UPGRADE]
-     <dd>Mike West. <a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/">Upgrade Insecure Requests</a>. 8 October 2015. CR. URL: <a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/">https://w3c.github.io/webappsec-upgrade-insecure-requests/</a>
+     <dd>Mike West. <a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/">Upgrade Insecure Requests</a>. URL: <a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/">https://w3c.github.io/webappsec-upgrade-insecure-requests/</a>
      <dt id="biblio-url">[URL]
      <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
      <dt id="biblio-webidl">[WEBIDL]
-     <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 15 September 2016. PR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+     <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
      <dt id="biblio-whatwg-dom">[WHATWG-DOM]
      <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
      <dt id="biblio-wsp">[WSP]
@@ -3575,9 +3575,11 @@ Daniel Robertson,
 Daniel Veditz,
 David Håsäther,
 David Orchard,
-Domenic Denicola,
 Dean Jackson,
+Domenic Denicola,
+Dominique Hazaël-Massieux,
 Doug Turner,
+Eero Häkkinen,
 Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,


### PR DESCRIPTION
RFC 2388 has been obsoleted by RFC 7578. This change reflects a similar
change applied to the HTML spec.

See https://github.com/whatwg/html/issues/398 for discussion.