### PR TITLE
Use auto-linking for CSP3.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1223,7 +1223,7 @@ Unless stated otherwise it is `<code>OK</code>`.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-csp-list>CSP list</dfn>, which is a
-list of <a href=https://w3c.github.io/webappsec-csp/#policy>Content Security Policy objects</a>
+list of <a lt="policy" for="/">Content Security Policy objects</a>
 for the <a for=/>response</a>. The list is empty unless otherwise
 specified. [[!CSP]]
 
@@ -2383,7 +2383,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  not <a lt="is local">local</a>, set
  <var>response</var> to a <a>network error</a>.
 
- <li><p>Execute <a href=https://w3c.github.io/webappsec-csp/#report-for-request>Report Content Security Policy violations for <var>request</var></a>.
+ <li><p>Execute [[csp-3#report-for-request]] on <var>request</var></a>.
  [[!CSP]]
 
  <li><p><a href=https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request>Upgrade <var>request</var> to a potentially secure URL, if appropriate</a>.
@@ -2393,7 +2393,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <a lt="block bad port">should fetching <var>request</var> be blocked due to a bad port</a>,
  <a href=https://w3c.github.io/webappsec-mixed-content/#should-block-fetch>should fetching <var>request</var> be blocked as mixed content</a>,
  or
- <a href=https://w3c.github.io/webappsec-csp/#should-block-request>should fetching <var>request</var> be blocked by Content Security Policy</a>
+ [[csp-3#should-block-request]]
  returns <b>blocked</b>, set <var>response</var> to a
  <a>network error</a>.
  [[!MIX]]
@@ -2615,8 +2615,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   <ul class=brief>
    <li><a href=https://w3c.github.io/webappsec-mixed-content/#should-block-response>should <var>internalResponse</var> to <var>request</var> be blocked as mixed content</a>
    [[!MIX]]
-   <li><a href=https://w3c.github.io/webappsec-csp/#should-block-response>should <var>internalResponse</var> to <var>request</var> be blocked by Content Security Policy</a>
-   [[!CSP]]
+   <li>[[csp-3#should-block-response]] executed upon <var>internalResponse</var> and <var>request</var> [[!CSP]]
    <li><a lt="should response to request be blocked due to mime type">should <var>internalResponse</var> to <var>request</var> be blocked due to its MIME type</a>
    <li><a lt="should response to request be blocked due to nosniff">should <var>internalResponse</var> to <var>request</var> be blocked due to nosniff</a>
   </ul>
@@ -2883,9 +2882,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
        <a for=response>url list</a> has more than one item.
       </ul>
 
-     <li><p>Execute
-     <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
-     on <var>actualResponse</var>. [[!CSP]]
+     <li><p>Execute [[csp-3#set-response-csp-list]] on <var>actualResponse</var>. [[!CSP]]
     </ol>
   </ol>
 
@@ -3585,9 +3582,7 @@ steps:
   <a href=https://bugzilla.mozilla.org/show_bug.cgi?id=1030660>bug 1030660</a> looks
   into whether this quirk can be removed.
 
- <li><p>Execute
- <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
- on <var>response</var>. [[!CSP]]
+ <li><p>Execute [[csp-3#set-response-csp-list]] on <var>response</var>. [[!CSP]]
 
  <li><p>If <var>response</var> is not a
  <a>network error</a> and <var>request</var>'s


### PR DESCRIPTION
Rather than hard-coding links to CSP, we should use the magic of Bikeshed
automatically link to the right spot with the right text.

Addresses part of whatwg/fetch#409.