### PR TITLE
Use "read a chunk" operation correctly

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1183,8 +1183,7 @@ or "<code>worker</code>".
   <p>Let <var>reader</var> be the result of <a lt="get a reader" for=ReadableStream>getting
   a reader</a> from <var>body</var>'s <a for=body>stream</a>.
 
-  <p class="note no-backref">This operation cannot throw an exception</p>
-  throw as it was called for the same <a for=body>source</a> before.
+  <p class="note no-backref">This operation cannot throw an exception.
 
  <li><p>Let <var>read</var> be the result of <a lt="read a chunk" for=ReadableStream>reading a
  chunk</a> from <var>body</var>'s <a for=body>stream</a> with <var>reader</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1179,8 +1179,15 @@ or "<code>worker</code>".
  <li><p>If <var>body</var> is null, then <a>queue a fetch task</a> on <var>request</var> to
  <a>process request end-of-body</a> for <var>request</var> and abort these steps.
 
+ <li>
+  <p>Let <var>reader</var> be the result of <a lt="get a reader" for=ReadableStream>getting
+  a reader</a> from <var>body</var>'s <a for=body>stream</a>.
+
+  <p class="note no-backref">This operation cannot throw an exception</p>
+  throw as it was called for the same <a for=body>source</a> before.
+
  <li><p>Let <var>read</var> be the result of <a lt="read a chunk" for=ReadableStream>reading a
- chunk</a> from <var>body</var>'s <a for=body>stream</a>.
+ chunk</a> from <var>body</var>'s <a for=body>stream</a> with <var>reader</var>.
 
  <li>
   <p><a>In parallel</a>, while true:
@@ -1205,7 +1212,7 @@ or "<code>worker</code>".
       <p class="note no-backref">This step blocks until <var>bs</var> is fully transmitted.
 
      <li><p>Set <var>read</var> to the result of <a lt="read a chunk" for=ReadableStream>reading a
-     chunk</a> from <var>body</var>'s <a for=body>stream</a>.
+     chunk</a> from <var>body</var>'s <a for=body>stream</a> with <var>reader</var>.
     </ol>
 
    <li><p>Otherwise, if <var>read</var> is fulfilled with an object whose <code>done</code> property


### PR DESCRIPTION
The operation takes a reader but we passed a stream. This change fixes that.

Fixes #570.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/reading-a-chunk/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/194c2a1...6aad002.html)