### PR TITLE
Editorial: clarify that an internal response cannot be filtered

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1295,11 +1295,11 @@ navigate algorithm. It ensures `<code>Location</code>` has
 <a>filtered response</a>'s associated
 <dfn export id=concept-internal-response for=internal>internal response</dfn>.
 
-<p class="note no-backref">The <a for=/>fetch</a> algorithm returns
-such a view to ensure APIs do not accidentally leak information. If the information is
-required, e.g., to feed image data to a decoder, the associated
-<a for=internal>internal response</a> can be used, which is only
-"accessible" to internal specification algorithms.
+<p class="note no-backref">The <a for=/>fetch</a> algorithm returns such a view to ensure APIs do
+not accidentally leak information. If the information needs to be exposed for legacy reasons, e.g.,
+to feed image data to a decoder, the associated <a for=internal>internal response</a> can be used,
+which is only "accessible" to internal specification algorithms and is never a
+<a>filtered response</a> itself.
 
 <p>A <dfn export id=concept-filtered-response-basic>basic filtered response</dfn> is a
 <a>filtered response</a> whose


### PR DESCRIPTION
Fixes #386.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/internal-response/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/b59c72b...36bfd7b.html)