### PR TITLE
Make fetch() use "same-origin" credentials by default

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4774,7 +4774,7 @@ constructor must run these steps:
 
    <li><p>Set <var>fallbackMode</var> to "<code>cors</code>".
 
-   <li><p>Set <var>fallbackCredentials</var> to "<code>omit</code>".
+   <li><p>Set <var>fallbackCredentials</var> to "<code>same-origin</code>".
   </ol>
 
  <li>


### PR DESCRIPTION
Most features in the platform have this default and not having this default causes multiple connections in contemporary implementations. It also causes confusion as switching from XMLHttpRequest to fetch() is not as seamless as it could be.

Making this change will also make it easier for <script type=module> to have this default as per discussion in https://github.com/whatwg/html/issues/2557.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/fetch-api-credentials-mode/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/8a91018...5550bf9.html)