### PR TITLE
Do not always set the recursive flag in HTTP-redirect fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3053,10 +3053,6 @@ in addition to <a>HTTP fetch</a> above.
  <a lt="include credential">includes credentials</a>, then return a
  <a>network error</a>.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>status</a> is not <code>303</code>,
- <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
- <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
-
  <li>
   <p>If <i>CORS flag</i> is set and <var>actualResponse</var>'s
   <a for=response>location URL</a>
@@ -3065,13 +3061,14 @@ in addition to <a>HTTP fetch</a> above.
 
   <p class=note>This catches a cross-origin resource redirecting to a same-origin URL.
 
+ <li><p>If <var>actualResponse</var>'s <a for=response>status</a> is not <code>303</code>,
+ <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
+ <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
+
  <li><p>If <i>CORS flag</i> is set and <var>actualResponse</var>'s
- <a for=response>location URL</a>'s
- <a for=url>origin</a> is <em>not</em>
- <a>same origin</a> with <var>request</var>'s
- <a for=request>current url</a>'s
- <a for=url>origin</a>, set <var>request</var>'s
- <a for=request>origin</a> to a globally unique identifier.
+ <a for=response>location URL</a>'s <a for=url>origin</a> is not <a>same origin</a> with
+ <var>request</var>'s <a for=request>current url</a>'s <a for=url>origin</a>, then set
+ <var>request</var>'s <a for=request>origin</a> to a unique <a>opaque origin</a>.
 
  <li><p>If either <var>actualResponse</var>'s <a for=response>status</a> is
  <code>301</code> or <code>302</code> and <var>request</var>'s
@@ -3098,8 +3095,17 @@ in addition to <a>HTTP fetch</a> above.
  <var>actualResponse</var>. [[!REFERRER]]
 
  <li>
-  <p>Return the result of performing a <a for=main>main fetch</a> using
-  <var>request</var> with <i>CORS flag</i> if set and <i>recursive flag</i> set.
+  <p>Return the result of performing a <a for=main>main fetch</a> using <var>request</var> with
+
+  <ul class=brief>
+   <li><p><i>CORS flag</i> if set and
+   <li>
+    <p><i>recursive flag</i> set if <var>request</var>'s <a for=request>redirect mode</a> is not
+    "<code>manual</code>".
+
+    <p class=note>It can only be "<code>manual</code>" when invoked directly from
+    <cite>HTML</cite>'s "navigate" algorithm.
+  </ul>
 
   <p class="note no-backref">This has to invoke <a for=main>main fetch</a> to
   get <a for=request>response tainting</a> correct.


### PR DESCRIPTION
Also keep “includes credentials” steps next to each other by moving
another step and update origin terminology.

Fixes https://github.com/whatwg/html/issues/2396.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/http-redirect-fetch/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/3b4cb54...c958914.html)