### PR TITLE
Properly set the Origin header for WebSocket requests

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3246,8 +3246,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
  <!-- XXX ideally we have an easier way to convert something ASCII-safe into bytes
           concept-as-bytes -->
 
- <li><p>If the <i>CORS flag</i> is set or <var>httpRequest</var>'s <a for=request>method</a> is
- neither `<code>GET</code>` nor `<code>HEAD</code>`, then <a for="header list">append</a>
+ <li><p>If the <i>CORS flag</i> is set, <var>httpRequest</var>'s <a for=request>method</a> is
+ neither `<code>GET</code>` nor `<code>HEAD</code>`, or <var>httpRequest</var>'s
+ <a for=request>mode</a> is "<code>websocket</code>", then <a for="header list">append</a>
  `<code>Origin</code>`/<var>httpRequest</var>'s <a for=request>origin</a>,
  <a lt="ASCII serialization of an origin">serialized</a> and <a>UTF-8 encoded</a>, to
  <var>httpRequest</var>'s <a for=request>header list</a>.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/nox/fetch/websocket-origin.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/cbca2c2...nox:c43ea5c.html)