### PR TITLE
Define header value inline

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -373,21 +373,24 @@ a <a for=/>header list</a> (<var>list</var>), run these steps:
 <p>A <dfn export id=concept-header>header</dfn> consists of a
 <dfn export for=header id=concept-header-name>name</dfn> and
 <dfn export for=header id=concept-header-value>value</dfn>.
-A <a for=header>name</a> is a
-<a>case-insensitive byte sequence</a> that matches the
-<a spec=http>field-name</a> token production. A
-<a for=header>value</a> is a byte sequence that matches the
-<a spec=http>field-content</a> token production.
 
-<p class=XXX>The definition of <a for=header>value</a>
-<a href=https://github.com/whatwg/fetch/issues/332>needs serious work</a>.
+<p>A <a for=header>name</a> is a <a>case-insensitive byte sequence</a> that matches the
+<a spec=http>field-name</a> token production.
 
-<p class="note no-backref"><a spec=http>field-value</a> allows 0x0A and
-0x0D bytes which can lead to reparsing issues.
+<p>A <a for=header>value</a> is a <a>byte sequence</a> that matches the following conditions:
+
+<ul class=brief>
+ <li><p>Has no leading or trailing <a>HTTP whitespace bytes</a>.
+ <li><p>Contains no 0x00, 0x0A or 0x0D bytes.
+</ul>
+
+<p class=note>The definition of <a for=header>value</a> is not defined in terms of an HTTP token
+production as
+<a href=https://github.com/httpwg/http11bis/issues/19 title="fix field-value ABNF">it is broken</a>.
 
 <p>To <dfn export for=header id=concept-header-value-normalize>normalize</dfn> a
-<a for=header>value</a>, remove any leading and trailing
-<a>HTTP whitespace bytes</a> from it.
+<var>potentialValue</var>, remove any leading and trailing <a>HTTP whitespace bytes</a> from
+<var>potentialValue</var>.
 
 <p>A <dfn export for=header id=concept-header-value-combined>combined value</dfn>,
 given a <a for=header>name</a> (<var>name</var>) and


### PR DESCRIPTION
HTTP is taking too long to sort this out.

Tests: https://github.com/w3c/web-platform-tests/pull/4525.

Fixes #332.