### PR TITLE
Add "fetch" as a destination for "connect-src" bound features

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2226,6 +2226,9 @@ the request.
  `<code>Accept-Language</code>`/an appropriate <a for=header>value</a>
  to <var>request</var>'s <a for=request>header list</a>.
 
+ <li><p>If <var>request</var>'s <a for=request>destination</a> is <code>fetch</code>, then set it
+ to the empty string.
+
  <li>
   <p>If <var>request</var>'s <a for=request>priority</a> is
   null, use <var>request</var>'s
@@ -2237,9 +2240,6 @@ the request.
   <p class=note>The user-agent-defined object could encompass stream weight and dependency
   for HTTP/2, and equivalent information used to prioritize dispatch and processing of
   HTTP/1 fetches.
-
- <li><p>If <var>request</var>'s <a for=request>destination</a> is <code>fetch</code>, then set it
- to the empty string.
 
  <li>
   <p>If <var>request</var> is a <a>navigation request</a>, a user agent should, for each

--- a/fetch.bs
+++ b/fetch.bs
@@ -750,6 +750,7 @@ the empty string,
 the empty string,
 "<code>document</code>",
 "<code>embed</code>",
+"<code>fetch</code>",
 "<code>font</code>",
 "<code>image</code>",
 "<code>manifest</code>",
@@ -1084,10 +1085,10 @@ Unless stated otherwise, it is "<code>basic</code>".
 <hr>
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
-whose <a for=request>destination</a> is "<code>font</code>",
-"<code>image</code>", "<code>manifest</code>", "<code>media</code>",
-"<code>script</code>", "<code>style</code>", "<code>xslt</code>", or the empty
-string.
+whose <a for=request>destination</a> is "<code>fetch</code>",
+"<code>font</code>", "<code>image</code>", "<code>manifest</code>",
+"<code>media</code>", "<code>script</code>", "<code>style</code>",
+"<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>potential-navigation-or-subresource request</dfn> is a
 <a for=/>request</a> whose
@@ -4490,7 +4491,7 @@ dictionary RequestInit {
 };
 
 enum RequestType { "", "audio", "font", "image", "script", "style", "track", "video" };
-enum RequestDestination { "", "document", "embed", "font", "image", "manifest", "media", "object", "report", "script", "serviceworker", "sharedworker", "style",  "worker", "xslt" };
+enum RequestDestination { "", "document", "embed", "fetch", "font", "image", "manifest", "media", "object", "report", "script", "serviceworker", "sharedworker", "style",  "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -791,7 +791,7 @@ the empty string,
    <td><code>child-src</code>
    <td>HTML's <code>&lt;iframe></code> and <code>&lt;frame></code>
   <tr>
-   <td>""
+   <td>"" or "<code>fetch</code>"
    <td><code>connect-src</code>
    <td><code>navigator.sendBeacon()</code>, <code>EventSource</code>,
    HTML's <code>ping=""</code>, <a><code>fetch()</code></a>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -792,7 +792,7 @@ the empty string,
    <td><code>child-src</code>
    <td>HTML's <code>&lt;iframe></code> and <code>&lt;frame></code>
   <tr>
-   <td>"" or "<code>fetch</code>"
+   <td>"" ("<code>fetch</code>")
    <td><code>connect-src</code>
    <td><code>navigator.sendBeacon()</code>, <code>EventSource</code>,
    HTML's <code>ping=""</code>, <a><code>fetch()</code></a>,
@@ -2238,6 +2238,9 @@ the request.
   for HTTP/2, and equivalent information used to prioritize dispatch and processing of
   HTTP/1 fetches.
 
+ <li>
+  <p>If <var>request</var>'s <a for=request>destination</a> is
+  <code>fetch</code>, set it to be the empty string.
 
  <li>
   <p>If <var>request</var> is a <a>navigation request</a>, a user agent should, for each

--- a/fetch.bs
+++ b/fetch.bs
@@ -4493,7 +4493,7 @@ dictionary RequestInit {
 };
 
 enum RequestType { "", "audio", "font", "image", "script", "style", "track", "video" };
-enum RequestDestination { "", "document", "embed", "fetch", "font", "image", "manifest", "media", "object", "report", "script", "serviceworker", "sharedworker", "style",  "worker", "xslt" };
+enum RequestDestination { "", "document", "embed", "font", "image", "manifest", "media", "object", "report", "script", "serviceworker", "sharedworker", "style",  "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -2238,9 +2238,8 @@ the request.
   for HTTP/2, and equivalent information used to prioritize dispatch and processing of
   HTTP/1 fetches.
 
- <li>
-  <p>If <var>request</var>'s <a for=request>destination</a> is
-  <code>fetch</code>, set it to be the empty string.
+ <li><p>If <var>request</var>'s <a for=request>destination</a> is <code>fetch</code>, then set it
+ to the empty string.
 
  <li>
   <p>If <var>request</var> is a <a>navigation request</a>, a user agent should, for each


### PR DESCRIPTION
Following the discussion on https://github.com/w3c/preload/issues/80 I believe there's agreement to add an alias to the empty destination in Fetch. 

This is a stab in that direction (I'm not sure that's the right way to do that though, so guidance would be appreciated).

/cc @annevk @igrigorik 