### PR TITLE
Simplify HeadersInit

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4015,7 +4015,7 @@ fetch("/music/pk/altes-kamuffel.flac")
 
 <h3 id=headers-class>Headers class</h3>
 
-<pre class=idl>typedef (Headers or sequence&lt;sequence&lt;ByteString>> or record&lt;ByteString, ByteString>) HeadersInit;
+<pre class=idl>typedef (sequence&lt;sequence&lt;ByteString>> or record&lt;ByteString, ByteString>) HeadersInit;
 
 [Constructor(optional HeadersInit init),
  Exposed=(Window,Worker)]
@@ -4100,18 +4100,8 @@ run these steps:
 
 <ol>
  <li>
-  <p>If <var>object</var> is a {{Headers}} object, then for each <var>header</var> in its
-  <a for=Headers>header list</a>, retaining order,
-  <a for=Headers>append</a>
-  <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a>
-  to <var>headers</var>. Rethrow any exception.
-
-  <p class=note>Once <code>Headers.prototype[Symbol.iterator]</code> is defined this
-  special casing will no longer be needed.
-
- <li>
-  <p>Otherwise, if <var>object</var> is a sequence, then for each
-  <var>header</var> in <var>object</var>, run these substeps:
+  <p>If <var>object</var> is a sequence, then for each <var>header</var> in <var>object</var>, run
+  these substeps:
 
   <ol>
    <li><p>If <var>header</var> does not contain exactly two items, then <a>throw</a> a
@@ -4122,7 +4112,7 @@ run these steps:
    <var>headers</var>. Rethrow any exception.
   </ol>
 
- <li><p>Otherwise, if <var>object</var> is a <a>record</a>, then for each <a for=record>mapping</a>
+ <li><p>Otherwise, <var>object</var> is a <a>record</a>, then for each <a for=record>mapping</a>
  (<var>key</var>, <var>value</var>) in <var>object</var>, <a lt=append for=Headers>append</a>
  <var>key</var>/<var>value</var> to <var>headers</var>. Rethrow any exception.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4015,7 +4015,8 @@ fetch("/music/pk/altes-kamuffel.flac")
 
 <h3 id=headers-class>Headers class</h3>
 
-<pre class=idl>typedef (sequence&lt;sequence&lt;ByteString>> or record&lt;ByteString, ByteString>) HeadersInit;
+<pre class=idl>
+typedef (sequence&lt;sequence&lt;ByteString>> or record&lt;ByteString, ByteString>) HeadersInit;
 
 [Constructor(optional HeadersInit init),
  Exposed=(Window,Worker)]
@@ -4100,8 +4101,8 @@ run these steps:
 
 <ol>
  <li>
-  <p>If <var>object</var> is a sequence, then for each <var>header</var> in <var>object</var>, run
-  these substeps:
+  <p>If <var>object</var> is a <a>sequence</a>, then for each <var>header</var> in
+  <var>object</var>, run these substeps:
 
   <ol>
    <li><p>If <var>header</var> does not contain exactly two items, then <a>throw</a> a


### PR DESCRIPTION
Since Headers has an iterator now through its iterable<> declaration
there’s no real need to special case.

It might be slightly faster to have it there, but this is not
performance-critical code and I’d rather have it be simple.