### PR TITLE
Regression: make Request constructor account for changes to fill

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4963,8 +4963,13 @@ constructor must run these steps:
    "<code>request-no-cors</code>".
   </ol>
 
- <li><p><a lt=fill for=Headers>Fill</a> <var>r</var>'s <a for=Request>headers</a> with
- <var>headers</var>. Rethrow any exceptions.
+ <li><p>If <var>headers</var> is a <code>Headers</code> object, then for each <var>header</var> in
+ its <a for=Headers>header list</a>, retaining order, <a for=Headers>append</a> <var>header</var>'s
+ <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to <var>r</var>'s {{Headers}}
+ object.
+
+ <li><p>Otherwise, <a for=Headers>fill</a> <var>r</var>'s {{Headers}} object with
+ <var>headers</var>.
 
  <li><p>Let <var>inputBody</var> be <var>input</var>'s
  <a for=Request>request</a>'s <a for=request>body</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4963,10 +4963,10 @@ constructor must run these steps:
    "<code>request-no-cors</code>".
   </ol>
 
- <li><p>If <var>headers</var> is a <code>Headers</code> object, then for each <var>header</var> in
- its <a for=Headers>header list</a>, retaining order, <a for=Headers>append</a> <var>header</var>'s
- <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to <var>r</var>'s {{Headers}}
- object.
+ <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
+ <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>
+ <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to
+ <var>r</var>'s {{Headers}} object.
 
  <li><p>Otherwise, <a for=Headers>fill</a> <var>r</var>'s {{Headers}} object with
  <var>headers</var>.


### PR DESCRIPTION
In particular, now the fill algorithm no longer takes Headers objects,
the Request constructor algorithm will need to deal with that situation
itself.

Regressed in 00fce0d96e799f5bc8bc53b30fcec56c4e0b948c.

(Also fix some minor linking issues Bikeshed found.)

Fixes #483.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/regression-fix/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/686a1ad...d91f5df.html)