### PR TITLE
Add potential destination.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -811,14 +811,14 @@ the empty string,
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
 <p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
-<dfn export for=/ id=concept-potential-destination>potential-destination</dfn> into a <a for=request>destination</a>, run these steps:
+<dfn export for=/ id=concept-potential-destination>potential destination</dfn> into a <a for=request>destination</a>, run these steps:
 
 <ol>
- <li><p>If <a for=/>potential destination</a> is a valid <a for=request>destination</a>, return its value.
-
- <li><p>Assert: <a for=/>potential destination</a> is "<code>fetch</code>".
-
  <li><p>If <a for=/>potential destination</a> is "<code>fetch</code>", return the empty string.
+
+ <li><p>Assert: <a for=/>potential destination</a> is is a valid <a for=request>destination</a>.
+
+ <li><p>If <a for=/>potential destination</a> is a valid <a for=request>destination</a>, return its value.
 
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -818,7 +818,7 @@ the empty string,
 <ol>
  <li><p>If <a for=/>potential destination</a> is "<code>fetch</code>", return the empty string.
 
- <li><p>Assert: <a for=/>potential destination</a> is is a valid <a for=request>destination</a>.
+ <li><p>Assert: <a for=/>potential destination</a> is a valid <a for=request>destination</a>.
 
  <li><p>If <a for=/>potential destination</a> is a valid <a for=request>destination</a>, return its value.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1469,6 +1469,7 @@ for each associated <a for="fetch group">fetch record</a> whose
 <a for="fetch group">fetch record</a>'s
 <a for="fetch record">fetch</a> with reason <i>fatal</i>.
 
+
 <h3 id=connections>Connections</h3>
 
 <p>A user agent has an associated

--- a/fetch.bs
+++ b/fetch.bs
@@ -1415,18 +1415,18 @@ is a <a>filtered response</a> whose
 
 <h4 id=miscellaneous>Miscellaneous</h4>
 
-<p>A <dfn export id=concept-potential-destination>potential destination</dfn> is "<code>fetch</code>" or a <a for=request>destination</a>.
+<p>A <dfn export id=concept-potential-destination>potential destination</dfn> is
+"<code>fetch</code>" or a <a for=request>destination</a>.
 
 <p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
-<a for=/>potential destination</a> <code>potentialDestination</code>, run these steps:
+<a for=/>potential destination</a> <var>potentialDestination</var>, run these steps:
 
 <ol>
- <li><p>If <code>potentialDestination</code> is "<code>fetch</code>", then return the empty string.
+ <li><p>If <var>potentialDestination</var> is "<code>fetch</code>", then return the empty string.
 
- <li><p>Assert: <code>potentialDestination</code> is a <a for=request>destination</a>.
+ <li><p>Assert: <var>potentialDestination</var> is a <a for=request>destination</a>.
 
- <li><p>Return <code>potentialDestination</code>.
-
+ <li><p>Return <var>potentialDestination</var>.
 </ol>
 
 <h3 id=authentication-entries>Authentication entries</h3>

--- a/fetch.bs
+++ b/fetch.bs
@@ -810,20 +810,6 @@ the empty string,
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
-<p>A <dfn export id=concept-potential-destination>potential destination</dfn> is "<code>fetch</code>" or a <a for=request>destination</a>.
-
-<p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
-<a for=/>potential destination</a> into a <a for=request>destination</a>, run these steps:
-
-<ol>
- <li><p>If <a for=/>potential destination</a> is "<code>fetch</code>", return the empty string.
-
- <li><p>Assert: <a for=/>potential destination</a> is a valid <a for=request>destination</a>.
-
- <li><p>If <a for=/>potential destination</a> is a valid <a for=request>destination</a>, return its value.
-
-</ol>
-
 <div class=note>
  <p>The following table illustrates the relationship between a
  <a for=/>request</a>'s
@@ -1427,6 +1413,21 @@ is a <a>filtered response</a> whose
  <li><p>Return <var>newResponse</var>.
 </ol>
 
+<h4 id=miscellaneous>Miscellaneous</h4>
+
+<p>A <dfn export id=concept-potential-destination>potential destination</dfn> is "<code>fetch</code>" or a <a for=request>destination</a>.
+
+<p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
+<a for=/>potential destination</a> <code>potentialDestination</code>, run these steps:
+
+<ol>
+ <li><p>If <code>potentialDestination</code> is "<code>fetch</code>", then return the empty string.
+
+ <li><p>Assert: <code>potentialDestination</code> is a <a for=request>destination</a>.
+
+ <li><p>Return <code>potentialDestination</code>.
+
+</ol>
 
 <h3 id=authentication-entries>Authentication entries</h3>
 
@@ -1467,7 +1468,6 @@ for each associated <a for="fetch group">fetch record</a> whose
 <a lt=terminated for=fetch>terminate</a> the
 <a for="fetch group">fetch record</a>'s
 <a for="fetch record">fetch</a> with reason <i>fatal</i>.
-
 
 <h3 id=connections>Connections</h3>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -810,6 +810,18 @@ the empty string,
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
+<p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
+<dfn export for=/ id=concept-potential-destination>potential-destination</dfn> into a <a for=request>destination</a>, run these steps:
+
+<ol>
+ <li><p>If <a for=/>potential destination</a> is a valid <a for=request>destination</a>, return its value.
+
+ <li><p>Assert: <a for=/>potential destination</a> is "<code>fetch</code>".
+
+ <li><p>If <a for=/>potential destination</a> is "<code>fetch</code>", return the empty string.
+
+</ol>
+
 <div class=note>
  <p>The following table illustrates the relationship between a
  <a for=/>request</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -810,8 +810,10 @@ the empty string,
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
+<p>A <dfn export id=concept-potential-destination>potential destination</dfn> is "<code>fetch</code>" or a <a for=request>destination</a>.
+
 <p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
-<dfn export for=/ id=concept-potential-destination>potential destination</dfn> into a <a for=request>destination</a>, run these steps:
+<a for=/>potential destination</a> into a <a for=request>destination</a>, run these steps:
 
 <ol>
  <li><p>If <a for=/>potential destination</a> is "<code>fetch</code>", return the empty string.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1413,6 +1413,7 @@ is a <a>filtered response</a> whose
  <li><p>Return <var>newResponse</var>.
 </ol>
 
+
 <h4 id=miscellaneous>Miscellaneous</h4>
 
 <p>A <dfn export id=concept-potential-destination>potential destination</dfn> is
@@ -1428,6 +1429,7 @@ is a <a>filtered response</a> whose
 
  <li><p>Return <var>potentialDestination</var>.
 </ol>
+
 
 <h3 id=authentication-entries>Authentication entries</h3>
 


### PR DESCRIPTION
Add a potential destination definition and processing, to enable preload
processing to decouple the `as` value from `destination` to enable
preloading the empty destination using the `fetch` keyword.

This is an alternative solution to https://github.com/whatwg/fetch/pull/442 as discussed in https://github.com/whatwg/fetch/pull/442#discussion_r103624566


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/fetch/potential_destination.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/a38ae96...yoavweiss:ad27990.html)