### PR TITLE
Http cache

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3119,6 +3119,9 @@ steps:
 <p class=note><i>CORS flag</i> is still a bookkeeping detail. As is
 <i>authentication-fetch flag</i>.
 
+<p class=note>Some implementations might support caching of partial content, as per <cite>HTTP
+Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by browser caches.
+
 <ol>
  <li><p>Let <var>httpRequest</var> be null.
 
@@ -3345,7 +3348,7 @@ steps:
 
  <li><p>Let <var>response</var> and <var>storedResponse</var> be null.
 
- <li><p>Let the <var>revalidatingFlag</var> and <var>partialFlag</var> be unset.
+ <li><p>Let the <var>revalidatingFlag</var> be unset.
 
  <li>
   <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is neither "<code>no-store</code>"
@@ -3369,11 +3372,6 @@ steps:
    <li><p>If <var>storedResponse</var> requires validation (i.e., it is not fresh), then set the
    <var>revalidatingFlag</var>.
 
-   <li><p>If <var>storedResponse</var> is not complete, then set the <var>partialFlag</var>.
-
-   <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>only-if-cached</code>"
-   and the <var>partialFlag</var> is set, then abort these substeps.
-
    <li>
     <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>force-cache</code>" or
     "<code>only-if-cached</code>", then set <var>response</var> to <var>storedResponse</var> and
@@ -3382,14 +3380,8 @@ steps:
     <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>` <a>header</a>
     into account.
 
-   <li><p>If both the <var>revalidatingFlag</var> and <var>partialFlag</var> are set,
-   <a for="header list">append</a> `<code>If-Range</code>` with an appropriate value to
-   <var>httpRequest</var>'s <a for=request>header list</a>, as per the
-   "<a href=https://tools.ietf.org/html/rfc7233#section-3.2>If-Range</a>" chapter of
-   <cite>HTTP Range Requests</cite>. [[!HTTP-RANGE]]
-
    <li>
-    <p>If the <var>revalidatingFlag</var> is set and the <var>partialFlag</var> is unset, then:
+    <p>If the <var>revalidatingFlag</var> is set, then:
 
     <ol>
      <li><p>If <var>storedResponse</var>'s <a for=response>header list</a>
@@ -3406,15 +3398,6 @@ steps:
     <p class=note>See also the
     "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
-
-   <li><p>If the <var>revalidatingFlag</var> is unset and the <var>partialFlag</var> is set, then
-   <a for="header list">append</a> `<code>Range</code>` with an appropriate value to
-   <var>httpRequest</var>'s <a for=request>header list</a>, as per the
-   "<a href=https://tools.ietf.org/html/rfc7233#section-3.1>Range</a>" chapter of
-   <cite>HTTP Range Requests</cite>. [[!HTTP-RANGE]]
-
-   <li><p>If both the <var>revalidatingFlag</var> and <var>partialFlag</var> are unset, then set
-   <var>response</var> to <var>storedResponse</var>.
   </ol>
 
  <li>
@@ -3451,24 +3434,6 @@ steps:
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
     </ol>
-
-   <li>
-    <p>If the <var>partialFlag</var> is set and <var>forwardResponse</var>'s
-    <a for=response>status</a> is <code>206</code>, run these substeps:
-
-    <ol>
-     <li>
-      <p>Update <var>storedResponse</var>'s <a for=response>header list</a> using
-      <var>forwardResponse</var>'s <a for=response>header list</a>, as per the
-      "<a href=https://tools.ietf.org/html/rfc7234#section-3.3>Combining Partial Content</a>" chapter
-      of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
-
-      <p class="note">This updates the stored response in cache as well.
-
-     <li><p>Set <var>response</var> to <var>storedResponse</var>.
-
-    </ol>
-    <!-- TODO: account for partial request failure -->
 
    <li>
     <p>If <var>response</var> is null, then run these substeps:

--- a/fetch.bs
+++ b/fetch.bs
@@ -3345,7 +3345,7 @@ steps:
 
  <li><p>Let <var>response</var> and <var>storedResponse</var> be null.
 
- <li><p>Let the <var>revalidating flag</var> and <var>partial flag</var> be unset.
+ <li><p>Let the <var>revalidatingFlag</var> and <var>partialFlag</var> be unset.
 
  <li>
   <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is neither "<code>no-store</code>"
@@ -3358,22 +3358,21 @@ steps:
     "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]], if any.
 
-    <p>The cache key used to locate a stored response must include the value of the
-    <var>credentials flag</var>.
+    <p>The cache key used to locate a stored response must include the <var>credentials flag</var>.
 
-    <p class=note>This ensures that a stored response to a request with credentials is
-    not used to satisfy a request without credentials.
+    <p class=note>This ensures that a stored response to a request with credentials is not used to
+    satisfy a request without credentials.
 
-   <li><p>If <var>storedResponse</var> is null, abort these substeps.
+   <li><p>If <var>storedResponse</var> is null, then abort these substeps.
 
    <!-- cache hit -->
-   <li><p>If <var>storedResponse</var> requires validation (i.e., it is not fresh), set the
-   <var>revalidating flag</var>.
+   <li><p>If <var>storedResponse</var> requires validation (i.e., it is not fresh), then set the
+   <var>revalidatingFlag</var>.
 
-   <li><p>If <var>storedResponse</var> is not complete, set the <var>partial flag</var>.
+   <li><p>If <var>storedResponse</var> is not complete, then set the <var>partialFlag</var>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>only-if-cached</code>"
-   and <var>partial flag</var> is set, then abort these substeps.
+   and the <var>partialFlag</var> is set, then abort these substeps.
 
    <li>
     <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>force-cache</code>" or
@@ -3383,44 +3382,44 @@ steps:
     <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>` <a>header</a>
     into account.
 
-   <li><p>If both the <var>revalidating flag</var> and <var>partial flag</var> are set,
+   <li><p>If both the <var>revalidatingFlag</var> and <var>partialFlag</var> are set,
    <a for="header list">append</a> `<code>If-Range</code>` with an appropriate value to
    <var>httpRequest</var>'s <a for=request>header list</a>, as per the
    "<a href=https://tools.ietf.org/html/rfc7233#section-3.2>If-Range</a>" chapter of
-   <cite>HTTP Range Requests</cite> [[!HTTP-RANGE]].
+   <cite>HTTP Range Requests</cite>. [[!HTTP-RANGE]]
 
    <li>
-    <p>If the <var>revalidating flag</var> is set and the <var>partial flag</var> is unset,
-     run these substeps:
+    <p>If the <var>revalidatingFlag</var> is set and the <var>partialFlag</var> is unset, then:
 
     <ol>
-     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a> contains
-     `<code>ETag</code>`, <a for="header list">append</a> `<code>If-None-Match</code>` with its
-     value to <var>httpRequest</var>'s <a for=request>header list</a>.
-
-     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a> contains
-     `<code>Last-Modified</code>`, <a for="header list">append</a>
-     `<code>If-Modified-Since</code>` with its value to <var>httpRequest</var>'s
+     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a>
+     <a for="header list">contains</a> `<code>ETag</code>`, then <a for="header list">append</a>
+     `<code>If-None-Match</code>` with its value to <var>httpRequest</var>'s
      <a for=request>header list</a>.
+
+     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a>
+     <a for="header list">contains</a> `<code>Last-Modified</code>`, then
+     <a for="header list">append</a> `<code>If-Modified-Since</code>` with its value to
+     <var>httpRequest</var>'s <a for=request>header list</a>.
     </ol>
 
     <p class=note>See also the
     "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
 
-    <li><p>If the <var>revalidating flag</var> is unset and the <var>partial flag</var> is set,
-    <a for="header list">append</a> `<code>Range</code>` with an appropriate value to
-    <var>httpRequest</var>'s <a for=request>header list</a>, as per the
-    "<a href=https://tools.ietf.org/html/rfc7233#section-3.1>Range</a>" chapter of
-    <cite>HTTP Range Requests</cite> [[!HTTP-RANGE]].
+   <li><p>If the <var>revalidatingFlag</var> is unset and the <var>partialFlag</var> is set, then
+   <a for="header list">append</a> `<code>Range</code>` with an appropriate value to
+   <var>httpRequest</var>'s <a for=request>header list</a>, as per the
+   "<a href=https://tools.ietf.org/html/rfc7233#section-3.1>Range</a>" chapter of
+   <cite>HTTP Range Requests</cite>. [[!HTTP-RANGE]]
 
-    <li><p>If both the <var>revalidating flag</var> and <var>partial flag</var> are unset, set
-    <var>response</var> to <var>storedResponse</var>.
+   <li><p>If both the <var>revalidatingFlag</var> and <var>partialFlag</var> are unset, then set
+   <var>response</var> to <var>storedResponse</var>.
   </ol>
 
  <li>
   <!-- If response is still null, we require a forwarded request. -->
-  <p>If <var>response</var> is null, run these substeps:
+  <p>If <var>response</var> is null, then run these substeps:
 
   <ol>
    <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is
@@ -3430,15 +3429,14 @@ steps:
    <var>httpRequest</var> with <i>credentials flag</i> if set.
 
    <li><p>If <var>httpRequest</var>'s <var>method</var> is
-   <a href=https://tools.ietf.org/html/rfc7231#safe.methods>unsafe</a>
-   and <var>forwardResponse</var>'s
-   <a for=response>status</a> is in the range <code>200</code> to <code>399</code> inclusive,
-   invalidate appropriate stored responses in the HTTP cache, as per the
-   "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
-   <cite>HTTP Caching</cite> [[!HTTP-CACHING]], and set <var>storedResponse</var> to null.
+   <a href=https://tools.ietf.org/html/rfc7231#safe.methods>unsafe</a> and
+   <var>forwardResponse</var>'s <a for=response>status</a> is in the range <code>200</code> to
+   <code>399</code>, inclusive, invalidate appropriate stored responses in the HTTP cache, as per
+   the "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
+   <cite>HTTP Caching</cite>, and set <var>storedResponse</var> to null. [[!HTTP-CACHING]]
 
    <li>
-    <p>If the <var>revalidating flag</var> is set and <var>forwardResponse</var>'s
+    <p>If the <var>revalidatingFlag</var> is set and <var>forwardResponse</var>'s
     <a for=response>status</a> is <code>304</code>, run these substeps:
 
     <ol>
@@ -3446,7 +3444,7 @@ steps:
       <p>Update <var>storedResponse</var>'s <a for=response>header list</a> using
       <var>forwardResponse</var>'s <a for=response>header list</a>, as per the
       "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
-      chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+      chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
 
       <p class="note">This updates the stored response in cache as well.
 
@@ -3455,7 +3453,7 @@ steps:
     </ol>
 
    <li>
-    <p>If the <var>partial flag</var> is set and <var>forwardResponse</var>'s
+    <p>If the <var>partialFlag</var> is set and <var>forwardResponse</var>'s
     <a for=response>status</a> is <code>206</code>, run these substeps:
 
     <ol>
@@ -3472,33 +3470,32 @@ steps:
     </ol>
     <!-- TODO: account for partial request failure -->
 
-    <li>
-     <p>If <var>response</var> is null, run these substeps:
+   <li>
+    <p>If <var>response</var> is null, then run these substeps:
 
-     <ol>
-      <li><p>If <var>forwardResponse</var> is a <a>network error</a>, <var>storedResponse</var> is
-      not null, <var>storedResponse</var> is complete, and <var>storedResponse</var> is allowed to
-      be served stale, as per the
-      "<a href=https://tools.ietf.org/html/rfc7234#section-4.2.4>Serving Stale Responses</a>"
-      chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]]>", set <var>response</var> to
-      <var>storedResponse</var> and abort these substeps.
+    <ol>
+     <li><p>If <var>forwardResponse</var> is a <a>network error</a>, <var>storedResponse</var> is
+     not null, <var>storedResponse</var> is complete, and <var>storedResponse</var> is allowed to be
+     served stale, as per the
+     "<a href=https://tools.ietf.org/html/rfc7234#section-4.2.4>Serving Stale Responses</a>" chapter
+     of <cite>HTTP Caching</cite>, then set <var>response</var> to <var>storedResponse</var> and
+     abort these substeps. [[!HTTP-CACHING]]
 
-      <li><p>Set <var>response</var> to <var>forwardResponse</var>.
+     <li><p>Set <var>response</var> to <var>forwardResponse</var>.
 
-      <li>
-       <p>Store <var>httpRequest</var> and <var>forwardResponse</var> in the HTTP cache, as per
-       the "<a href=https://tools.ietf.org/html/rfc7234#section-3>Storing Responses in Caches</a>"
-       chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+     <li>
+      <p>Store <var>httpRequest</var> and <var>forwardResponse</var> in the HTTP cache, as per the
+      "<a href=https://tools.ietf.org/html/rfc7234#section-3>Storing Responses in Caches</a>"
+      chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
 
-       <p>The cache key used to store the response must include the value of the
-       <var>credentials flag</var>.
+      <p>The cache key used to store the response must include the <var>credentials flag</var>.
 
-       <p class=note>This ensures that a stored response to a request with credentials
-       is not used to satisfy a request without credentials.
+      <p class=note>This ensures that a stored response to a request with credentials is not used to
+      satisfy a request without credentials.
 
-       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively
-       caches the network error, which is sometimes known as "negative caching".
-     </ol>
+      <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
+      the network error, which is sometimes known as "negative caching".
+    </ol>
   </ol>
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -98,7 +98,6 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
         "href": "https://www.kb.cert.org/vuls/id/150227",
         "title": "HTTP proxy default configurations allow arbitrary TCP connections."
     }
-
 }
 </pre>
 
@@ -3356,7 +3355,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
   <ol>
    <li>
-    <p>Let <var>storedResponse</var> be the result of selecting a response from the HTTP cache,
+    <p>Set <var>storedResponse</var> to the result of selecting a response from the HTTP cache,
     possibly needing validation, as per the
     "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]], if any.
@@ -3394,8 +3393,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
 
-    <li><p>Otherwise, if the <var>revalidatingFlag</var> is unset, then set <var>response</var>
-     to <var>storedResponse</var>.
+    <li><p>Otherwise, if the <var>revalidatingFlag</var> is unset, then set <var>response</var> to
+    <var>storedResponse</var>.
   </ol>
 
  <li>
@@ -3418,7 +3417,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <li>
     <p>If the <var>revalidatingFlag</var> is set and <var>forwardResponse</var>'s
-    <a for=response>status</a> is <code>304</code>, run these substeps:
+    <a for=response>status</a> is <code>304</code>, then:
 
     <ol>
      <li>
@@ -3434,7 +3433,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     </ol>
 
    <li>
-    <p>If <var>response</var> is null, then run these substeps:
+    <p>If <var>response</var> is null, then:
 
     <ol>
      <li><p>Set <var>response</var> to <var>forwardResponse</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3361,11 +3361,6 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]], if any.
 
-    <p>The cache key used to locate a stored response must include the <var>credentials flag</var>.
-
-    <p class=note>This ensures that a stored response to a request with credentials is not used to
-    satisfy a request without credentials.
-
    <li><p>If <var>storedResponse</var> is null, then abort these substeps.
 
    <!-- cache hit -->
@@ -3445,11 +3440,6 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
       <p>Store <var>httpRequest</var> and <var>forwardResponse</var> in the HTTP cache, as per the
       "<a href=https://tools.ietf.org/html/rfc7234#section-3>Storing Responses in Caches</a>"
       chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
-
-      <p>The cache key used to store the response must include the <var>credentials flag</var>.
-
-      <p class=note>This ensures that a stored response to a request with credentials is not used to
-      satisfy a request without credentials.
 
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".

--- a/fetch.bs
+++ b/fetch.bs
@@ -3474,13 +3474,6 @@ steps:
     <p>If <var>response</var> is null, then run these substeps:
 
     <ol>
-     <li><p>If <var>forwardResponse</var> is a <a>network error</a>, <var>storedResponse</var> is
-     not null, <var>storedResponse</var> is complete, and <var>storedResponse</var> is allowed to be
-     served stale, as per the
-     "<a href=https://tools.ietf.org/html/rfc7234#section-4.2.4>Serving Stale Responses</a>" chapter
-     of <cite>HTTP Caching</cite>, then set <var>response</var> to <var>storedResponse</var> and
-     abort these substeps. [[!HTTP-CACHING]]
-
      <li><p>Set <var>response</var> to <var>forwardResponse</var>.
 
      <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3393,6 +3393,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <p class=note>See also the
     "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
     chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+
+    <li><p>Otherwise, if the <var>revalidatingFlag</var> is unset, then set <var>response</var>
+     to <var>storedResponse</var>.
   </ol>
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -49,6 +49,9 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
     "HTTP-CACHING": {
         "aliasOf": "RFC7234"
     },
+    "HTTP-RANGE": {
+        "aliasOf": "RFC7233"
+    },
     "HTTP-AUTH": {
         "aliasOf": "RFC7235"
     },
@@ -3340,88 +3343,162 @@ steps:
   <var>httpRequest</var>'s
   <a for=request>credentials mode</a>.
 
- <li><p>Let <var>response</var> be null.
+ <li><p>Let <var>response</var> and <var>storedResponse</var> be null.
+
+ <li><p>Let the <var>revalidating flag</var> and <var>partial flag</var> be unset.
 
  <li>
-  <p>If <var>httpRequest</var>'s
-  <a for=request>cache mode</a> is neither
-  "<code>no-store</code>" nor "<code>reload</code>", and there is a <em>complete</em>
-  <a for=/>response</a> in the HTTP cache for
-  <var>httpRequest</var> run these substeps:
-  <!-- XXX xref "HTTP cache" -->
+  <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is neither "<code>no-store</code>"
+  nor "<code>reload</code>", run these substeps:
 
   <ol>
    <li>
-    <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is
-    "<code>force-cache</code>" or "<code>only-if-cached</code>", then set
-    <var>response</var> to the <a for=/>response</a> in the HTTP cache for
-    <var>httpRequest</var>.
+    <p>Let <var>storedResponse</var> be the result of selecting a response from the HTTP cache,
+    possibly needing validation, as per the
+    "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
+    chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]], if any.
 
-    <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>`
-    <a>header</a> into account.
+    <p>The cache key used to locate a stored response must include the value of the
+    <var>credentials flag</var>.
 
-   <li><p>Otherwise, if <var>httpRequest</var>'s
-   <a for=request>cache mode</a> is "<code>default</code>" and the
-   <a for=/>response</a> in the HTTP cache for <var>httpRequest</var> does
-   not require revalidation, then set <var>response</var> to that
-   <a for=/>response</a>.
-   <!-- XXX xref "revalidation" -->
+    <p class=note>This ensures that a stored response to a request with credentials is
+    not used to satisfy a request without credentials.
 
-   <li><p>Otherwise, if <var>httpRequest</var>'s
-   <a for=request>cache mode</a> is either "<code>default</code>"
-   or "<code>no-cache</code>", modify <var>httpRequest</var>'s
-   <a for=request>header list</a> with revalidation
-   <a>headers</a>.
-   <!-- XXX modify, revalidation headers -->
+   <li><p>If <var>storedResponse</var> is null, abort these substeps.
+
+   <!-- cache hit -->
+   <li><p>If <var>storedResponse</var> requires validation (i.e., it is not fresh), set the
+   <var>revalidating flag</var>.
+
+   <li><p>If <var>storedResponse</var> is not complete, set the <var>partial flag</var>.
+
+   <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>only-if-cached</code>"
+   and <var>partial flag</var> is set, then abort these substeps.
+
+   <li>
+    <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>force-cache</code>" or
+    "<code>only-if-cached</code>", then set <var>response</var> to <var>storedResponse</var> and
+    abort these substeps.
+
+    <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>` <a>header</a>
+    into account.
+
+   <li><p>If both the <var>revalidating flag</var> and <var>partial flag</var> are set,
+   <a for="header list">append</a> `<code>If-Range</code>` with an appropriate value to
+   <var>httpRequest</var>'s <a for=request>header list</a>, as per the
+   "<a href=https://tools.ietf.org/html/rfc7233#section-3.2>If-Range</a>" chapter of
+   <cite>HTTP Range Requests</cite> [[!HTTP-RANGE]].
+
+   <li>
+    <p>If the <var>revalidating flag</var> is set and the <var>partial flag</var> is unset,
+     run these substeps:
+
+    <ol>
+     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a> contains
+     `<code>ETag</code>`, <a for="header list">append</a> `<code>If-None-Match</code>` with its
+     value to <var>httpRequest</var>'s <a for=request>header list</a>.
+
+     <li><p>If <var>storedResponse</var>'s <a for=response>header list</a> contains
+     `<code>Last-Modified</code>`, <a for="header list">append</a>
+     `<code>If-Modified-Since</code>` with its value to <var>httpRequest</var>'s
+     <a for=request>header list</a>.
+    </ol>
+
+    <p class=note>See also the
+    "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
+    chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+
+    <li><p>If the <var>revalidating flag</var> is unset and the <var>partial flag</var> is set,
+    <a for="header list">append</a> `<code>Range</code>` with an appropriate value to
+    <var>httpRequest</var>'s <a for=request>header list</a>, as per the
+    "<a href=https://tools.ietf.org/html/rfc7233#section-3.1>Range</a>" chapter of
+    <cite>HTTP Range Requests</cite> [[!HTTP-RANGE]].
+
+    <li><p>If both the <var>revalidating flag</var> and <var>partial flag</var> are unset, set
+    <var>response</var> to <var>storedResponse</var>.
   </ol>
 
- <li><p>Otherwise, if <var>httpRequest</var>'s
- <a for=request>cache mode</a> is either
- "<code>default</code>" or "<code>force-cache</code>", and there is a
- <em>partial</em> <a for=/>response</a> in the HTTP cache for
- <var>httpRequest</var>, modify <var>httpRequest</var>'s
- <a for=request>header list</a> with resume
- <a>headers</a>.
- <!-- XXX xref partial, modify, resume headers -->
-
  <li>
+  <!-- If response is still null, we require a forwarded request. -->
   <p>If <var>response</var> is null, run these substeps:
 
   <ol>
    <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is
-   "<code>only-if-cached</code>", then return a
-   <a>network error</a>.
+   "<code>only-if-cached</code>", then return a <a>network error</a>.
 
-   <li><p>Set <var>response</var> to the result of making an
-   <a>HTTP-network fetch</a> using <var>httpRequest</var>
-   with <i>credentials flag</i> if set.
-  </ol>
+   <li><p>Set <var>forwardResponse</var> to the result of making an <a>HTTP-network fetch</a> using
+   <var>httpRequest</var> with <i>credentials flag</i> if set.
 
- <li>
-  <p>If <var>response</var>'s <a for=response>status</a> is <code>304</code> and
-  <var>httpRequest</var>'s <a for=request>cache mode</a> is either
-  "<code>default</code>" or "<code>no-cache</code>", run these substeps:
-
-  <ol>
-   <li><p>Set <var>cachedResponse</var> to the result of selecting a stored
-   <a for=/>response</a> from the HTTP cache using <var>httpRequest</var>, as
-   per the
-   "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
-   chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
-
-   <li><p>If <var>cachedResponse</var> is null (i.e., one cannot be selected), return a
-   <a>network error</a>.
-
-   <li><p>Update <var>cachedResponse</var>'s <a for=response>header list</a>
-   using <var>response</var>'s <a for=response>header list</a>, as per the
-   "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
-   chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
+   <li><p>If <var>httpRequest</var>'s <var>method</var> is
+   <a href=https://tools.ietf.org/html/rfc7231#safe.methods>unsafe</a>
+   and <var>forwardResponse</var>'s
+   <a for=response>status</a> is in the range <code>200</code> to <code>399</code> inclusive,
+   invalidate appropriate stored responses in the HTTP cache, as per the
+   "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
+   <cite>HTTP Caching</cite> [[!HTTP-CACHING]], and set <var>storedResponse</var> to null.
 
    <li>
-    <p>Set <var>response</var> to the <var>cachedResponse</var>.
+    <p>If the <var>revalidating flag</var> is set and <var>forwardResponse</var>'s
+    <a for=response>status</a> is <code>304</code>, run these substeps:
 
-    <p class="note no-backref">This changes <var>response</var> entirely, including its
-    <a for=response>status</a> which is most likely <code>200</code> now.
+    <ol>
+     <li>
+      <p>Update <var>storedResponse</var>'s <a for=response>header list</a> using
+      <var>forwardResponse</var>'s <a for=response>header list</a>, as per the
+      "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
+      chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+
+      <p class="note">This updates the stored response in cache as well.
+
+     <li><p>Set <var>response</var> to <var>storedResponse</var>.
+
+    </ol>
+
+   <li>
+    <p>If the <var>partial flag</var> is set and <var>forwardResponse</var>'s
+    <a for=response>status</a> is <code>206</code>, run these substeps:
+
+    <ol>
+     <li>
+      <p>Update <var>storedResponse</var>'s <a for=response>header list</a> using
+      <var>forwardResponse</var>'s <a for=response>header list</a>, as per the
+      "<a href=https://tools.ietf.org/html/rfc7234#section-3.3>Combining Partial Content</a>" chapter
+      of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+
+      <p class="note">This updates the stored response in cache as well.
+
+     <li><p>Set <var>response</var> to <var>storedResponse</var>.
+
+    </ol>
+    <!-- TODO: account for partial request failure -->
+
+    <li>
+     <p>If <var>response</var> is null, run these substeps:
+
+     <ol>
+      <li><p>If <var>forwardResponse</var> is a <a>network error</a>, <var>storedResponse</var> is
+      not null, <var>storedResponse</var> is complete, and <var>storedResponse</var> is allowed to
+      be served stale, as per the
+      "<a href=https://tools.ietf.org/html/rfc7234#section-4.2.4>Serving Stale Responses</a>"
+      chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]]>", set <var>response</var> to
+      <var>storedResponse</var> and abort these substeps.
+
+      <li><p>Set <var>response</var> to <var>forwardResponse</var>.
+
+      <li>
+       <p>Store <var>httpRequest</var> and <var>forwardResponse</var> in the HTTP cache, as per
+       the "<a href=https://tools.ietf.org/html/rfc7234#section-3>Storing Responses in Caches</a>"
+       chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
+
+       <p>The cache key used to store the response must include the value of the
+       <var>credentials flag</var>.
+
+       <p class=note>This ensures that a stored response to a request with credentials
+       is not used to satisfy a request without credentials.
+
+       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively
+       caches the network error, which is sometimes known as "negative caching".
+     </ol>
   </ol>
 
  <li>


### PR DESCRIPTION
For #373.

Also should help #336 (since HTTP clearly says this, and there's a direct reference now).

I think it addresses #307 (although Anne may want a different approach).

Touches #144.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mnot/fetch/http-cache.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/3b4cb54...mnot:edef79f.html)