### PR TITLE
Clarified that origins are compared as being same-origin

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2436,7 +2436,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
 
   <dl class=switch>
    <dt><var>request</var>'s <a for=request>current url</a>'s
-   <a for=url>origin</a> is <var>request</var>'s
+   <a for=url>origin</a> is <a>same origin</a> with <var>request</var>'s
    <a for=request>origin</a> and <i>CORS flag</i> is unset
    <dt><var>request</var>'s
    <a for=request>current url</a>'s
@@ -5586,6 +5586,7 @@ however, it is perfectly fine to do so.
 <p>Thanks to
 Adam Barth,
 Adam Lavin,
+Alan Jeffrey,
 Alexey Proskuryakov,
 Andrew Sutherland,
 Ángel González,


### PR DESCRIPTION
Origins should be compared as being same-origin in the main fetch algorithm.

Fixes #468.