### PR TITLE
Only use nosniff for "script" and "style"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2124,38 +2124,26 @@ X-Content-Type-Options           = "nosniff" ; case-insensitive</pre>
  `<a http-header><code>X-Content-Type-Options</code></a>` in <var>response</var>'s
  <a for=response>header list</a>.
 
- <li><p>If <var>nosniff</var> is failure, return <b>allowed</b>.
+ <li><p>If <var>nosniff</var> is failure, then return <b>allowed</b>.
 
  <li><p>Let <var>MIMEType</var> be the result of
  <a lt="extract a MIME type" for="header list">extracting a MIME type</a> from
  <var>response</var>'s <a for=response>header list</a>.
 
- <li><p>Let <var>type</var> be <var>request</var>'s
- <a for=request>type</a>.
-
- <li><p class=XXX">"<code>audio</code>", "<code>video</code>" ...
-
- <li><p>If <var>type</var> is "<code>image</code>", and <var>MIMEType</var> does <em>not</em>
- start with `<code>image/</code>`, return <b>blocked</b>.
-
- <li><p>If <var>type</var> is "<code>font</code>" and
- <var>MIMEType</var> (ignoring parameters) is <em>not</em> a
- <a class=XXX href=https://lists.w3.org/Archives/Public/www-style/2015Apr/0027.html>font MIME type</a>,
- return <b>blocked</b>.
+ <li><p>Let <var>type</var> be <var>request</var>'s <a for=request>type</a>.
 
  <li><p>If <var>type</var> is "<code>script</code>", and <var>MIMEType</var> (ignoring parameters)
- is <em>not</em> a <a>JavaScript MIME type</a>, return <b>blocked</b>.
+ is not a <a>JavaScript MIME type</a>, then return <b>blocked</b>.
 
- <li><p>If <var>type</var> is "<code>style</code>" and
- <var>MIMEType</var> (ignoring parameters) is <em>not</em>
- `<code>text/css</code>`, return <b>blocked</b>.
-
- <li><p>If <var>type</var> is "<code>track</code>" and
- <var>MIMEType</var> (ignoring parameters) is <em>not</em>
- `<code>text/vtt</code>`, return <b>blocked</b>.
+ <li><p>If <var>type</var> is "<code>style</code>" and <var>MIMEType</var> (ignoring parameters) is
+ not `<code>text/css</code>`, then return <b>blocked</b>.
 
  <li><p>Return <b>allowed</b>.
 </ol>
+
+<p class="note no-backref">Only "<code>script</code>" and "<code>style</code>" are considered as any
+exploits pertain to those <a for=request>types</a>. Also, considering "<code>image</code>" was not
+compatible with deployed content.
 
 
 <h2 id=fetching>Fetching</h2>


### PR DESCRIPTION
For “image” it was not web-compatible and checking the others doesn’t
seem worth it given there are no known issues with sniffing there.

Closes #395.