### PR TITLE
Editorial: Making headers their own property

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4728,8 +4728,8 @@ omitted from <a enum><code>RequestMode</code></a> as it cannot be used nor obser
 <p>A {{Request}} object has an associated
 <dfn id=concept-request-request for=Request export>request</dfn> (a <a for=/>request</a>).
 
-<p>A {{Request}} object also has an associated <dfn for=Request>headers</dfn> (null or a {{Headers}}
-object), initially null.
+<p>A {{Request}} object also has an associated <dfn for=Request export>headers</dfn> (null or a
+{{Headers}} object), initially null.
 
 <p>A {{Request}} object's <a for=Body>body</a> is its
 <a for=Request>request</a>'s
@@ -5177,8 +5177,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 <dfn id=concept-response-response for=Response export>response</dfn> (a
 <a for=/>response</a>).
 
-<p>A {{Response}} object also has an associated <dfn for=Response>headers</dfn> (a {{Headers}}
-object), initially null.
+<p>A {{Response}} object also has an associated <dfn for=Response export>headers</dfn> (null, or a
+{{Headers}} object), initially null.
 
 <p>A {{Response}} object also has an associated
 <dfn id=concept-response-trailer-promise for=Response>trailer promise</dfn> (a promise). <span class=note>Used

--- a/fetch.bs
+++ b/fetch.bs
@@ -4728,7 +4728,8 @@ omitted from <a enum><code>RequestMode</code></a> as it cannot be used nor obser
 <p>A {{Request}} object has an associated
 <dfn id=concept-request-request for=Request export>request</dfn> (a <a for=/>request</a>).
 
-<p>A {{Request}} object also has associated <dfn for=Request>headers</dfn> (a {{Headers}} object).
+<p>A {{Request}} object also has an associated <dfn for=Request>headers</dfn> (null or a {{Headers}}
+object), initially null.
 
 <p>A {{Request}} object's <a for=Body>body</a> is its
 <a for=Request>request</a>'s
@@ -4951,11 +4952,9 @@ constructor must run these steps:
 
  <li><p>Let <var>r</var> be a new {{Request}} object associated with <var>request</var>.
 
- <li><p>Let <var>headersObject</var> be a new {{Headers}} object, whose
+ <li><p>Set <var>r</var>'s <a for=Request>headers</a> to a new {{Headers}} object, whose
  <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
  <a for=Headers>guard</a> is "<code>request</code>".
-
- <li><p>Set <var>r</var>'s <a for=Request>headers</a> to <var>headersObject</var>.
 
  <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
  associated <a for=Headers>header list</a>.
@@ -5178,7 +5177,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 <dfn id=concept-response-response for=Response export>response</dfn> (a
 <a for=/>response</a>).
 
-<p>A {{Response}} object also has associated <dfn for=Response>headers</dfn> (a {{Headers}} object).
+<p>A {{Response}} object also has an associated <dfn for=Response>headers</dfn> (a {{Headers}}
+object), initially null.
 
 <p>A {{Response}} object also has an associated
 <dfn id=concept-response-trailer-promise for=Response>trailer promise</dfn> (a promise). <span class=note>Used
@@ -5200,11 +5200,9 @@ constructor, when invoked, must run these steps:
 
  <li><p>Let <var>r</var> be a new {{Response}} object associated with a new <a for=/>response</a>.
 
- <li><p>Let <var>headersObject</var> be a new {{Headers}} object, whose
+ <li><p>Set <var>r</var>'s <a for=Response>headers</a> to a new {{Headers}} object, whose
  <a for=Headers>header list</a> is <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>header list</a>, and <a for=Headers>guard</a> is "<code>response</code>".
-
- <li><p>Set <var>r</var>'s <a for=Response>headers</a> to <var>headersObject</var>.
 
  <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>status</a> to <var>init</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -5177,7 +5177,7 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 <dfn id=concept-response-response for=Response export>response</dfn> (a
 <a for=/>response</a>).
 
-<p>A {{Response}} object also has an associated <dfn for=Response export>headers</dfn> (null, or a
+<p>A {{Response}} object also has an associated <dfn for=Response export>headers</dfn> (null or a
 {{Headers}} object), initially null.
 
 <p>A {{Response}} object also has an associated

--- a/fetch.bs
+++ b/fetch.bs
@@ -292,15 +292,16 @@ for consistency.
 
 <h4 id=terminology-headers>Headers</h4>
 
-<p>A <dfn export id=concept-header-list>header list</dfn> consists of zero or more <a>headers</a>.
+<p>A <dfn export id=concept-header-list>header list</dfn> consists of zero or more
+<a for=/>headers</a>.
 
 <p class="note no-backref">A <a for=/>header list</a> is essentially a
 specialized multimap. An ordered list of key-value pairs with potentially duplicate keys.
 
 <p>A <a for=/>header list</a> (<var>list</var>)
 <dfn export for="header list" lt="contains|does not contain">contains</dfn> a <a for=header>name</a>
-(<var>name</var>) if <var>list</var> contains a <a>header</a> whose <a for=header>name</a> is a
-<a>byte-case-insensitive</a> match for <var>name</var>.
+(<var>name</var>) if <var>list</var> contains a <a for=/>header</a> whose <a for=header>name</a> is
+a <a>byte-case-insensitive</a> match for <var>name</var>.
 
 <p>To <dfn export for="header list" id=concept-header-list-append>append</dfn> a
 <a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair to a
@@ -309,20 +310,20 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 <ol>
  <li>
   <p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set <var>name</var>
-  to the first such <a>header</a>'s <a for=header>name</a>.
+  to the first such <a for=/>header</a>'s <a for=header>name</a>.
 
   <p class="note no-backref">This reuses the casing of the <a for=header>name</a> of the
-  <a>header</a> already in the <a for=/>header list</a>, if any. If there are multiple matched
-  <a>headers</a> their <a for=header>names</a> will all be identical.
+  <a for=/>header</a> already in the <a for=/>header list</a>, if any. If there are multiple matched
+  <a for=/>headers</a> their <a for=header>names</a> will all be identical.
   <!-- XXX Firefox and Safari adjust known header names too. -->
 
- <li><p>Append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
+ <li><p>Append a new <a for=/>header</a> whose <a for=header>name</a> is <var>name</var> and
  <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-delete>delete</dfn> a
 <a for=header>name</a> (<var>name</var>) from a <a for=/>header list</a> (<var>list</var>), remove
-all <a>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for
+all <a for=/>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for
 <var>name</var> from <var>list</var>.
 
 <p>To <dfn export for="header list" id=concept-header-list-set>set</dfn> a
@@ -331,10 +332,11 @@ all <a>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a
 
 <ol>
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
- <a for=header>value</a> of the first such <a>header</a> to <var>value</var> and remove the others.
+ <a for=header>value</a> of the first such <a for=/>header</a> to <var>value</var> and remove the
+ others.
 
- <li><p>Otherwise, append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
- <a for=header>value</a> is <var>value</var> to <var>list</var>.
+ <li><p>Otherwise, append a new <a for=/>header</a> whose <a for=header>name</a> is <var>name</var>
+ and <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
@@ -343,11 +345,11 @@ all <a>headers</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a
 
 <ol>
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
- <a for=header>value</a> of the first such <a>header</a> to its <a for=header>value</a>, followed
- by 0x2C 0x20, followed by <var>value</var>.
+ <a for=header>value</a> of the first such <a for=/>header</a> to its <a for=header>value</a>,
+ followed by 0x2C 0x20, followed by <var>value</var>.
 
- <li><p>Otherwise, append a new <a>header</a> whose <a for=header>name</a> is <var>name</var> and
- <a for=header>value</a> is <var>value</var> to <var>list</var>.
+ <li><p>Otherwise, append a new <a for=/>header</a> whose <a for=header>name</a> is <var>name</var>
+ and <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
 <p class="note no-backref"><a for="header list">Combine</a> is used by {{XMLHttpRequest}} and the
@@ -364,8 +366,8 @@ a <a for=/>header list</a> (<var>list</var>), run these steps:
  <a for=header>value</a>.
 
  <li><p>Let <var>names</var> be all the <a lt=name for=header>names</a> of the
- <a>headers</a> in <var>list</var>, <a>byte-lowercased</a>, with duplicates removed, and finally
- sorted lexicographically.
+ <a for=/>headers</a> in <var>list</var>, <a>byte-lowercased</a>, with duplicates removed, and
+ finally sorted lexicographically.
 
  <li>
   <p>For each <var>name</var> in <var>names</var>, run these substeps:
@@ -407,14 +409,14 @@ production as
 
 <p>A <dfn export for=header id=concept-header-value-combined>combined value</dfn>, given a
 <a for=header>name</a> (<var>name</var>) and <a for=/>header list</a> (<var>list</var>), is the
-<a lt=value for=header>values</a> of all <a>headers</a> in <var>list</var> whose
+<a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var> whose
 <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated from
 each other by 0x2C 0x20, in order.
 
 <hr>
 
-<p id=simple-header>A <dfn export>CORS-safelisted request-header</dfn> is a <a>header</a> whose
-<a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
+<p id=simple-header>A <dfn export>CORS-safelisted request-header</dfn> is a <a for=/>header</a>
+whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
 
 <ul class=brief>
  <li>`<code>Accept</code>`
@@ -446,7 +448,7 @@ failure.
 for `<code>Authorization</code>`.
 
 <p>A <dfn export>CORS-safelisted response-header name</dfn>, given a
-<a for=response>CORS-exposed header-name list</a> <var>list</var>, is a <a>header</a>
+<a for=response>CORS-exposed header-name list</a> <var>list</var>, is a <a for=/>header</a>
 <a for=header>name</a> that is a <a>byte-case-insensitive</a> match for one of
 
 <ul class=brief>
@@ -460,8 +462,8 @@ for `<code>Authorization</code>`.
  <a>forbidden response-header name</a>.
 </ul>
 
-<p>A <dfn export>forbidden header name</dfn> is a <a>header</a> <a for=header>name</a> that is a
-<a>byte-case-insensitive</a> match for one of
+<p>A <dfn export>forbidden header name</dfn> is a <a for=/>header</a> <a for=header>name</a> that
+is a <a>byte-case-insensitive</a> match for one of
 
 <ul class=brief>
  <li>`<code>Accept-Charset</code>`
@@ -486,21 +488,21 @@ for `<code>Authorization</code>`.
  <li>`<code>Via</code>`
 </ul>
 
-<p>or a <a>header</a> <a for=header>name</a> that
+<p>or a <a for=/>header</a> <a for=header>name</a> that
 starts with a <a>byte-case-insensitive</a> match for `<code>Proxy-</code>` or `<code>Sec-</code>`
 (including being a <a>byte-case-insensitive</a> match for just `<code>Proxy-</code>` or
 `<code>Sec-</code>`).
 
 <p class=note>These are forbidden so the user agent remains in full control over them.
 <a for=header>Names</a> starting with `<code>Sec-</code>` are
-reserved to allow new <a>headers</a> to be minted that are safe
+reserved to allow new <a for=/>headers</a> to be minted that are safe
 from APIs using <a for=/>fetch</a> that allow control over
-<a>headers</a> by developers, such as
+<a for=/>headers</a> by developers, such as
 {{XMLHttpRequest}}.
 [[XHR]]
 
-<p>A <dfn export>forbidden response-header name</dfn> is a <a>header</a> <a for=header>name</a> that
-is a <a>byte-case-insensitive</a> match for one of:
+<p>A <dfn export>forbidden response-header name</dfn> is a <a for=/>header</a>
+<a for=header>name</a> that is a <a>byte-case-insensitive</a> match for one of:
 
 <ul class=brief>
  <li>`<code>Set-Cookie</code>`
@@ -510,7 +512,7 @@ is a <a>byte-case-insensitive</a> match for one of:
 <hr>
 
 <p>To <dfn export lt="extract header values|extracting header values">extract header values</dfn>
-given a <a>header</a> <var>header</var>, run these steps:
+given a <a for=/>header</a> <var>header</var>, run these steps:
 
 <ol>
  <li><p>If parsing <var>header</var>'s <a for=header>value</a>, per the <a>ABNF</a> for
@@ -530,17 +532,18 @@ run these steps:
  null.
 
  <li>
-  <p>If the <a>ABNF</a> for <var>name</var> allows a single <a>header</a> and <var>list</var>
+  <p>If the <a>ABNF</a> for <var>name</var> allows a single <a for=/>header</a> and <var>list</var>
   <a for="header list">contains</a> more than one, then return failure.
 
   <p class="note no-backref">If different error handling is needed, extract the desired
-  <a>header</a> first.
+  <a for=/>header</a> first.
 
  <li><p>Let <var>values</var> be an empty <a for=/>list</a>.
 
  <li>
-  <p>For each <a>header</a> <var>header</var> <var>list</var> <a for="header list">contains</a>
-  whose <a for=header>name</a> is <var>name</var>, run these substeps:
+  <p>For each <a for=/>header</a> <var>header</var> <var>list</var>
+  <a for="header list">contains</a> whose <a for=header>name</a> is <var>name</var>, run these
+  substeps:
 
   <ol>
    <li><p>Let <var>extract</var> be the result of <a>extracting header values</a> from
@@ -571,7 +574,7 @@ from a <a for=/>header list</a> (<var>headers</var>), run these steps:
 
 <p>A <dfn id=default-user-agent-value export>default `<code>User-Agent</code>` value</dfn> is a
 user-agent-defined <a for=header>value</a> for the
-`<code>User-Agent</code>` <a>header</a>.
+`<code>User-Agent</code>` <a for=/>header</a>.
 
 
 <h4 id=statuses>Statuses</h4>
@@ -1293,7 +1296,7 @@ specified. [[!CSP]]
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</dfn>
-(a list of zero or more <a>header</a>
+(a list of zero or more <a for=/>header</a>
 <a lt=name for=header>names</a>). The list is empty unless otherwise specified.
 
 <p class="note no-backref">A <a for=/>response</a> will typically get its
@@ -1344,7 +1347,7 @@ which is only "accessible" to internal specification algorithms and is never a
 <a>filtered response</a> whose
 <a for=response>type</a> is "<code>basic</code>" and
 <a for=response>header list</a> excludes any
-<a>headers</a> in
+<a for=/>headers</a> in
 <a for=internal>internal response</a>'s
 <a for=response>header list</a> whose
 <a for=header>name</a> is a
@@ -1354,7 +1357,7 @@ which is only "accessible" to internal specification algorithms and is never a
 <a>filtered response</a> whose
 <a for=response>type</a> is "<code>cors</code>",
 <a for=response>header list</a> excludes any
-<a>headers</a> in
+<a for=/>headers</a> in
 <a for=internal>internal response</a>'s
 <a for=response>header list</a> whose
 <a for=header>name</a> is <em>not</em> a
@@ -1842,7 +1845,7 @@ if the result of calling
 <h3 id=origin-header>`<code>Origin</code>` header</h3>
 
 <p>The `<dfn export http-header id=http-origin><code>Origin</code></dfn>`
-request <a>header</a> indicates where a
+request <a for=/>header</a> indicates where a
 <a for=/>fetch</a> originates from.
 
 <p class="note no-backref">The `<a http-header><code>Origin</code></a>` header is a version
@@ -1864,7 +1867,7 @@ origin-or-null                   = origin / %x6E.75.6C.6C ; "null", case-sensiti
 origin                           = <a for=url>scheme</a> "://" <a for=url>host</a> [ ":" <a for=url>port</a> ]</pre>
 
 <p class="note no-backref">This supplants the `<code>Origin</code>`
-<a>header</a>.
+<a for=/>header</a>.
 [[ORIGIN]]
 
 
@@ -1907,7 +1910,7 @@ all <a for=/>requests</a> whose <a for=request>method</a> is neither `<code>GET<
 <p>A <dfn id=cors-preflight-request export>CORS-preflight request</dfn> is a <a>CORS request</a> that checks to see
 if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
 <a for=/>method</a> and includes these
-<a>headers</a>:
+<a for=/>headers</a>:
 
 <dl>
  <dt>`<dfn export http-header id=http-access-control-request-method><code>Access-Control-Request-Method</code></dfn>`
@@ -1915,7 +1918,7 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
  <a>CORS request</a> to the same resource might use.
 
  <dt>`<dfn export http-header id=http-access-control-request-headers><code>Access-Control-Request-Headers</code></dfn>`
- <dd><p>Indicates which <a>headers</a> a future
+ <dd><p>Indicates which <a for=/>headers</a> a future
  <a>CORS request</a> to the same resource might use.
 </dl>
 
@@ -1923,13 +1926,13 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
 <h4 id=http-responses>HTTP responses</h4>
 
 <p>An HTTP response to a <a>CORS request</a> can include the following
-<a>headers</a>:
+<a for=/>headers</a>:
 
 <dl>
  <dt>`<dfn export http-header id=http-access-control-allow-origin><code>Access-Control-Allow-Origin</code></dfn>`
  <dd><p>Indicates whether the response can be shared, via returning the literal
  <a for=header>value</a> of the
- `<a http-header><code>Origin</code></a>` request <a>header</a>
+ `<a http-header><code>Origin</code></a>` request <a for=/>header</a>
  (which can be `<code>null</code>`) or `<code>*</code>` in a response.
 
  <dt>`<dfn export http-header id=http-access-control-allow-credentials><code>Access-Control-Allow-Credentials</code></dfn>`
@@ -1948,7 +1951,7 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
 </dl>
 
 <p>An HTTP response to a <a>CORS-preflight request</a> can include the following
-<a>headers</a>:
+<a for=/>headers</a>:
 
 <dl>
  <dt>`<dfn export http-header id=http-access-control-allow-methods><code>Access-Control-Allow-Methods</code></dfn>`
@@ -1957,27 +1960,27 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
   <a for=/>response</a>'s <a for=response>url</a> for the
   purposes of the <a>CORS protocol</a>.
 
-  <p class=note>The `<code>Allow</code>` <a>header</a> is
+  <p class=note>The `<code>Allow</code>` <a for=/>header</a> is
   not relevant for the purposes of the <a>CORS protocol</a>.
 
  <dt>`<dfn export http-header id=http-access-control-allow-headers><code>Access-Control-Allow-Headers</code></dfn>`
- <dd><p>Indicates which <a>headers</a> are supported by the
+ <dd><p>Indicates which <a for=/>headers</a> are supported by the
  <a for=/>response</a>'s <a for=response>url</a> for the
  purposes of the <a>CORS protocol</a>.
 
  <dt>`<dfn export http-header id=http-access-control-max-age><code>Access-Control-Max-Age</code></dfn>`
  <dd><p>Indicates how long the information provided by the
  `<a http-header><code>Access-Control-Allow-Methods</code></a>` and
- `<a http-header><code>Access-Control-Allow-Headers</code></a>` <a>headers</a> can be cached.
+ `<a http-header><code>Access-Control-Allow-Headers</code></a>` <a for=/>headers</a> can be cached.
 </dl>
 
 <p>An HTTP response to a <a>CORS request</a> that is not a
 <a>CORS-preflight request</a> can also include the following
-<a>header</a>:
+<a for=/>header</a>:
 
 <dl>
  <dt>`<dfn export http-header id=http-access-control-expose-headers><code>Access-Control-Expose-Headers</code></dfn>`
- <dd><p>Indicates which <a>headers</a> can be exposed as part
+ <dd><p>Indicates which <a for=/>headers</a> can be exposed as part
  of the response by listing their <a lt=name for=header>names</a>.
 </dl>
 
@@ -1985,14 +1988,14 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
 
 <p>In case a server does not wish to participate in the <a>CORS protocol</a>, its HTTP response to
 the <a lt="CORS request">CORS</a> or <a>CORS-preflight request</a> must not include any of the above
-<a>headers</a>. The server is encouraged to use the <code>403</code> <a for=/>status</a> in such
-HTTP responses.
+<a for=/>headers</a>. The server is encouraged to use the <code>403</code> <a for=/>status</a> in
+such HTTP responses.
 
 
 <h4 id=http-new-header-syntax>HTTP new-header syntax</h4>
 
 <p><a>ABNF</a> for the <a lt=value for=header>values</a> of the
-<a>headers</a> used by the <a>CORS protocol</a>:
+<a for=/>headers</a> used by the <a>CORS protocol</a>:
 
 <pre>
 Access-Control-Request-Method    = <a spec=http>method</a>
@@ -2053,9 +2056,9 @@ with <a for=/>credentials</a> is rather unsafe, and extreme care has to be taken
 
 <p>To share responses with <a for=/>credentials</a>, the
 `<a http-header><code>Access-Control-Allow-Origin</code></a>` and
-`<a http-header><code>Access-Control-Allow-Credentials</code></a>` <a>headers</a> are important. The
-following table serves to illustrate the various legal and illegal combinations for a request to
-<code>https://rabbit.invalid/</code>:
+`<a http-header><code>Access-Control-Allow-Credentials</code></a>` <a for=/>headers</a> are
+important. The following table serves to illustrate the various legal and illegal combinations for a
+request to <code>https://rabbit.invalid/</code>:
 
 <table>
  <tbody><tr>
@@ -2210,9 +2213,9 @@ Access-Control-Allow-Credentials: true</pre>
 
 <p>The
 `<dfn export http-header id=http-x-content-type-options><code>X-Content-Type-Options</code></dfn>`
-response <a>header</a> can be used to require checking of a
+response <a for=/>header</a> can be used to require checking of a
 <a for=/>response</a>'s `<code>Content-Type</code>`
-<a>header</a> against the
+<a for=/>header</a> against the
 <a for=request>type</a> of a
 <a for=/>request</a>.
 
@@ -2233,8 +2236,8 @@ X-Content-Type-Options           = "nosniff" ; case-insensitive</pre>
  then return <b>allowed</b>.
 
  <li><p>Let <var>nosniff</var> be the result of <a>extracting header values</a> from the
- <em>first</em> <a>header</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match
- for `<a http-header><code>X-Content-Type-Options</code></a>` in <var>response</var>'s
+ <em>first</em> <a for=/>header</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a>
+ match for `<a http-header><code>X-Content-Type-Options</code></a>` in <var>response</var>'s
  <a for=response>header list</a>.
 
  <li><p>If <var>nosniff</var> is failure, then return <b>allowed</b>.
@@ -2363,8 +2366,8 @@ the request.
 
  <li>
   <p>If <var>request</var> is a <a>navigation request</a>, a user agent should, for each
-  <a>header</a> <a for=header>name</a> (<var>hintName</var>) in the first column of the following
-  table, if <var>request</var>'s <a for=request>header list</a>
+  <a for=/>header</a> <a for=header>name</a> (<var>hintName</var>) in the first column of the
+  following table, if <var>request</var>'s <a for=request>header list</a>
   <a for="header list">does not contain</a> <var>hintName</var>, then
   <a for="header list">append</a>
   <var>hintName</var>/the value given in the same row on the second column, to <var>request</var>'s
@@ -2576,7 +2579,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <dt><var>request</var>'s <a>use-CORS-preflight flag</a> is set
    <dt><var>request</var>'s <a>unsafe-request flag</a> is set and either <var>request</var>'s
    <a for=request>method</a> is not a <a>CORS-safelisted method</a> or
-   a <a>header</a> in <var>request</var>'s
+   a <a for=/>header</a> in <var>request</var>'s
    <a for=request>header list</a> is not a
    <a>CORS-safelisted request-header</a>
    <dd>
@@ -2630,7 +2633,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
      <a for=request>credentials mode</a> is not
      "<code>include</code>", then set <var>response</var>'s
      <a for=response>CORS-exposed header-name list</a>
-     to all unique <a>header</a>
+     to all unique <a for=/>header</a>
      <a lt=name for=header>names</a> in <var>response</var>'s
      <a for=response>header list</a>.
 
@@ -2778,7 +2781,7 @@ steps:
   <a for=url>path</a> contains a single string
   "<code>blank</code>", return a <a for=/>response</a> whose
   <a for=response>header list</a> consist of a single
-  <a>header</a> whose
+  <a for=/>header</a> whose
   <a for=header>name</a> is `<code>Content-Type</code>` and
   <a for=header>value</a> is
   `<code>text/html;charset=utf-8</code>`,
@@ -2842,7 +2845,7 @@ steps:
   <var>request</var>'s <a for=request>current url</a> does not return
   failure, then return a <a for=/>response</a> whose
   <a for=response>header list</a> consist of a single
-  <a>header</a> whose <a for=header>name</a> is
+  <a for=/>header</a> whose <a for=header>name</a> is
   `<code>Content-Type</code>` and <a for=header>value</a> is the
   MIME type and parameters returned from
   <a href=https://simonsapin.github.io/data-urls/>obtaining a resource</a>,
@@ -2964,7 +2967,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
      <a>CORS-safelisted method</a> or <var>request</var>'s
      <a>use-CORS-preflight flag</a> is set.
 
-     <li>There is at least one <a>header</a> in
+     <li>There is at least one <a for=/>header</a> in
      <var>request</var>'s <a for=request>header list</a>
      for whose <a for=header>name</a> there is no
      <a for=cache>header-name cache match</a> using
@@ -3334,7 +3337,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
   <a for=request>header list</a> per HTTP.
 
   <p class="note no-backref">It would be great if we could make this more normative
-  somehow. At this point <a>headers</a> such as
+  somehow. At this point <a for=/>headers</a> such as
   `<code>Accept-Encoding</code>`,
   `<code>Connection</code>`,
   `<code>DNT</code>`, and
@@ -3433,7 +3436,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     "<code>only-if-cached</code>", then set <var>response</var> to <var>storedResponse</var> and
     abort these substeps.
 
-    <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>` <a>header</a>
+    <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>` <a for=/>header</a>
     into account.
 
    <li>
@@ -3630,7 +3633,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
   <ul>
    <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
-   <li><p>Wait until all the <a>headers</a> are transmitted or
+   <li><p>Wait until all the <a for=/>headers</a> are transmitted or
    <a for=/>fetch</a> is being
    <a for=fetch>terminated</a> with reason <var>reason</var>. If
    <a for=/>fetch</a> is being
@@ -3782,7 +3785,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
       content codings</a> given <var>codings</var> and <var>bytes</var>.
 
       <p class="note no-backref">This makes the `<code>Content-Length</code>`
-      <a>header</a> unreliable to the extent that it was reliable
+      <a for=/>header</a> unreliable to the extent that it was reliable
       to begin with.
 
      <li>
@@ -3863,7 +3866,7 @@ steps:
 
  <li><p>Let <var>headers</var> be the <a lt=name for=header>names</a> of
  <var>request</var>'s <a for=request>header list</a>'s
- <a>headers</a>, excluding
+ <a for=/>headers</a>, excluding
  <a>CORS-safelisted request-headers</a> and duplicates,
  sorted lexicographically, and <a lt="byte-lowercase">byte-lowercased</a>.
 
@@ -3938,7 +3941,7 @@ steps:
 
    <li><p>If one of <var>request</var>'s <a for=request>header list</a>'
    <a lt=name for=header>names</a> is not a <a>byte-case-insensitive</a> match for an
-   <a for=list>item</a> in <var>headerNames</var>, its corresponding <a>header</a> is not a
+   <a for=list>item</a> in <var>headerNames</var>, its corresponding <a for=/>header</a> is not a
    <a>CORS-safelisted request-header</a>, and <var>headerNames</var> does not contain
    `<code>*</code>`, then return a <a>network error</a>.
 
@@ -3994,7 +3997,7 @@ entries where each entry has these fields:
  <li><dfn id=concept-cache-method for=cache>method</dfn> (null, `<code>*</code>`, or a
  <a for=/>method</a>)
  <li><dfn id=concept-cache-header-name for=cache>header name</dfn> (null, `<code>*</code>`, or a
- <a>header</a> <a for=header>name</a>)
+ <a for=/>header</a> <a for=header>name</a>)
 </ul>
 
 <p>Entries must be removed after the seconds specified in the
@@ -4725,9 +4728,7 @@ omitted from <a enum><code>RequestMode</code></a> as it cannot be used nor obser
 <p>A {{Request}} object has an associated
 <dfn id=concept-request-request for=Request export>request</dfn> (a <a for=/>request</a>).
 
-<p>A {{Request}} object also has an associated {{Headers}} object which
-is itself associated with <a for=Request>request</a>'s
-<a for=request>header list</a>.
+<p>A {{Request}} object also has associated <dfn for=Request>headers</dfn> (a {{Headers}} object).
 
 <p>A {{Request}} object's <a for=Body>body</a> is its
 <a for=Request>request</a>'s
@@ -4930,7 +4931,7 @@ constructor must run these steps:
  <var>request</var>'s
  <a for=request>integrity metadata</a> to it.
 
-<li><p>If <var>init</var>'s <code>keepalive</code> member is present, then set <var>request</var>'s
+ <li><p>If <var>init</var>'s <code>keepalive</code> member is present, then set <var>request</var>'s
  <a>keepalive flag</a> if <var>init</var>'s <code>keepalive</code> member is true, and unset
  it otherwise.
 
@@ -4948,19 +4949,22 @@ constructor must run these steps:
    to <var>method</var>.
   </ol>
 
- <li><p>Let <var>r</var> be a new {{Request}} object associated with <var>request</var> and
- a new associated {{Headers}} object whose <a for=Headers>guard</a>
- is "<code>request</code>".
+ <li><p>Let <var>r</var> be a new {{Request}} object associated with <var>request</var>.
 
- <li><p>Let <var>headers</var> be a copy of <var>r</var>'s {{Headers}} object and its
+ <li><p>Let <var>headersObject</var> be a new {{Headers}} object, whose
+ <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
+ <a for=Headers>guard</a> is "<code>request</code>".
+
+ <li><p>Set <var>r</var>'s <a for=Request>headers</a> to <var>headersObject</var>.
+
+ <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
  associated <a for=Headers>header list</a>.
  <!-- it might contain a header that is no longer allowed per the mode change -->
 
  <li><p>If <var>init</var>'s <code>headers</code> member is present, set
  <var>headers</var> to <var>init</var>'s <code>headers</code> member.
 
- <li><p>Empty <var>r</var>'s {{Headers}} object's
- <a for=Headers>header list</a>.
+ <li><p>Empty <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
 
  <li>
   <p>If <var>r</var>'s <a for=Request>request</a>'s
@@ -4974,12 +4978,12 @@ constructor must run these steps:
    <li><p>If <var>request</var>'s <a for=request>integrity metadata</a> is not the empty string,
    then <a>throw</a> a <code>TypeError</code>.
 
-   <li><p>Set <var>r</var>'s {{Headers}} object's
-   <a for=Headers>guard</a> to "<code>request-no-cors</code>".
+   <li><p>Set <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
+   "<code>request-no-cors</code>".
   </ol>
 
- <li><p><a lt=fill for=Headers>Fill</a> <var>r</var>'s
- {{Headers}} object with <var>headers</var>. Rethrow any exceptions.
+ <li><p><a lt=fill for=Headers>Fill</a> <var>r</var>'s <a for=Request>headers</a> with
+ <var>headers</var>. Rethrow any exceptions.
 
  <li><p>Let <var>inputBody</var> be <var>input</var>'s
  <a for=Request>request</a>'s <a for=request>body</a>
@@ -5007,11 +5011,11 @@ constructor must run these steps:
    <a lt=extract for=BodyInit>extracting</a> <var>init</var>'s
    <code>body</code> member. Rethrow any exceptions.
 
-   <li><p>If <var>Content-Type</var> is non-null and <var>r</var>'s {{Headers}} object's
+   <li><p>If <var>Content-Type</var> is non-null and <var>r</var>'s <a for=Request>headers</a>'s
    <a for=Headers>header list</a> <a for="header list">does not contain</a>
    `<code>Content-Type</code>`, then <a for=Headers>append</a>
-   `<code>Content-Type</code>`/<var>Content-Type</var> to <var>r</var>'s
-   {{Headers}} object. Rethrow any exception.
+   `<code>Content-Type</code>`/<var>Content-Type</var> to <var>r</var>'s <a for=Request>headers</a>.
+   Rethrow any exception.
   </ol>
 
  <li>
@@ -5068,8 +5072,8 @@ return <a for=Request>request</a>'s
 <a for=request>url</a>,
 <a lt="url serializer">serialized</a>.
 
-<p>The <dfn attribute for=Request><code>headers</code></dfn> attribute's getter must
-return the associated {{Headers}} object.
+<p>The <dfn attribute for=Request><code>headers</code></dfn> attribute's getter must return the
+associated <a for=Request>headers</a>.
 
 <p>The <dfn attribute for=Request><code>type</code></dfn> attribute's getter must return
 <a for=Request>request</a>'s
@@ -5124,10 +5128,19 @@ run these steps:
  <li><p>If this {{Request}} object is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then
  <a>throw</a> a <code>TypeError</code>.
 
- <li><p>Return a new {{Request}} object associated with the result of
- <a lt=clone for=request>cloning</a> <a for=Request>request</a> and a new associated {{Headers}}
- object whose <a for=Headers>guard</a> is <a>context object</a>'s {{Headers}} object's
- <a for=Headers>guard</a>.
+ <li><p>Let <var>clonedRequestObject</var> be a new {{Request}} object.
+
+ <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a>
+ <a>context object</a>'s <a for=Request>request</a>.
+
+ <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>request</a> to <var>clonedRequest</var>.
+
+ <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
+ whose <a for=Headers>header list</a> is set to <var>clonedRequest</var>'s
+ <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
+ <a for=Request>headers</a>' <a for=Headers>guard</a>.
+
+ <li><p>Return <var>clonedRequestObject</var>.
 </ol>
 
 
@@ -5165,9 +5178,7 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 <dfn id=concept-response-response for=Response export>response</dfn> (a
 <a for=/>response</a>).
 
-<p>A {{Response}} object also has an associated {{Headers}} object which
-is itself associated with <a for=Response>response</a>'s
-<a for=response>header list</a>.
+<p>A {{Response}} object also has associated <dfn for=Response>headers</dfn> (a {{Headers}} object).
 
 <p>A {{Response}} object also has an associated
 <dfn id=concept-response-trailer-promise for=Response>trailer promise</dfn> (a promise). <span class=note>Used
@@ -5187,9 +5198,13 @@ constructor, when invoked, must run these steps:
  <li><p>If <var>init</var>'s <code>statusText</code> member does not match the
  <a spec=http>reason-phrase</a> token production, then <a>throw</a> a <code>TypeError</code>.
 
- <li><p>Let <var>r</var> be a new {{Response}} object, associated with a new
- <a for=/>response</a> and a new associated {{Headers}} object whose
- <a for=Headers>guard</a> is "<code>response</code>".
+ <li><p>Let <var>r</var> be a new {{Response}} object associated with a new <a for=/>response</a>.
+
+ <li><p>Let <var>headersObject</var> be a new {{Headers}} object, whose
+ <a for=Headers>header list</a> is <var>r</var>'s <a for=Response>response</a>'s
+ <a for=response>header list</a>, and <a for=Headers>guard</a> is "<code>response</code>".
+
+ <li><p>Set <var>r</var>'s <a for=Response>headers</a> to <var>headersObject</var>.
 
  <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>status</a> to <var>init</var>'s
@@ -5200,8 +5215,8 @@ constructor, when invoked, must run these steps:
  <var>init</var>'s <code>statusText</code> member.
 
  <li><p>If <var>init</var>'s <code>headers</code> member is present, then <a for=Headers>fill</a>
- <var>r</var>'s {{Headers}} object with <var>init</var>'s <code>headers</code> member. Rethrow any
- exceptions.
+ <var>r</var>'s <a for=Response>headers</a> with <var>init</var>'s <code>headers</code> member.
+ Rethrow any exceptions.
 
  <li>
   <p>If <var>body</var> is non-null, run these substeps:
@@ -5243,10 +5258,18 @@ constructor, when invoked, must run these steps:
  <li><p>Return <var>r</var>.
 </ol>
 
-<p>The static <dfn method for=Response><code>error()</code></dfn> method, when invoked, must
-return a new {{Response}} object, associated with a new
-<a>network error</a> and a new associated {{Headers}}
-object whose <a for=Headers>guard</a> is "<code>immutable</code>".
+<p>The static <dfn method for=Response><code>error()</code></dfn> method, when invoked, must run
+these steps:
+
+<ol>
+ <li><p>Let <var>r</var> be a new {{Response}} object, whose <a for=Response>response</a> is a new
+ <a>network error</a>.
+
+ <li><p>Set <var>r</var>'s <a for=Response>headers</a> to a new {{Headers}} object whose
+ <a for=Headers>guard</a> is "<code>immutable</code>".
+
+ <li><p>Return <var>r</var>.
+</ol>
 
 <p>The static
 <dfn method for=Response><code>redirect(<var>url</var>, <var>status</var>)</code></dfn>
@@ -5263,8 +5286,10 @@ method, when invoked, must run these steps:
  <li><p>If <var>status</var> is not a <a>redirect status</a>, then <a>throw</a> a
  <code>RangeError</code>.
 
- <li><p>Let <var>r</var> be a new {{Response}} object, associated with a new
- <a for=/>response</a> and a new associated {{Headers}} object whose
+ <li><p>Let <var>r</var> be a new {{Response}} object, whose <a for=Response>response</a> is a new
+ <a for=/>response</a>.
+
+ <li><p>Set <var>r</var>'s <a for=Response>headers</a> to a new {{Headers}} object whose
  <a for=Headers>guard</a> is "<code>immutable</code>".
 
  <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
@@ -5325,15 +5350,25 @@ run these steps:
  <li><p>If <a>context object</a> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then
  <a>throw</a> a <code>TypeError</code>.
 
- <li><p>Let <var>clonedResponse</var> be a new {{Response}} object associated with the result of
- <a lt=clone for=response>cloning</a> <a>context object</a>'s <a for=Response>response</a> and a new
- associated {{Headers}} object whose <a for=Headers>guard</a> is <a>context object</a>'s {{Headers}}
- object's <a for=Headers>guard</a>.
+ <li><p>Let <var>clonedResponseObject</var> be a new {{Response}} object.
+
+ <li><p>Let <var>clonedResponse</var> be the result of <a lt=clone for=response>cloning</a>
+ <a>context object</a>'s <a for=Response>response</a>.
+
+ <li><p>Set <var>clonedResponseObject</var>'s <a for=Response>response</a> to
+ <var>clonedResponse</var>.
+
+ <li><p>Set <var>clonedResponseObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
+ whose <a for=Headers>header list</a> is set to <var>clonedResponse</var>'s
+ <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
+ <a for=Response>headers</a>' <a for=Headers>guard</a>.
 
  <li><p>Upon fulfillment of <a>context object</a>'s <a for=Response>trailer promise</a>, resolve
- <var>clonedResponse</var>'s <a for=Response>trailer promise</a> with a new {{Headers}} object whose
- <a for=Headers>guard</a> is "<code>immutable</code>" that is associated with
- <var>clonedResponse</var>'s <a for=response>trailer</a>.
+ <var>clonedResponseObject</var>'s <a for=Response>trailer promise</a> with a new {{Headers}} object
+ whose <a for=Headers>guard</a> is "<code>immutable</code>", and whose
+ <a for="Headers">header list</a> is <var>clonedResponse</var>'s <a for=response>trailer</a>.
+
+ <li><p>Return <var>clonedResponseObject</var>.
 
  <li><p>Return <var>clonedResponse</var>.
 </ol>
@@ -5553,7 +5588,7 @@ therefore not shareable, a WebSocket connection is very close to identical to an
 
  <li>
   <p>Let <var>permessageDeflate</var> be a user-agent defined
-  "<code>permessage-deflate</code>" extension <a>header</a>
+  "<code>permessage-deflate</code>" extension <a for=/>header</a>
   <a for=header>value</a>. [[!WSP]]
 
   <p id=example-permessage-deflate class=example>`<code>permessage-deflate; client_max_window_bits</code>`
@@ -5642,21 +5677,21 @@ scripting attack.
 <strong>unsafe</strong>. (This is the reason why the <a>CORS protocol</a> had to be
 invented.)
 
-<p>However, otherwise using the following <a>header</a> is
+<p>However, otherwise using the following <a for=/>header</a> is
 <strong>safe</strong>:
 
 <pre>
 Access-Control-Allow-Origin: *</pre>
 
 <p>Even if a resource exposes additional information based on cookie or HTTP
-authentication, using the above <a>header</a> will not reveal
+authentication, using the above <a for=/>header</a> will not reveal
 it. It will share the resource with APIs such as
 {{XMLHttpRequest}}, much like it is already shared with
 <code>curl</code> and <code>wget</code>.
 
 <p>Thus in other words, if a resource cannot be accessed from a random device connected to
 the web using <code>curl</code> and <code>wget</code> the aforementioned
-<a>header</a> is not to be included. If it can be accessed
+<a for=/>header</a> is not to be included. If it can be accessed
 however, it is perfectly fine to do so.
 
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/editorial-headers/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/c5a1394...032184d.html)