### PR TITLE
Make combine work for XMLHttpRequest and WebSocket

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -315,20 +315,24 @@ all <a>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
-<p>To <dfn export id=concept-header-list-combine>combine</dfn> a
+<p>To <dfn export id=concept-header-list-combine for="header list">combine</dfn> a
 <a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair in a
-<a for=/>header list</a> (<var>list</var>), run these steps:
+<a for=/>header list</a> (<var>list</var>), optionally with a <var>legacySpaceFlag</var>, run these
+steps:
 
 <ol>
+ <li><p>Let <var>separator</var> be `<code>, </code>` if <var>legacySpaceFlag</var> is set, and
+ `<code>,</code>` otherwise.
+
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
  <a for=header>value</a> of the first such <a>header</a> to its <a for=header>value</a>, followed
- by `<code>,</code>`, followed by <var>value</var>.
+ by <var>separator</var>, followed by <var>value</var>.
 
  <li><p>Otherwise, append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
-<p class="note no-backref"><a>Combine</a> is used by {{XMLHttpRequest}} and the
+<p class="note no-backref">The <var>legacySpaceFlag</var> is used by {{XMLHttpRequest}} and the
 <a lt="establish a WebSocket connection" for=websocket>WebSocket protocol handshake</a>.
 
 <p>To
@@ -3783,17 +3787,10 @@ steps:
  <a>CORS-safelisted request-headers</a> and duplicates,
  sorted lexicographically, and <a lt="byte-lowercase">byte-lowercased</a>.
 
- <li>
-  <p>If <var>headers</var> <a for=list lt="is empty">is not empty</a>, then:
-
-  <ol>
-   <li><p>Let <var>value</var> be the items in <var>headers</var> separated from each other by
-   `<code>,</code>`.
-
-   <li><p><a for="header list">Set</a>
-   `<a http-header><code>Access-Control-Request-Headers</code></a>` to <var>value</var> in
-   <var>preflight</var>'s <a for=request>header list</a>.
-  </ol>
+ <li><p>If <var>headers</var> <a for=list lt="is empty">is not empty</a>, then
+ <a for=list>for each</a> <var>value</var> in <var>headers</var>, <a for="header list">combine</a>
+ `<a http-header><code>Access-Control-Request-Headers</code></a>`/<var>value</var> in
+ <var>preflight</var>'s <a for=request>header list</a>.
 
  <li><p>Let <var>response</var> be the result of performing an
  <a>HTTP-network-or-cache fetch</a> using
@@ -5468,10 +5465,9 @@ therefore not shareable, a WebSocket connection is very close to identical to an
  `<code>Sec-WebSocket-Version</code>`/`<code>13</code>` to
  <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>For each <var>protocol</var> in <var>protocols</var>,
- <a>combine</a>
- `<code>Sec-WebSocket-Protocol</code>`/<var>protocol</var> in
- <var>request</var>'s <a for=request>header list</a>.
+ <li><p>For each <var>protocol</var> in <var>protocols</var>, <a for="header list">combine</a>
+ `<code>Sec-WebSocket-Protocol</code>`/<var>protocol</var> in <var>request</var>'s
+ <a for=request>header list</a> with <var>legacySpaceFlag</var> set.
 
  <li>
   <p>Let <var>permessageDeflate</var> be a user-agent defined


### PR DESCRIPTION
Unfortunately as established in https://github.com/whatwg/xhr/issues/108 setRequestHeader() uses `, ` whereas fetch() uses `,` as value separator. This introduces a legacySpaceFlag for combine that XMLHttpRequest and WebSocket can use. New code and CORS (in Access-Control-Request-Headers) can continue not passing this flag.

Tests were fixed in https://github.com/w3c/web-platform-tests/pull/5008.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/legacy-space/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/ba175cf...4dc529a.html)