### PR TITLE
Meta: Close <ol> tag in concept-header-list-append.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -318,6 +318,7 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 
  <li><p>Append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
+</ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-delete>delete</dfn> a
 <a for=header>name</a> (<var>name</var>) from a <a for=/>header list</a> (<var>list</var>), remove


### PR DESCRIPTION
Commit 5869c43a27fff06c6dfc228fe1288018f7f2168d started describing the steps
to append to a header list with an ordered list but never added a closing
`</ol>` tag, which meant the entire rest of the contents were wrongly indented
and considered part of those steps.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rakuco/fetch/close-ol-tag-headerlist-append.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/406c5a6...rakuco:3787352.html)