### PR TITLE
Add a missing "is" to 3.1 ("Origin header").

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1732,7 +1732,7 @@ of the `<code>Referer</code>` [sic] header that does not reveal a
 <a for=url>path</a>. It is used for
 all <a lt="HTTP fetch">HTTP fetches</a> whose <i>CORS flag</i> is
 set as well as those where <a for=/>request</a>'s
-<a for=request>method</a> neither `<code>GET</code>` nor `<code>HEAD</code>`. Due to
+<a for=request>method</a> is neither `<code>GET</code>` nor `<code>HEAD</code>`. Due to
 compatibility constraints it is not included in all
 <a lt=fetch for=/>fetches</a>.
 <!-- Ian Hickson told me Adam Barth researched that -->
@@ -5579,6 +5579,7 @@ Odin Hørthe Omdal,
 Ondřej Žára,
 Philip Jägenstedt,
 R. Auburn,
+Raphael Kubo da Costa,
 Ryan Sleevi,
 Rory Hewitt,
 Sébastien Cevey,


### PR DESCRIPTION
Commit eb89fcd5 ("Remove request's omit-Origin-header flag") changed the
phrasing in section 3.1, but is missing a word in the note about the Origin
header.