### PR TITLE
Change combine and combined value to use 0x2C 0x20 

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -315,20 +315,20 @@ all <a>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
-<p>To <dfn export id=concept-header-list-combine>combine</dfn> a
+<p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
 <a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair in a
 <a for=/>header list</a> (<var>list</var>), run these steps:
 
 <ol>
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
  <a for=header>value</a> of the first such <a>header</a> to its <a for=header>value</a>, followed
- by `<code>,</code>`, followed by <var>value</var>.
+ by 0x2C 0x20, followed by <var>value</var>.
 
  <li><p>Otherwise, append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
-<p class="note no-backref"><a>Combine</a> is used by {{XMLHttpRequest}} and the
+<p class="note no-backref"><a for="header list">Combine</a> is used by {{XMLHttpRequest}} and the
 <a lt="establish a WebSocket connection" for=websocket>WebSocket protocol handshake</a>.
 
 <p>To
@@ -387,7 +387,7 @@ production as
 <a for=header>name</a> (<var>name</var>) and <a for=/>header list</a> (<var>list</var>), is the
 <a lt=value for=header>values</a> of all <a>headers</a> in <var>list</var> whose
 <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated from
-each other by `<code>,</code>`, in order.
+each other by 0x2C 0x20, in order.
 
 <hr>
 
@@ -3792,6 +3792,9 @@ steps:
    <var>preflight</var>'s <a for=request>header list</a>.
   </ol>
 
+  <p class=note>This intentionally does not use <a for="header list">combine</a>, as 0x20 following
+  0x2C is not the way this was implemented, for better or worse.
+
  <li><p>Let <var>response</var> be the result of performing an
  <a>HTTP-network-or-cache fetch</a> using
  <var>preflight</var>.
@@ -5462,10 +5465,9 @@ therefore not shareable, a WebSocket connection is very close to identical to an
  `<code>Sec-WebSocket-Version</code>`/`<code>13</code>` to
  <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>For each <var>protocol</var> in <var>protocols</var>,
- <a>combine</a>
- `<code>Sec-WebSocket-Protocol</code>`/<var>protocol</var> in
- <var>request</var>'s <a for=request>header list</a>.
+ <li><p>For each <var>protocol</var> in <var>protocols</var>, <a for="header list">combine</a>
+ `<code>Sec-WebSocket-Protocol</code>`/<var>protocol</var> in <var>request</var>'s
+ <a for=request>header list</a>.
 
  <li>
   <p>Let <var>permessageDeflate</var> be a user-agent defined


### PR DESCRIPTION
Instead of just 0x2C, use 0x2C 0x20 somewhat consistently (except where we can't and point it out) as that is what XMLHttpRequest implementations have always done and nobody likes too much change.

Fixes the Fetch part of https://github.com/whatwg/xhr/issues/108 and https://github.com/whatwg/xhr/issues/109.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/combine/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/89f7361...e3978ef.html)