### PR TITLE
Meta: Give Travis the full path to the java binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
 script:
   - bash ./deploy.sh
-  - java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/fetch
+  - /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/fetch
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Travis needs Java8 to run the `vnu.jar` HTML checker. This change causes Travis to use the full path to the `java` binary, to ensure it always gets the right (Java8) one.