### PR TITLE
Editorial: let Infra define byte-case-insensitive

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -162,11 +162,6 @@ Standards.
 
 <p><dfn>ABNF</dfn> means ABNF as modified by HTTP (in particular the addition <code>#</code>).
 
-<p>Comparing two <a>byte sequences</a> in a <dfn export>byte-case-insensitive</dfn> manner means
-comparing them exactly, byte for byte, except that the bytes in the range 0x41 to 0x5A,
-inclusive, are considered to also match their corresponding byte in the range 0x61 to
-0x7A, inclusive.
-
 <hr>
 
 <p id=fetch-url>A <dfn>response URL</dfn> is a <a for=/>URL</a> for which implementations need not


### PR DESCRIPTION
Depends on https://github.com/whatwg/infra/pull/76.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/infra-byte-case-insensitive/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/04968e2...4ad2be6.html)