### PR TITLE
Move some terminology from the URL Standard here

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -209,7 +209,6 @@ for <var>request</var>.
 <a>local scheme</a>.
 
 <p class=note>This definition is also used by <cite>Referrer Policy</cite>. [[REFERRER]]
-<!-- And soonish CSP -->
 
 <p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is a <a for=url>scheme</a> that is
 "<code>http</code>" or "<code>https</code>".
@@ -222,7 +221,7 @@ for <var>request</var>.
 <a>network scheme</a>.
 
 <p class="note no-backref"><a>HTTP(S) scheme</a>, <a>network scheme</a>, and <a>fetch scheme</a> are
-used by HTML. [[HTML]]
+also used by <cite>HTML</cite>. [[HTML]]
 
 <hr>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -164,13 +164,6 @@ Standards.
 
 <hr>
 
-<p id=fetch-url>A <dfn>response URL</dfn> is a <a for=/>URL</a> for which implementations need not
-store the <a for=url>fragment</a> as it is never exposed. When
-<a lt="url serializer">serialized</a>, the <i>exclude fragment flag</i> is set, meaning
-implementations can store the <a for=url>fragment</a> nonetheless.
-
-<hr>
-
 <p><dfn id=credentials export>Credentials</dfn> are HTTP cookies, TLS client certificates, and
 <a lt="authentication entry">authentication entries</a>.
 
@@ -205,6 +198,38 @@ of:
 <p>To <dfn>queue a fetch-request-done task</dfn>, given a <var>request</var>,
 <a>queue a fetch task</a> on <var>request</var> to <a>process request end-of-body</a>
 for <var>request</var>.
+
+
+<h3 id=url>URL</h3>
+
+<p>A <dfn export>local scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
+"<code>blob</code>", "<code>data</code>", or "<code>filesystem</code>".
+
+<p>A <a for=/>URL</a> <dfn export>is local</dfn> if its <a for=url>scheme</a> is a
+<a>local scheme</a>.
+
+<p class=note>This definition is also used by <cite>Referrer Policy</cite>. [[REFERRER]]
+<!-- And soonish CSP -->
+
+<p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is a <a for=url>scheme</a> that is
+"<code>http</code>" or "<code>https</code>".
+
+<p>A <dfn export>network scheme</dfn> is a <a for=url>scheme</a> that is "<code>ftp</code>" or an
+<a>HTTP(S) scheme</a>.
+
+<p>A <dfn export>fetch scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
+"<code>blob</code>", "<code>data</code>", "<code>file</code>", "<code>filesystem</code>", or a
+<a>network scheme</a>.
+
+<p class="note no-backref"><a>HTTP(S) scheme</a>, <a>network scheme</a>, and <a>fetch scheme</a> are
+used by HTML. [[HTML]]
+
+<hr>
+
+<p id=fetch-url>A <dfn>response URL</dfn> is a <a for=/>URL</a> for which implementations need not
+store the <a for=url>fragment</a> as it is never exposed. When
+<a lt="url serializer">serialized</a>, the <i>exclude fragment flag</i> is set, meaning
+implementations can store the <a for=url>fragment</a> nonetheless.
 
 
 <h3 id=http>HTTP</h3>


### PR DESCRIPTION
Fixes part of https://github.com/whatwg/url/issues/241.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/url-terminology/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/869ec2c...c985104.html)