### PR TITLE
Make sure that potential destination is not the empty string

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1417,7 +1417,7 @@ is a <a>filtered response</a> whose
 <h4 id=miscellaneous>Miscellaneous</h4>
 
 <p>A <dfn export id=concept-potential-destination>potential destination</dfn> is
-"<code>fetch</code>" or a <a for=request>destination</a>.
+"<code>fetch</code>" or a <a for=request>destination</a> which is not the empty string.
 
 <p>To <dfn export for=destination id=concept-potential-destination-translate>translate</dfn> a
 <a for=/>potential destination</a> <var>potentialDestination</var>, run these steps:


### PR DESCRIPTION
This completes https://github.com/whatwg/fetch/pull/547 and makes sure that the potential destination is not the empty string.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/potential_destination_not_empty_string/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/d6266c7...c33b1fd.html)