### PR TITLE
Split up media into video, audio and track

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -772,18 +772,20 @@ the empty string,
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-destination>destination</dfn>, which is
 the empty string,
+"<code>audio</code>",
 "<code>document</code>",
 "<code>embed</code>",
 "<code>font</code>",
 "<code>image</code>",
 "<code>manifest</code>",
-"<code>media</code>",
 "<code>object</code>",
 "<code>report</code>",
 "<code>script</code>",
 "<code>serviceworker</code>",
 "<code>sharedworker</code>",
 "<code>style</code>",
+"<code>track</code>",
+"<code>video</code>",
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
@@ -830,7 +832,7 @@ the empty string,
    <td>HTML's <code>&lt;embed></code>
   <tr>
    <td>"<code>audio</code>"
-   <td>"<code>media</code>"
+   <td>"<code>audio</code>"
    <td><code>media-src</code>
    <td>HTML's <code>&lt;audio></code>
   <tr>
@@ -869,12 +871,12 @@ the empty string,
    <td>HTML's <code>&lt;link rel=stylesheet></code>, CSS' <code>@import</code>
   <tr>
    <td>"<code>track</code>"
-   <td>"<code>media</code>"
+   <td>"<code>track</code>"
    <td><code>media-src</code>
    <td>HTML's <code>&lt;track></code>
   <tr>
    <td>"<code>video</code>"
-   <td>"<code>media</code>"
+   <td>"<code>video</code>"
    <td><code>media-src</code>
    <td>HTML's <code>&lt;video></code> element
   <tr>
@@ -1106,10 +1108,10 @@ Unless stated otherwise, it is "<code>basic</code>".
 <hr>
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
-whose <a for=request>destination</a> is "<code>font</code>",
-"<code>image</code>", "<code>manifest</code>", "<code>media</code>",
-"<code>script</code>", "<code>style</code>", "<code>xslt</code>", or the empty
-string.
+whose <a for=request>destination</a> is "<code>audio</code>", "<code>font</code>",
+"<code>image</code>", "<code>manifest</code>", "<code>script</code>",
+"<code>style</code>", "<code>track</code>", "<code>video</code>",
+"<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>potential-navigation-or-subresource request</dfn> is a
 <a for=/>request</a> whose
@@ -4627,7 +4629,7 @@ dictionary RequestInit {
 };
 
 enum RequestType { "", "audio", "font", "image", "script", "style", "track", "video" };
-enum RequestDestination { "", "document", "embed", "font", "image", "manifest", "media", "object", "report", "script", "serviceworker", "sharedworker", "style",  "worker", "xslt" };
+enum RequestDestination { "", "audio", "document", "embed", "font", "image", "manifest", "object", "report", "script", "serviceworker", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };


### PR DESCRIPTION
As [discussed](http://logs.glob.uno/?c=freenode%23whatwg&s=16+Dec+2016&e=30+Dec+2016#c1014610) on IRC:

* `video`, `audio` and `track` types are currently a single destination: `media`
* This is because we agreed on that as part of https://github.com/whatwg/fetch/pull/211
* I agreed to this change, saying "Merging `track` into `media` is probably also possible."
* It is not. (Not in a clean way, anyway)
* `track` is quite different from `audio`/`video` and is represented internally inside Blink using a different resource type and performs different `type` checks
* @annevk prefers that if we split `track` from `media`, we'd split them all to 3 different destinations, which will enable audio/video specific `Accept` headers.
* destination is also used (and exposed) in SW, but according to @jakearchibald it is not yet shipped, so now is a good time to make this change.

/cc @igrigorik @foolip


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/fetch/split_media_destination.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/3b4cb54...yoavweiss:59d955b.html)