### PR TITLE
Block subresource requests whose URLs include credentials.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2408,8 +2408,9 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
 
  <li>
   <p>If <var>request</var>'s <a for=request>current URL</a> <a for=URL>includes credentials</a>,
-  and <var>request</var> <span class=XXX>is not a <a>navigation request</a> that targets a
-  top-level browsing context</span>, set <var>response</var> to a <a>network error</a>.
+  and <var>request</var>'s <a for=request>reserved client</a> is either <code>null</code>
+  or an <a>environment</a> whose <a for=environment>target browsing context</a> is a
+  <a>nested browsing context</a>, set <var>response</var> to a <a>network error</a>.
 
  <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -2407,6 +2407,11 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   have it expose less sensitive information.
 
  <li>
+  <p>If <var>request</var>'s <a for=request>current URL</a> <a for=URL>includes credentials</a>,
+  and <var>request</var> <span class=XXX>is not a <a>navigation request</a> that targets a
+  top-level browsing context</span>, set <var>response</var> to a <a>network error</a>.
+
+ <li>
   <p>Set <var>request</var>'s <a for=request>current url</a>'s
   <a for=url>scheme</a> to "<code>https</code>" if
   all of the following conditions are true:


### PR DESCRIPTION
Hard-coding credentials into subresource requests (e.g.
`https://user:pass@host/`) is problematic from a security perspective,
as it's allowed folks to brute-force credentials in the past, enables
session fixation attacks for sites using basic auth, and can allow
attackers access to well-known, poorly-coded devices (such as users'
routers). Moreover, the ability to hard-code credentials leads to
inadvertant leakage via XSS on the one hand, and poor development
practice on the other. Sifting through HTTPArchive, for example, yields
a number of credentials for test servers and other internal
architecture.

Usage of the `http://user:pass@host/` pattern has [declined significantly
in the last few years][1]; given that low usage, closing this small
security hole seems quite reasonable.

[1]: https://www.chromestatus.com/metrics/feature/timeline/popularity/532


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/465.html" title="Last updated on Jan 15, 2021, 7:38 AM UTC (e28f797)">Preview</a> | <a href="https://whatpr.org/fetch/465/e4cf6c4...e28f797.html" title="Last updated on Jan 15, 2021, 7:38 AM UTC (e28f797)">Diff</a>