### PR TITLE
Block 'ftp:' requests from non-'ftp:' clients.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2408,11 +2408,11 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
 
  <li>
   <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
-  "<code>ftp</code>" and <var>request</var>'s <a for=request>client</a>'s
+  "<code>ftp</code>", <var>request</var>'s <a for=request>client</a>'s
   <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>", and
-  <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code> or an
-  <a>environment</a> whose <a for=environment>target browsing context</a> is a
-  <a>nested browsing context</a>, then set <var>response</var> to a <a>network error</a>.
+  <var>request</var>'s <a for=request>reserved client</a> is either null or an <a>environment</a>
+  whose <a for=environment>target browsing context</a> is a <a>nested browsing context</a>, then set
+  <var>response</var> to a <a>network error</a>.
 
  <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s
@@ -3147,7 +3147,7 @@ steps:
  <!-- https://chromium.googlesource.com/chromium/src/+/master/net/http/http_network_transaction.cc#982 -->
 
  <li><p>If <var>httpRequest</var>'s <a for=request>body</a> is non-null and <var>httpRequest</var>'s
- <a for=request>body</a>'s <a for=request>source</a> is non-null, then set
+ <a for=request>body</a>'s <a for=body>source</a> is non-null, then set
  <var>contentLengthValue</var> to <var>httpRequest</var>'s <a for=request>body</a>'s
  <a for=body>total bytes</a>, <a>UTF-8 encoded</a>.
 
@@ -3502,7 +3502,7 @@ steps:
 
  <li><p>If <var>connection</var> is not an HTTP/2 connection, <var>request</var>'s
  <a for=request>body</a> is non-null, and <var>request</var>'s <a for=request>body</a>'s
- <a for=request>source</a> is null, then <a for="header list">append</a>
+ <a for=body>source</a> is null, then <a for="header list">append</a>
  `<code>Transfer-Encoding</code>`/`<code>chunked</code>` to <var>request</var>'s
  <a for=request>header list</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2407,6 +2407,12 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   have it expose less sensitive information.
 
  <li>
+  <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
+  "<code>ftp</code>" and <var>request</var>'s <a for=request>client</a>'s
+  <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>",
+  set <var>response</var> to a <a>network error</a>.
+
+ <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s
   <a for=url>scheme</a> to "<code>https</code>" if
   all of the following conditions are true:

--- a/fetch.bs
+++ b/fetch.bs
@@ -2411,8 +2411,8 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   "<code>ftp</code>" and <var>request</var>'s <a for=request>client</a>'s
   <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>", and
   <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code> or an
-  <a>environment</a> whose <a for=environment>target browsing context</a> is a <a>nested browsing
-  context</a>, then set <var>response</var> to a <a>network error</a>.
+  <a>environment</a> whose <a for=environment>target browsing context</a> is a
+  <a>nested browsing context</a>, then set <var>response</var> to a <a>network error</a>.
 
  <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -2410,7 +2410,9 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
   "<code>ftp</code>" and <var>request</var>'s <a for=request>client</a>'s
   <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>",
-  set <var>response</var> to a <a>network error</a>.
+  and <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code>
+  or an <a>environment</a> whose <a for=environment>target browsing context</a> is a
+  <a>nested browsing context</a>, set <var>response</var> to a <a>network error</a>.
 
  <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -2409,10 +2409,10 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <li>
   <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
   "<code>ftp</code>" and <var>request</var>'s <a for=request>client</a>'s
-  <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>",
-  and <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code>
-  or an <a>environment</a> whose <a for=environment>target browsing context</a> is a
-  <a>nested browsing context</a>, set <var>response</var> to a <a>network error</a>.
+  <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>", and
+  <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code> or an
+  <a>environment</a> whose <a for=environment>target browsing context</a> is a <a>nested browsing
+  context</a>, then set <var>response</var> to a <a>network error</a>.
 
  <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s


### PR DESCRIPTION
Usage of the 'ftp:' protocol when requesting subresources from non-'ftp:'
clients has slowly declined over the last few years to the point where
it represents a [negligable amount of traffic][1]. The protocol does not
support modern requirements, like encryption, and there's interest from
at least one browser vendor in [removing support for FTP from their
network stack entirely][2].

To that end, this patch alters Fetch to block FTP subresources from
webby clients. That is, a page delivered from `http://example.com/`
will receive a network error response to requests like those generated
from `<img src='ftp://example.com/image.png'>`.

[1]: https://www.chromestatus.com/metrics/feature/timeline/popularity/531
[2]: https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/bIJdwwoQ98U/-F1aL2FgBAAJ