### PR TITLE
Add 'target browsing context' to requests.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -757,6 +757,15 @@ the empty string,
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-target-browsing-context-type>target browsing context
+type</dfn>, which is the empty string, "<code>top-level</code>", or "<code>nested</code>".
+Unless stated otherwise it is the empty string.
+
+<p class="note no-backref">A <a for=/>request</a>'s
+<a for=request>target browsing context type</a> is never the empty string for <a>navigation
+requests</a>, and always the empty string for <a>subresource requests</a>.
+
 <div class=note>
  <p>The following table illustrates the relationship between a
  <a for=/>request</a>'s


### PR DESCRIPTION
Currently, requests have a 'destination' property, which provides some
clarity about the type of request that's being made. For navigation
requests, however, we need a little more granularity in order to support
suggestions like #464 and #465. In particular, we need to distinguish
between navigation requests that target a new top-level browsing
context, and those that target nested browsing contexts (as the latter
are treated as subresource requests in the context of some policy
decisions).

This patch adds a new 'target browsing context' property to requests
which will be populated from HTML's navigation algorithm in order to
support these kinds of policies.