### PR TITLE
Response's trailer cannot use [SameObject]

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5044,7 +5044,7 @@ interface Response {
   readonly attribute boolean ok;
   readonly attribute ByteString statusText;
   [SameObject] readonly attribute Headers headers;
-  [SameObject] readonly attribute Promise&lt;Headers> trailer;
+  readonly attribute Promise&lt;Headers> trailer;
 
   [NewObject] Response clone();
 };


### PR DESCRIPTION
Since an attribute that returns a promise can be made to return a
rejecting promise as well. (We really need [Cached] or some such.)

Tests: https://github.com/w3c/web-platform-tests/issues/4811.