### PR TITLE
CORS preflights need a service-workers mode of "none"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3810,21 +3810,19 @@ number of these <a lt="CORS-preflight fetch">fetches</a>.
 steps:
 
 <ol>
- <li><p>Let <var>preflight</var> be a new <a for=/>request</a>
- whose <a for=request>method</a> is `<code>OPTIONS</code>`,
- <a for=request>url</a> is <var>request</var>'s
- <a for=request>current url</a>,
- <a for=request>initiator</a> is <var>request</var>'s
- <a for=request>initiator</a>,
- <a for=request>destination</a> is <var>request</var>'s
- <a for=request>destination</a>,
- <a for=request>origin</a> is <var>request</var>'s
- <a for=request>origin</a>,
- <a for=request>referrer</a> is <var>request</var>'s
- <a for=request>referrer</a>, and
- <a for=request>referrer policy</a> is
- <var>request</var>'s
- <a for=request>referrer policy</a>.
+ <li>
+  <p>Let <var>preflight</var> be a new <a for=/>request</a> whose
+  <a for=request>method</a> is `<code>OPTIONS</code>`,
+  <a for=request>url</a> is <var>request</var>'s <a for=request>current url</a>,
+  <a for=request>initiator</a> is <var>request</var>'s <a for=request>initiator</a>,
+  <a for=request>destination</a> is <var>request</var>'s <a for=request>destination</a>,
+  <a for=request>origin</a> is <var>request</var>'s <a for=request>origin</a>,
+  <a for=request>referrer</a> is <var>request</var>'s <a for=request>referrer</a>, and
+  <a for=request>referrer policy</a> is <var>request</var>'s <a for=request>referrer policy</a>.
+
+  <p class="note no-backref">The <a for=request>service-workers mode</a> of <var>preflight</var>
+  does not matter as this algorithm uses <a>HTTP-network-or-cache fetch</a> rather than
+  <a>HTTP fetch</a>.
 
  <li><p><a for="header list">Set</a> `<a http-header><code>Access-Control-Request-Method</code></a>`
  to <var>request</var>'s <a for=request>method</a> in <var>preflight</var>'s


### PR DESCRIPTION
Fixes #558.

This probably does not matter as it's never going to be same-origin, but better safe than sorry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/preflight-service-workers-mode/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/bc23529...7830c74.html)