### PR TITLE
Editorial: add note on event listeners & preflight

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1003,10 +1003,10 @@ discouraged from using it for new features. It is rather unsafe. "<code>navigate
 <dfn id=use-cors-preflight-flag export for=request>use-CORS-preflight flag</dfn>. Unless stated
 otherwise, it is unset.
 
-<p class="note no-backref">The <a>use-CORS-preflight flag</a> being set is just one of several
-conditions that can result in a <a>CORS-preflight request</a>. The <a>use-CORS-preflight flag</a>
-will be set if either one or more event listeners are registered on an {{XMLHttpRequestUpload}}
-object, or else if a {{ReadableStream}} object is used for uploads.
+<p class="note no-backref">The <a>use-CORS-preflight flag</a> being set is one of several conditions
+that results in a <a>CORS-preflight request</a>. The <a>use-CORS-preflight flag</a> is set if either
+one or more event listeners are registered on an {{XMLHttpRequestUpload}} object or if a
+{{ReadableStream}} object is used in a request.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-credentials-mode>credentials mode</dfn>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1003,6 +1003,9 @@ discouraged from using it for new features. It is rather unsafe. "<code>navigate
 <dfn id=use-cors-preflight-flag export for=request>use-CORS-preflight flag</dfn>. Unless stated
 otherwise, it is unset.
 
+<p class="note no-backref">Registering one or more event listeners on an {{XMLHttpRequestUpload}}
+object is one condition that will cause the <a>use-CORS-preflight flag</a> to be set.
+
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-credentials-mode>credentials mode</dfn>,
 which is "<code>omit</code>", "<code>same-origin</code>", or

--- a/fetch.bs
+++ b/fetch.bs
@@ -1003,8 +1003,10 @@ discouraged from using it for new features. It is rather unsafe. "<code>navigate
 <dfn id=use-cors-preflight-flag export for=request>use-CORS-preflight flag</dfn>. Unless stated
 otherwise, it is unset.
 
-<p class="note no-backref">Registering one or more event listeners on an {{XMLHttpRequestUpload}}
-object is one condition that will cause the <a>use-CORS-preflight flag</a> to be set.
+<p class="note no-backref">The <a>use-CORS-preflight flag</a> being set is just one of several
+conditions that can result in a <a>CORS-preflight request</a>. The <a>use-CORS-preflight flag</a>
+will be set if either one or more event listeners are registered on an {{XMLHttpRequestUpload}}
+object, or else if a {{ReadableStream}} object is used for uploads.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-credentials-mode>credentials mode</dfn>,


### PR DESCRIPTION
We already have this in the XHR spec, but I think it would be helpful to
readers to also have a note in the Fetch spec at point of use, because the
Fetch spec is what gets cited at StackOverflow and such as the source for
requirements on what causes a preflight. So omitting mention of this case from
the Fetch spec risks making people (continue to) forget this is among the
things that could be causing a preflight they’re running into but that they
don’t understand the reason for or how to prevent it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/sideshowbarker/event-listeners-and-preflight/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/07999e9...7bfea5c.html)