### PR TITLE
Using integrity with "no-cors" is fine same-origin

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4979,9 +4979,6 @@ constructor must run these steps:
    <li><p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
    <a>CORS-safelisted method</a>, then <a>throw</a> a <code>TypeError</code>.
 
-   <li><p>If <var>request</var>'s <a for=request>integrity metadata</a> is not the empty string,
-   then <a>throw</a> a <code>TypeError</code>.
-
    <li><p>Set <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
    "<code>request-no-cors</code>".
   </ol>


### PR DESCRIPTION
This exception also broke simple service worker passthrough handling.

Tests: ...

Fixes #583.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/no-cors-integrity/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/8a91018...334d67a.html)