### PR TITLE
Adds "audioworklet" and "paintworklet" as destinations.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -778,12 +778,14 @@ JavaScript. [[!CSP]] [[!MIX]]
 <dfn export for=request id=concept-request-destination>destination</dfn>, which is
 the empty string,
 "<code>audio</code>",
+"<code>audioworklet</code>",
 "<code>document</code>",
 "<code>embed</code>",
 "<code>font</code>",
 "<code>image</code>",
 "<code>manifest</code>",
 "<code>object</code>",
+"<code>paintworklet</code>",
 "<code>report</code>",
 "<code>script</code>",
 "<code>serviceworker</code>",
@@ -802,8 +804,9 @@ the empty string,
      * HTML -->
 
 <p>A <a for=/>request</a>'s <a for=request>destination</a> is
-<dfn export for=request/destination>script-like</dfn> if it is "<code>script</code>",
-"<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>".
+<dfn export for=request/destination>script-like</dfn> if it is "<code>audioworklet</code>",
+"<code>paintworklet</code>", "<code>script</code>", "<code>serviceworker</code>",
+"<code>sharedworker</code>", or "<code>worker</code>".
 
 <p class=warning>Algorithms that use <a for=request/destination>script-like</a> should also consider
 "<code>xslt</code>" as that too can cause script execution. It is not included in the list as it is
@@ -820,7 +823,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=16>""
+   <td rowspan=18>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.
@@ -859,6 +862,14 @@ not always relevant and might require different behavior.
    <td>HTML's <code>&lt;img src></code>, <code>/favicon.ico</code> resource,
    SVG's <code>&lt;image></code>, CSS' <code>background-image</code>, CSS'
    <code>cursor</code>, CSS' <code>list-style-image</code>, …
+  <tr>
+   <td>"<code>audioworklet</code>"
+   <td><code>script-src</code>
+   <td><code>audioWorklet.addModule()</code>
+  <tr>
+   <td>"<code>paintworklet</code>"
+   <td><code>script-src</code>
+   <td><code>CSS.paintWorklet.addModule()</code>
   <tr>
    <td>"<code>script</code>"
    <td><code>script-src</code>
@@ -1118,9 +1129,9 @@ Unless stated otherwise, it is unset.
 <hr>
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
-whose <a for=request>destination</a> is "<code>audio</code>", "<code>font</code>",
-"<code>image</code>", "<code>manifest</code>", "<code>script</code>",
-"<code>style</code>", "<code>track</code>", "<code>video</code>",
+whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworklet</code>",
+"<code>font</code>", "<code>image</code>", "<code>manifest</code>", "<code>paintworklet</code>",
+"<code>script</code>", "<code>style</code>", "<code>track</code>", "<code>video</code>",
 "<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>potential-navigation-or-subresource request</dfn> is a
@@ -4830,7 +4841,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "document", "embed", "font", "image", "manifest", "object", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };


### PR DESCRIPTION
These two are the ones which are being implemented, so starting with
them for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/bfgeek/fetch/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/e5abf0f...bfgeek:89a8f25.html)