### PR TITLE
Editorial: rename "basic fetch" to "scheme fetch"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2516,7 +2516,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      <li><p>Set <var>request</var>'s
      <a for=request>response tainting</a> to "<code>basic</code>".
 
-     <li><p>Return the result of performing a <a for=basic>basic fetch</a>
+     <li><p>Return the result of performing a <a>scheme fetch</a>
      using <var>request</var>.
     </ol>
 
@@ -2539,7 +2539,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      <a for=request>response tainting</a> to
      "<code>opaque</code>".
 
-     <li><p>Return the result of performing a <a for=basic>basic fetch</a>
+     <li><p>Return the result of performing a <a>scheme fetch</a>
      using <var>request</var>.
      <!-- file URLs end up here as they are not same-origin typically. -->
     </ol>
@@ -2737,10 +2737,10 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  for <var>response</var>.
 </ol>
 
+<!-- Prior to May 2017, this algorithm was named "basic fetch." -->
+<h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
-<h3 id=basic-fetch>Basic fetch</h3>
-
-<p>To perform a <dfn id=concept-basic-fetch for=basic>basic fetch</dfn> using
+<p>To perform a <dfn id=concept-scheme-fetch oldids=concept-basic-fetch>scheme fetch</dfn> using
 <var>request</var>, switch on <var>request</var>'s
 <a for=request>current url</a>'s
 <a for=url>scheme</a>, and run the associated


### PR DESCRIPTION
As it relates to the fetching algorithm, the term "basic" is sub-optimal
for a number of reasons:

- It implies a relative level of simplicity. Because the algorithm
  includes an invocation of HTTP Fetch, it is conceptually more complex
  than most other fetching algorithms defined in the specification.
- It suggests a relationship to the "basic" request tainting value and
  "basic" filtered response. While the algorithm is invoked for requests
  whose tainting is "basic", it is also invoked for requests whose
  tainting is set to "opaque".

Re-name the algorithm to "scheme fetch" in order to more precisely
describe its behavior while avoiding association with any particular
request tainting value.

---

@annevk I'm probably only thinking along these lines because of my inexperience
with the specification, but I know that same inexperience makes it easier for
me to stomach vocabulary changes like this. These details certainly have
momentum for folks who have been working in this space for a while. My bias
notwithstanding, I do think this would make the text easier to follow. Other
alternatives that would address my concern are "scheme fetch" or "scheme-based
fetch", though those may be too technical/wordy.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/bocoup/fetch/generic-fetch.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/ba50491...bocoup:ec0bb4f.html)