### PR TITLE
Allow range header to be set by APIs

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1341,13 +1341,13 @@ run these steps:
 <ol>
  <li><p>Let <var>rangeValue</var> be `<code>bytes </code>`.
 
- <li><p><a lt="serialize an integer">Serialize</a> and <a>UTF-8 encode</a> <var>first</var>, and
- append the result to <var>rangeValue</var>.
+ <li><p><a lt="serialize an integer">Serialize</a> and <a>isomorphic encode</a> <var>first</var>,
+ and append the result to <var>rangeValue</var>.
 
  <li><p>Append 0x2D (-) to <var>rangeValue</var>.
 
  <li><p>If <var>last</var> is given, then <a lt="serialize an integer">serialize</a> and
- <a>UTF-8 encode</a> it, and append the result to <var>rangeValue</var>.
+ <a>isomorphic encode</a> it, and append the result to <var>rangeValue</var>.
 
  <li><p><a for="header list">Append</a> `<code>Range</code>`/<var>rangeValue</var> to
  <var>request</var>'s <a for=request>header list</a>.
@@ -3556,7 +3556,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=request>body</a>'s <a for=body>source</a> is non-null, then set
    <var>contentLengthValue</var> to <var>httpRequest</var>'s <a for=request>body</a>'s
    <a for=body>total bytes</a>, <a lt="serialize an integer">serialized</a> and
-   <a>UTF-8 encoded</a>.
+   <a>isomorphic encoded</a>.
 
    <li><p>If <var>contentLengthValue</var> is non-null,
    <a for="header list">append</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -197,6 +197,12 @@ of:
 <a>queue a fetch task</a> on <var>request</var> to <a>process request end-of-body</a>
 for <var>request</var>.
 
+<p>To <dfn>serialize an integer</dfn>, represent it as a string of the shortest possible decimal
+number.
+
+<p class=XXX>This will be replaced by a more descriptive algorithm in Infra. See
+<a href="https://github.com/whatwg/infra/issues/201">infra/201</a>.
+
 
 <h3 id=url>URL</h3>
 
@@ -442,6 +448,24 @@ documented in <a href=#cors-protocol-exceptions>CORS protocol exceptions</a>.
 
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a>byte-case-insensitive</a> match
 for `<code>Authorization</code>`.
+
+<p>A <dfn export>privileged no-cors request-header name</dfn> is a <a for=/>header</a>
+<a for=header>name</a> that is a <a>byte-case-insensitive</a> match for one of
+
+<ul class=brief>
+ <li>`<code>Range</code>`.
+</ul>
+
+<div class="note no-backref">
+ <p>These are headers that can be set by privileged APIs, and will be preserved if their associated
+ request object is copied, but will be removed if the request is modified by unprivilaged APIs.
+
+ <p>`<code>Range</code>` headers are commonly used by <a lt="downloads a hyperlink">downloads</a>
+ and <a lt="resource fetch algorithm">media fetches</a>, although neither of these currently specify
+ how. <a href=https://github.com/whatwg/html/pull/2814>html/2914</a> aims to solve this.
+
+ <p>A helper is provided to <a for=request>add a range header</a> to a particular request.
+</div>
 
 <p>A <dfn export>CORS-safelisted response-header name</dfn>, given a
 <a for=response>CORS-exposed header-name list</a> <var>list</var>, is a <a for=/>header</a>
@@ -1308,6 +1332,33 @@ run these steps:
   </ol>
 </ol>
 
+<hr>
+
+<p>To <dfn export for=request id=concept-request-add-range-header>add a range header</dfn> to a
+<a for=/>request</a> <var>request</var>, with an integer <var>first</var>, and an optional integer
+<var>last</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>rangeValue</var> be `<code>bytes </code>`.
+
+ <li><p><a lt="serialize an integer">Serialize</a> and <a>UTF-8 encode</a> <var>first</var>, and
+ append the result to <var>rangeValue</var>.
+
+ <li><p>Append 0x2D (-) to <var>rangeValue</var>.
+
+ <li><p>If <var>last</var> is given, then <a lt="serialize an integer">serialize</a> and
+ <a>UTF-8 encode</a> it, and append the result to <var>rangeValue</var>.
+
+ <li><p><a for="header list">Append</a> `<code>Range</code>`/<var>rangeValue</var> to
+ <var>request</var>'s <a for=request>header list</a>.
+</ol>
+
+<p class=note>A range header denotes an inclusive byte range. There a range header where
+<var>first</var> is 0 and <var>last</var> is 500, is a range of 501 bytes.
+
+<p class=note>Features that combine multiple responses into one logical resource are historically a
+source of security bugs. Please seek security review for features that deal with partial responses.
+
 
 <h4 id=responses>Responses</h4>
 
@@ -1402,6 +1453,14 @@ specified. [[!CSP]]
 <a for=response>CORS-exposed header-name list</a> set by <a>extracting header values</a> from the
 `<a http-header><code>Access-Control-Expose-Headers</code></a>` header. This list is used by a
 <a>CORS filtered response</a> to determine which headers to expose.
+
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-range-requested-flag>range-requested flag</dfn>, which is
+initially unset.
+
+<p class=note>This is used to ensure to prevent a partial response from an earlier ranged request
+being provided to an API that didn't make a range request. See the flag's usage for a detailed
+description of the attack.
 
 <p>A <a for=/>response</a> can have an associated
 <dfn export for=response id=concept-response-location-url>location URL</dfn> (null, failure, or a
@@ -2930,6 +2989,31 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   </ul>
 
  <li>
+  <p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>",
+  <var>internalResponse</var>'s <a for=response>status</a> is <code>206</code>,
+  <var>internalResponse</var>'s <a for=response>range-requested flag</a> is set, and
+  <var>request</var>'s <a for=request>header list</a> does not <a for="header list">contain</a>
+  `<code>Range</code>`, then set <var>response</var> and <var>internalResponse</var> to a
+  <a>network error</a>.
+
+  <div class=note>
+   <p>Traditionally, APIs accept a ranged response even if a range was not requested. This prevents
+   a partial response from an earlier ranged request being provided to an API that did not make a
+   range request.
+
+   <details>
+    <summary>Further details</summary>
+
+    <p>The above steps prevent the following attack attack:
+
+    <p>A media element is used to request a range of a cross-origin HTML resource. Although this is
+    invalid media, a reference to a clone of the response can be retained in a service worker. This
+    can later be used as the response to a script element's fetch. If the partial response is valid
+    JavaScript (even though the whole resource is not), executing it would leak private data.
+   </details>
+  </div>
+
+ <li>
   <p>If <var>response</var> is not a <a>network error</a> and
   either <var>request</var>'s <a for=request>method</a> is
   `<code>HEAD</code>` or `<code>CONNECT</code>`, or <var>internalResponse</var>'s
@@ -3471,7 +3555,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <li><p>If <var>httpRequest</var>'s <a for=request>body</a> is non-null and <var>httpRequest</var>'s
    <a for=request>body</a>'s <a for=body>source</a> is non-null, then set
    <var>contentLengthValue</var> to <var>httpRequest</var>'s <a for=request>body</a>'s
-   <a for=body>total bytes</a>, <a>UTF-8 encoded</a>.
+   <a for=body>total bytes</a>, <a lt="serialize an integer">serialized</a> and
+   <a>UTF-8 encoded</a>.
 
    <li><p>If <var>contentLengthValue</var> is non-null,
    <a for="header list">append</a>
@@ -3750,6 +3835,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
       the network error, which is sometimes known as "negative caching".
     </ol>
   </ol>
+
+ <li><p>If <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">contains</a>
+ `<code>Range</code>`, then set <var>response</var>'s <a for=response>range-requested flag</a>.
 
  <li>
   <p>If <var>response</var>'s <a for=response>status</a> is <code>401</code>, <i>CORS flag</i>
@@ -4521,9 +4609,6 @@ objects.</span>
 "<code>response</code>" or
 "<code>none</code>".
 
-<p class="note no-backref">"<code>immutable</code>" exists for service workers.
-[[!SW]]
-
 <p>To <dfn export for=Headers id=concept-headers-append>append</dfn> a
 <a for=header>name</a>/<a for=header>value</a>
 (<var>name</var>/<var>value</var>) pair to a
@@ -4542,9 +4627,8 @@ objects.</span>
  "<code>request</code>" and <var>name</var> is a <a>forbidden header name</a>,
  return.
 
- <li><p>Otherwise, if <a for=Headers>guard</a> is
- "<code>request-no-cors</code>" and <var>name</var>/<var>value</var> is not a
- <a>CORS-safelisted request-header</a>, return.
+ <li><p>Otherwise, if <a for=Headers>guard</a> is "<code>request-no-cors</code>" and
+ <var>name</var>/<var>value</var> is not a <a>CORS-safelisted request-header</a>, then return.
 
  <li><p>Otherwise, if <a for=Headers>guard</a> is
  "<code>response</code>" and <var>name</var> is a
@@ -4553,6 +4637,9 @@ objects.</span>
  <li><p><a for="header list">Append</a>
  <var>name</var>/<var>value</var> to
  <a for=Headers>header list</a>.
+
+ <li><p>If <var>headers</var>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>", then
+ <a for=Headers>remove privileged no-cors request headers</a> from <var>headers</var>.
 </ol>
 
 <p>To <dfn export for=Headers id=concept-headers-fill>fill</dfn> a
@@ -4576,6 +4663,22 @@ run these steps:
  <var>key</var> → <var>value</var> in <var>object</var>, <a lt=append for=Headers>append</a>
  <var>key</var>/<var>value</var> to <var>headers</var>.
 </ol>
+
+<p>To
+<dfn for=Headers id=concept-headers-remove-privileged-no-cors-request-headers>remove privileged no-cors request headers</dfn>
+from a {{Headers}} object (<var>headers</var>), run these steps:
+
+<ol>
+ <li><p><a for="list">For each</a> <var>headerName</var> of
+ <a>privileged no-cors request-header names</a>:
+
+ <ol>
+  <li><p><a for="header list">Delete</a> <var>headerName</var> from <var>headers</var>'s
+  <a for=Headers>header list</a>.
+ </ol>
+</ol>
+
+<p class=note>This is called when headers are modified by unprivileged code.
 
 <p>The
 <dfn id=dom-headers export for=Headers constructor><code>Headers(<var>init</var>)</code></dfn>
@@ -4609,9 +4712,10 @@ method, when invoked, must run these steps:
  "<code>request</code>" and <var>name</var> is a <a>forbidden header name</a>,
  return.
 
- <li><p>Otherwise, if <a for=Headers>guard</a> is
- "<code>request-no-cors</code>" and <var>name</var>/`<code>invalid</code>` is
- not a <a>CORS-safelisted request-header</a>, then return.
+ <li>
+  <p>Otherwise, if <a for=Headers>guard</a> is "<code>request-no-cors</code>",
+  <var>name</var>/`<code>invalid</code>` is not a <a>CORS-safelisted request-header</a>, and
+  <var>name</var> is not a <a>privileged no-cors request-header name</a>, then return.
 
   <p class=note>`<code>invalid</code>` is used because
   <a method for=Headers><code>delete()</code></a> is not passed a value as argument.
@@ -4620,8 +4724,14 @@ method, when invoked, must run these steps:
  "<code>response</code>" and <var>name</var> is a
  <a>forbidden response-header name</a>, return.
 
+ <li><p>If <a for=Headers>header list</a> does not <a for="header list">contain</a> <var>name</var>,
+ then return.
+
  <li><p><a for="header list">Delete</a> <var>name</var> from
  <a for=Headers>header list</a>.
+
+ <li><p>If <a for=Headers>guard</a> is "<code>request-no-cors</code>", then
+ <a for=Headers>remove privileged no-cors request headers</a> from the <a>context object</a>.
 </ol>
 
 <p>The <dfn export for=Headers method><code>get(<var>name</var>)</code></dfn> method, when
@@ -4666,9 +4776,8 @@ method, when invoked, must run these steps:
  "<code>request</code>" and <var>name</var> is a <a>forbidden header name</a>,
  return.
 
- <li><p>Otherwise, if <a for=Headers>guard</a> is
- "<code>request-no-cors</code>" and <var>name</var>/<var>value</var> is not a
- <a>CORS-safelisted request-header</a>, return.
+ <li><p>Otherwise, if <a for=Headers>guard</a> is "<code>request-no-cors</code>" and
+ <var>name</var>/<var>value</var> is not a <a>CORS-safelisted request-header</a>, then return.
 
  <li><p>Otherwise, if <a for=Headers>guard</a> is
  "<code>response</code>" and <var>name</var> is a
@@ -4677,6 +4786,9 @@ method, when invoked, must run these steps:
  <li><p><a for="header list">Set</a>
  <var>name</var>/<var>value</var> in
  <a for=Headers>header list</a>.
+
+ <li><p>If <a for=Headers>guard</a> is "<code>request-no-cors</code>", then
+ <a for=Headers>remove privileged no-cors request headers</a> from the <a>context object</a>.
 </ol>
 
 <p>The <a>value pairs to iterate over</a> are the return value of running
@@ -5219,42 +5331,61 @@ constructor must run these steps:
  <li><p>If <var>init</var>'s <code>window</code> member is present, set
  <var>window</var> to "<code>no-window</code>".
 
- <li><p>Set <var>request</var> to a new <a for=/>request</a>
- whose <a for=request>url</a> is <var>request</var>'s
- <a for=request>current url</a>,
- <a for=request>method</a> is <var>request</var>'s
- <a for=request>method</a>,
- <a for=request>header list</a> is a copy of
- <var>request</var>'s <a for=request>header list</a>,
- <a>unsafe-request flag</a> is set,
- <a for=request>client</a> is
- <a>current settings object</a>,
- <a for=request>window</a> is <var>window</var>,
- <a for=request>origin</a> is "<code>client</code>",
- <a for=request>referrer</a> is <var>request</var>'s
- <a for=request>referrer</a>,
- <a for=request>referrer policy</a> is
- <var>request</var>'s
- <a for=request>referrer policy</a>,
- <a for=request>mode</a> is <var>request</var>'s
- <a for=request>mode</a>,
- <a for=request>credentials mode</a> is
- <var>request</var>'s
- <a for=request>credentials mode</a>,
- <a for=request>cache mode</a> is
- <var>request</var>'s
- <a for=request>cache mode</a>,
- <a for=request>redirect mode</a> is
- <var>request</var>'s
- <a for=request>redirect mode</a>,
- <a for=request>integrity metadata</a> is
- <var>request</var>'s
- <a for=request>integrity metadata</a>,
- <a>keepalive flag</a> is <var>request</var>'s <a>keepalive flag</a>,
- <a for=request>reload-navigation flag</a> is <var>request</var>'s
- <a for=request>reload-navigation flag</a>, and
- <a for=request>history-navigation flag</a> is <var>request</var>'s
- <a for=request>history-navigation flag</a>.
+ <li>
+  <p>Set <var>request</var> to a new <a for=/>request</a> with the following properties:
+
+  <dl>
+   <dt><a for=request>url</a>
+   <dd><var>request</var>'s <a for=request>current url</a>.
+
+   <dt><a for=request>method</a>
+   <dd><var>request</var>'s <a for=request>method</a>.
+
+   <dt><a for=request>header list</a>
+   <dd>A copy of <var>request</var>'s <a for=request>header list</a>.
+
+   <dt><a>unsafe-request flag</a>
+   <dd>Set.
+
+   <dt><a for=request>client</a>
+   <dd><a>Current settings object</a>.
+
+   <dt><a for=request>window</a>
+   <dd><var>window</var>.
+
+   <dt><a for=request>origin</a>
+   <dd>"<code>client</code>".
+
+   <dt><a for=request>referrer</a>
+   <dd><var>request</var>'s <a for=request>referrer</a>.
+
+   <dt><a for=request>referrer policy</a>
+   <dd><var>request</var>'s <a for=request>referrer policy</a>.
+
+   <dt><a for=request>mode</a>
+   <dd><var>request</var>'s <a for=request>mode</a>.
+
+   <dt><a for=request>credentials mode</a>
+   <dd><var>request</var>'s <a for=request>credentials mode</a>.
+
+   <dt><a for=request>cache mode</a>
+   <dd><var>request</var>'s <a for=request>cache mode</a>.
+
+   <dt><a for=request>redirect mode</a>
+   <dd><var>request</var>'s <a for=request>redirect mode</a>.
+
+   <dt><a for=request>integrity metadata</a>
+   <dd><var>request</var>'s <a for=request>integrity metadata</a>.
+
+   <dt><a>keepalive flag</a>
+   <dd><var>request</var>'s <a>keepalive flag</a>.
+
+   <dt><a for=request>reload-navigation flag</a>
+   <dd><var>request</var>'s <a for=request>reload-navigation flag</a>.
+
+   <dt><a for=request>history-navigation flag</a>
+   <dd><var>request</var>'s <a for=request>history-navigation flag</a>.
+  </dl>
 
  <li>
   <p>If any of <var>init</var>'s members are present, then:
@@ -5271,14 +5402,13 @@ constructor must run these steps:
    <li><p>Set <var>request</var>'s <a for=request>referrer</a> to
    "<code>client</code>"
 
-   <li><p>Set <var>request</var>'s
-   <a for=request>referrer policy</a> to the empty string.
+   <li><p>Set <var>request</var>'s <a for=request>referrer policy</a> to the empty string.
   </ol>
 
-  <p class=note>This is done to ensure that when a service worker "redirects" a request, e.g.,
-  from an image in a cross-origin stylesheet, and makes modifications, it no longer appears to come
-  from the original source (i.e., the cross-origin stylesheet), but instead from the service worker
-  that "redirected" the request. This is important as the original source might not even be able to
+  <p class=note>This is done to ensure that when a service worker "redirects" a request, e.g., from
+  an image in a cross-origin style sheet, and makes modifications, it no longer appears to come from
+  the original source (i.e., the cross-origin style sheet), but instead from the service worker that
+  "redirected" the request. This is important as the original source might not even be able to
   generate the same kind of requests as the service worker. Services that trust the original source
   could therefore be exploited were this not done, although that is somewhat farfetched.
 
@@ -5381,41 +5511,51 @@ constructor must run these steps:
 
  <li><p>Let <var>r</var> be a new {{Request}} object associated with <var>request</var>.
 
+ <li><p>If <var>signal</var> is not null, then make <var>r</var>'s <a for=Request>signal</a>
+ <a for=AbortSignal>follow</a> <var>signal</var>.
+
  <li><p>Set <var>r</var>'s <a for=Request>headers</a> to a new {{Headers}} object, whose
  <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
  <a for=Headers>guard</a> is "<code>request</code>".
 
- <li><p>If <var>signal</var> is not null, then make <var>r</var>'s <a for=Request>signal</a>
- <a for=AbortSignal>follow</a> <var>signal</var>.
-
- <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
- associated <a for=Headers>header list</a>.
- <!-- it might contain a header that is no longer allowed per the mode change -->
-
- <li><p>If <var>init</var>'s <code>headers</code> member is present, set
- <var>headers</var> to <var>init</var>'s <code>headers</code> member.
-
- <li><p>Empty <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
-
  <li>
-  <p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>mode</a> is
-  "<code>no-cors</code>", then:
+  <p>If any of <var>init</var>'s members are present, then:
+
+  <p class=note>The headers are sanitised as they might contain headers that are not allowed by this
+  mode. Otherwise, they were previously sanitised or are unmodified since creation by a privileged
+  API.
 
   <ol>
-   <li><p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
-   <a>CORS-safelisted method</a>, then <a>throw</a> a <code>TypeError</code>.
+   <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
+   associated <a for=Headers>header list</a>.
 
-   <li><p>Set <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
-   "<code>request-no-cors</code>".
+   <li><p>If <var>init</var>'s <code>headers</code> member is present, set
+   <var>headers</var> to <var>init</var>'s <code>headers</code> member.
+
+   <li><p>Empty <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
+
+   <li>
+    <p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>mode</a> is
+    "<code>no-cors</code>", then:
+
+    <ol>
+     <li><p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
+     <a>CORS-safelisted method</a>, then <a>throw</a> a <code>TypeError</code>.
+
+     <li><p>Set <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
+     "<code>request-no-cors</code>".
+    </ol>
+   </li>
+
+   <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
+   <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>
+   <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to
+   <var>r</var>'s {{Headers}} object.
+
+   <li><p>Otherwise, <a for=Headers>fill</a> <var>r</var>'s {{Headers}} object with
+   <var>headers</var>.
   </ol>
-
- <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
- <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>
- <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to
- <var>r</var>'s {{Headers}} object.
-
- <li><p>Otherwise, <a for=Headers>fill</a> <var>r</var>'s {{Headers}} object with
- <var>headers</var>.
+ </li>
 
  <li><p>Let <var>inputBody</var> be <var>input</var>'s
  <a for=Request>request</a>'s <a for=request>body</a>
@@ -5571,10 +5711,18 @@ run these steps:
 
  <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>request</a> to <var>clonedRequest</var>.
 
- <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
- whose <a for=Headers>header list</a> is set to <var>clonedRequest</var>'s
- <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
- <a for=Request>headers</a>' <a for=Headers>guard</a>.
+ <li>
+  <p>Set <var>clonedRequestObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
+  with the following properties:
+
+  <dl>
+   <dt><a for=Headers>header list</a>
+   <dd><var>clonedRequest</var>'s <a for=Headers>header list</a>.
+
+   <dt><a for=Headers>guard</a>
+   <dd><a>context object</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a>.
+  </dl>
+ </li>
 
  <li><p>Make <var>clonedRequestObject</var>'s <a for=Request>signal</a>
  <a for=AbortSignal>follow</a> <a>context object</a>'s <a for=Request>signal</a>.
@@ -5797,8 +5945,8 @@ run these steps:
 
  <li><p>Set <var>clonedResponseObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
  whose <a for=Headers>header list</a> is set to <var>clonedResponse</var>'s
- <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
- <a for=Response>headers</a>' <a for=Headers>guard</a>.
+ <a for=Headers>header list</a>, and <a for=Headers>guard</a> is the <a>context object</a>'s
+ <a for=Response>headers</a>'s <a for=Headers>guard</a>.
 
  <li><p>Upon fulfillment of <a>context object</a>'s <a for=Response>trailer promise</a>, resolve
  <var>clonedResponseObject</var>'s <a for=Response>trailer promise</a> with a new {{Headers}} object


### PR DESCRIPTION
This is part of #144.

The aim is to allow APIs to use the range header for no-cors requests, and allow them to pass through a service worker, but disallow modification of these requests, and disallow developers creating their own no-cors ranged requests.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/560.html" title="Last updated on May 29, 2018, 11:31 AM GMT (e1ad29d)">Preview</a> | <a href="https://whatpr.org/fetch/560/bd9b4e3...e1ad29d.html" title="Last updated on May 29, 2018, 11:31 AM GMT (e1ad29d)">Diff</a>