### PR TITLE
Remove an obsolete note for ReadableStream type

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -577,9 +577,7 @@ user-agent-defined <a for=header>value</a> for the
 <p>A <dfn export id=concept-body>body</dfn> consists of:
 
 <ul>
- <li>
-  <p>A <dfn export for=body id=concept-body-stream>stream</dfn> (a
-  {{ReadableStream}} object).
+ <li><p>A <dfn export for=body id=concept-body-stream>stream</dfn> (a {{ReadableStream}} object).
 
  <li><p>A <dfn export for=body id=concept-body-transmitted>transmitted bytes</dfn>
  (an integer), initially 0.

--- a/fetch.bs
+++ b/fetch.bs
@@ -581,11 +581,6 @@ user-agent-defined <a for=header>value</a> for the
   <p>A <dfn export for=body id=concept-body-stream>stream</dfn> (a
   {{ReadableStream}} object).
 
-  <p class=XXX><a href=https://github.com/whatwg/streams/issues/379>This might become a
-  <code>ReadableByteStream</code> object</a>. While the type might change, the behavior specified
-  will be equivalent since the hypothetical <code>ReadableByteStream</code> object will have
-  the same members as the {{ReadableStream}} object has today.
-
  <li><p>A <dfn export for=body id=concept-body-transmitted>transmitted bytes</dfn>
  (an integer), initially 0.
 


### PR DESCRIPTION
Once we planned to have both ReadableStream and ReadableByteStream and wrote a note in the spec for a possible naming change in the future. But the plan was abandoned and we only have ReadableStream. Let's remove the obsolete note.