### PR TITLE
Enforce limit on inflight keepalive bytes

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3180,10 +3180,17 @@ steps:
 
  <li>
   <p>If <var>contentLengthValue</var> is non-null, <var>httpRequest</var>'s
-  <a>keepalive flag</a> is set, and <var>contentLengthValue</var> is greater than a
-  user-agent-defined maximum, then return a <a>network error</a>.
+  <a>keepalive flag</a> is set:
 
-  <p class="note no-backref">The above user-agent-defined maximum ensures that requests that are
+  <ul>
+    <li>Let <var>group</var> be <var>httpRequest</var>'s <a>client</a>'s <a>fetch group</a>.
+    <li>Let <var>inflight keepalive bytes</var> be the sum of <a>request</a> <a>body</a>'s
+    <a>total bytes</a> for each <a>record</a> in <var>group</var> whose <a>done flag</a> is unset.
+    <li>If the sum of <var>contentLengthValue</var> and <var>inflight keepalive bytes</var> is
+    greater than 64KB, then return a <a>network error</a>.
+  </ul>
+
+  <p class="note no-backref">The above limit ensures that requests that are
   allowed to outlive the <a>environment settings object</a> and contain
   a body, have a bounded size and are not allowed to stay alive indefinitely.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3178,31 +3178,35 @@ steps:
  <var>httpRequest</var>'s
  <a for=request>header list</a>.
 
-<li>
+ <li>
   <p>If <var>contentLengthValue</var> is non-null and <var>httpRequest</var>'s
-  <a for=request>keepalive flag</a> is set:
+  <a for=request>keepalive flag</a> is set, then:
 
-  <ul>
-    <li>Let <var>inflight keepalive bytes</var> be zero.
-    <li>Let <var>group</var> be <var>httpRequest</var>'s <a>client</a>'s <a>fetch group</a>.
-    <li>Let <var>inflight records</var> be the set of <a>records</a> in <var>group</var> whose
-    <a for=request>keepalive flag</a> is set, and whose <a>done flag</a> is unset.
-    <li>
-      <p>For each <var>rec</var> in <var>inflight records</var>:
+  <ol>
+   <li><p>Let <var>inflight keepalive bytes</var> be zero.
 
-      <ul class=brief>
-        <li>Let <var>inflight request</var> be <var>rec</var>'s <a>request</a>.
-        <li>Increment <var>inflight keepalive bytes</var> by <var>inflight request</var>'s
-        <a for=request>body</a>'s <a for=body>total bytes</a>.
-      </ul>
+   <li><p>Let <var>group</var> be <var>httpRequest</var>'s <a>client</a>'s <a>fetch group</a>.
 
-    <li>If the sum of <var>contentLengthValue</var> and <var>inflight keepalive bytes</var> is
-    greater than 64 <abbr title="kibibyte">KiB</abbr>, then return a <a>network error</a>.
-  </ul>
+   <li><p>Let <var>inflight records</var> be the set of <a>records</a> in <var>group</var> whose
+   <a for=request>keepalive flag</a> is set, and whose <a>done flag</a> is unset.
 
-  <p class="note no-backref">The above limit ensures that requests that are
-  allowed to outlive the <a>environment settings object</a> and contain
-  a body, have a bounded size and are not allowed to stay alive indefinitely.
+   <li>
+    <p><a for=set>For each</a> <var>rec</var> in <var>inflight records</var>:
+
+    <ol>
+     <li><p>Let <var>inflight request</var> be <var>rec</var>'s <a>request</a>.
+
+     <li><p>Increment <var>inflight keepalive bytes</var> by <var>inflight request</var>'s
+     <a for=request>body</a>'s <a for=body>total bytes</a>.
+    </ol>
+
+   <li><p>If the sum of <var>contentLengthValue</var> and <var>inflight keepalive bytes</var> is
+   greater than 64 kibibytes, then return a <a>network error</a>.
+  </ol>
+
+  <p class="note no-backref">The above limit ensures that requests that are allowed to outlive the
+  <a>environment settings object</a> and contain a body, have a bounded size and are not allowed to
+  stay alive indefinitely.
 
  <li><p>If <var>httpRequest</var>'s <a for=request>referrer</a> is a <a for=/>URL</a>, then
  <a for="header list">append</a> `<code>Referer</code>`/<var>httpRequest</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -3178,16 +3178,26 @@ steps:
  <var>httpRequest</var>'s
  <a for=request>header list</a>.
 
- <li>
-  <p>If <var>contentLengthValue</var> is non-null, <var>httpRequest</var>'s
-  <a>keepalive flag</a> is set:
+<li>
+  <p>If <var>contentLengthValue</var> is non-null and <var>httpRequest</var>'s
+  <a for=request>keepalive flag</a> is set:
 
   <ul>
+    <li>Let <var>inflight keepalive bytes</var> be zero.
     <li>Let <var>group</var> be <var>httpRequest</var>'s <a>client</a>'s <a>fetch group</a>.
-    <li>Let <var>inflight keepalive bytes</var> be the sum of <a>request</a> <a>body</a>'s
-    <a>total bytes</a> for each <a>record</a> in <var>group</var> whose <a>done flag</a> is unset.
+    <li>Let <var>inflight records</var> be the set of <a>records</a> in <var>group</var> whose
+    <a for=request>keepalive flag</a> is set, and whose <a>done flag</a> is unset.
+    <li>
+      <p>For each <var>rec</var> in <var>inflight records</var>:
+
+      <ul class=brief>
+        <li>Let <var>inflight request</var> be <var>rec</var>'s <a>request</a>.
+        <li>Increment <var>inflight keepalive bytes</var> by <var>inflight request</var>'s
+        <a for=request>body</a>'s <a for=body>total bytes</a>.
+      </ul>
+
     <li>If the sum of <var>contentLengthValue</var> and <var>inflight keepalive bytes</var> is
-    greater than 64KB, then return a <a>network error</a>.
+    greater than 64 <abbr title="kibibyte">KiB</abbr>, then return a <a>network error</a>.
   </ul>
 
   <p class="note no-backref">The above limit ensures that requests that are

--- a/fetch.bs
+++ b/fetch.bs
@@ -3183,24 +3183,26 @@ steps:
   <a for=request>keepalive flag</a> is set, then:
 
   <ol>
-   <li><p>Let <var>inflight keepalive bytes</var> be zero.
+   <li><p>Let <var>inflightKeepaliveBytes</var> be zero.
 
    <li><p>Let <var>group</var> be <var>httpRequest</var>'s <a>client</a>'s <a>fetch group</a>.
 
-   <li><p>Let <var>inflight records</var> be the set of <a>records</a> in <var>group</var> whose
-   <a for=request>keepalive flag</a> is set, and whose <a>done flag</a> is unset.
+   <li><p>Let <var>inflightRecords</var> be the set of <a for="fetch group">fetch records</a> in
+   <var>group</var> whose <a for="fetch record">request</a> has its
+   <a for=request>keepalive flag</a> set and <a>done flag</a> unset.
 
    <li>
-    <p><a for=set>For each</a> <var>rec</var> in <var>inflight records</var>:
+    <p><a for=set>For each</a> <var>fetchRecord</var> in <var>inflightRecords</var>:
 
     <ol>
-     <li><p>Let <var>inflight request</var> be <var>rec</var>'s <a>request</a>.
+     <li><p>Let <var>inflightRequest</var> be <var>fetchRecord</var>'s
+     <a for="fetch record">request</a>.
 
-     <li><p>Increment <var>inflight keepalive bytes</var> by <var>inflight request</var>'s
+     <li><p>Increment <var>inflightKeepaliveBytes</var> by <var>inflightRequest</var>'s
      <a for=request>body</a>'s <a for=body>total bytes</a>.
     </ol>
 
-   <li><p>If the sum of <var>contentLengthValue</var> and <var>inflight keepalive bytes</var> is
+   <li><p>If the sum of <var>contentLengthValue</var> and <var>inflightKeepaliveBytes</var> is
    greater than 64 kibibytes, then return a <a>network error</a>.
   </ol>
 
@@ -4179,7 +4181,7 @@ run these steps:
 
 <ol>
  <li>
-  <p>If <var>object</var> is a <a>sequence</a>, then for each <var>header</var> in
+  <p>If <var>object</var> is a <a>sequence</a>, then <a for=list>for each</a> <var>header</var> in
   <var>object</var>, run these substeps:
 
   <ol>
@@ -4191,8 +4193,8 @@ run these steps:
    <var>headers</var>. Rethrow any exception.
   </ol>
 
- <li><p>Otherwise, <var>object</var> is a <a>record</a>, then for each <a for=record>mapping</a>
- (<var>key</var>, <var>value</var>) in <var>object</var>, <a lt=append for=Headers>append</a>
+ <li><p>Otherwise, <var>object</var> is a <a>record</a>, then <a for=map>for each</a> <var>key</var>
+ → <var>value</var> in <var>object</var>, <a lt=append for=Headers>append</a>
  <var>key</var>/<var>value</var> to <var>headers</var>. Rethrow any exception.
 </ol>
 


### PR DESCRIPTION
Requests with keepalive flag set are allowed to outlive the environment
settings object. We want to make sure that such requests do not
negatively impact the user experience when a page is unloaded, etc.

This limits the amount of (body) bytes that can be inflight at any point
when the request has the keepalive flag set; this flag is set by
sendBeacon.

Background: https://github.com/w3c/beacon/pull/39


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/igrigorik/fetch/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/68a9867..igrigorik:master:1bd7e76.html)