### PR TITLE
Reference correct WebSocket protocol RFC

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -38,7 +38,7 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
 <pre class=biblio>
 {
     "HTTP": {
-        "aliasOf": "HTTP11"
+        "aliasOf": "RFC7230"
     },
     "HTTP-SEMANTICS": {
         "aliasOf": "RFC7231"
@@ -65,10 +65,10 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
         "aliasOf": "upgrade-insecure-requests"
     },
     "HSTS": {
-        "aliasOf": "rfc6797"
+        "aliasOf": "RFC6797"
     },
     "WSP": {
-        "aliasOf": "WEBSOCKETS-PROTOCOL"
+        "aliasOf": "RFC6455"
     },
     "CLIENT-HINTS": {
         "authors": [


### PR DESCRIPTION
Fixes #613.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/references/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/d095af0...0d1bede.html)