### PR TITLE
Expose Request's body

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4393,6 +4393,7 @@ typedef (Blob or BufferSource or FormData or URLSearchParams or ReadableStream o
 <pre class=idl>[NoInterfaceObject,
  Exposed=(Window,Worker)]
 interface Body {
+  readonly attribute ReadableStream? body;
   readonly attribute boolean bodyUsed;
   [NewObject] Promise&lt;ArrayBuffer> arrayBuffer();
   [NewObject] Promise&lt;Blob> blob();
@@ -4419,6 +4420,9 @@ non-null and its <a for=body>stream</a> is
 <dfn export id=concept-body-locked for=Body>locked</dfn> if <a for=Body>body</a> is
 non-null and its <a for=body>stream</a> is
 <a for=ReadableStream>locked</a>.
+
+<p>The <dfn attribute for=Body><code>body</code></dfn> attribute's getter must return null if
+<a for=Body>body</a> is null and <a for=Body>body</a>'s <a for=body>stream</a> otherwise.
 
 <p>The <dfn attribute for=Body><code>bodyUsed</code></dfn> attribute's getter must
 return true if <a for=Body>disturbed</a>, and false otherwise.
@@ -5051,7 +5055,6 @@ interface Response {
   readonly attribute boolean ok;
   readonly attribute ByteString statusText;
   [SameObject] readonly attribute Headers headers;
-  readonly attribute ReadableStream? body;
   [SameObject] readonly attribute Promise&lt;Headers> trailer;
 
   [NewObject] Response clone();
@@ -5231,10 +5234,6 @@ must return <a for=Response>response</a>'s
 
 <p>The <dfn attribute for=Response><code>headers</code></dfn> attribute's getter must
 return the associated {{Headers}} object.
-
-<p>The <dfn attribute for=Response><code>body</code></dfn> attribute's getter must return null if
-the associated <a for=Body>body</a> is null and the associated
-<a for=Body>body</a>'s <a for=body>stream</a> otherwise.
 
 <p>The <dfn attribute for=Response><code>trailer</code></dfn> attribute's getter must return the
 associated <a for=Response>trailer promise</a>.


### PR DESCRIPTION
In order to expose Request's body property as well as Response's, this change moves the property from Response to Body mixin.

tests: https://github.com/w3c/web-platform-tests/pull/4612