### PR TITLE
Add `Last-Event-ID` as CORS-safelisted request-header

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -426,6 +426,7 @@ whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
  <a lt="extract header values">once extracted</a>, has a MIME type (ignoring parameters)
  that is `<code>application/x-www-form-urlencoded</code>`,
  `<code>multipart/form-data</code>`, or `<code>text/plain</code>`
+ <li>`<code>Last-Event-ID</code>`
 </ul>
 <!-- XXX * needs better xref
          * ignoring parameters has been the standard for a long time now


### PR DESCRIPTION
It turns out that you can set the Last-Event-ID request header to arbitrary values and get it across origins. That seems like sufficient reason to safelist it and hopefully make it clear to server administrators to pay extra attention to this header.

Tests: ...

Fixes #568.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/last-event-id/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/9fa071b...aa394cf.html)