### PR TITLE
Add RequestInit members to Request domintro

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1017,10 +1017,11 @@ unset.
   <a>opaque filtered response</a>.
 
   <dt>"<code>navigate</code>"
-  <dd>This is a special mode used only when navigating between documents.
+  <dd>This is a special mode used only when <a>navigating</a> between documents.
 
   <dt>"<code>websocket</code>"
-  <dd>This is a special mode used only when establishing a WebSocket connection.
+  <dd>This is a special mode used only when <a lt="establish a WebSocket connection">establishing
+  a WebSocket connection</a>.
  </dl>
 
  <p>Even though the default <a for=/>request</a>
@@ -1128,14 +1129,14 @@ Unless stated otherwise, it is "<code>follow</code>".
 <div class="note no-backref">
  <dl>
   <dt>"<code>follow</code>"
-  <dd>Used to follow all redirects incurred when fetching a resource.
+  <dd>Follow all redirects incurred when fetching a resource.
 
   <dt>"<code>error</code>"
-  <dd>This mode makes fetch return a <a>network error</a> when a request is met with a redirect.
+  <dd>Return a <a>network error</a> when a request is met with a redirect.
 
   <dt>"<code>manual</code>"
-  <dd>This mode is used to retrieve an <a>opaque-redirect filtered response</a> when a request is
-  met with a redirect so that the redirect can be followed manually.
+  <dd>Retrieves an <a>opaque-redirect filtered response</a> when a request is met with a redirect
+  so that the redirect can be followed manually.
  </dl>
 </div>
 
@@ -4953,8 +4954,7 @@ initially a new {{AbortSignal}} object.
  <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
  {{Request}} object.
 
- <p>The optional <var>init</var> argument allows for setting properties appearing in {{RequestInit}}
- via object members of the same name. These are the object members that can be used:</p>
+ <p>The optional <var>init</var> argument is an object whose properties can be set as follows:</p>
 
  <dl>
   <dt>{{RequestInit/method}}
@@ -5002,7 +5002,7 @@ initially a new {{AbortSignal}} object.
   <dd>An {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
 
   <dt>{{RequestInit/window}}
-  <dd>Can only be null. Used to set disassociate <var>request</var> from any {{Window}}.
+  <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
  </dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>

--- a/fetch.bs
+++ b/fetch.bs
@@ -773,7 +773,7 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 
   <dt>"<code>none</code>"
   <dd>No service workers will get events for this fetch.
- </dd>
+ </dl>
 </div>
 
 <p>A <a for=/>request</a> has an associated
@@ -1001,11 +1001,34 @@ unset.
 "<code>navigate</code>", or "<code>websocket</code>". Unless stated otherwise, it is
 "<code>no-cors</code>".
 
-<p class="note no-backref">Even though the default <a for=/>request</a>
-<a for=request>mode</a> is "<code>no-cors</code>", standards are highly
-discouraged from using it for new features. It is rather unsafe. "<code>navigate</code>" and
-"<code>websocket</code>" are special values for the HTML Standard.
-[[!HTML]]
+<div class="note no-backref">
+ <dl>
+  <dt>"<code>same-origin</code>"
+  <dd>Used to ensure requests are made to same-origin URLs. <a for=/>Fetch</a> will throw an error
+  if the request is not made to a same-origin URL.
+
+  <dt>"<code>cors</code>"
+  <dd>Ensures that the request being made is a <a>CORS request</a>. Fetch will throw an error if
+  the requested resource does not understand the <a>CORS protocol</a>.
+
+  <dt>"<code>no-cors</code>"
+  <dd>Restricts requests to using <a>CORS-safelisted method</a>s and
+  <a>CORS-safelisted request-header</a>s. Upon success, fetch will return a
+  <a>opaque filtered response</a>.
+
+  <dt>"<code>navigate</code>"
+  <dd>This is a special mode used only when navigating between documents.
+
+  <dt>"<code>websocket</code>"
+  <dd>This is a special mode used only when establishing a WebSocket connection.
+ </dl>
+
+ <p>Even though the default <a for=/>request</a>
+ <a for=request>mode</a> is "<code>no-cors</code>", standards are highly
+ discouraged from using it for new features. It is rather unsafe. "<code>navigate</code>" and
+ "<code>websocket</code>" are special values for the HTML Standard.
+ [[!HTML]]
+</div>
 
 <p>A <a for=/>request</a> has an associated
 <dfn id=use-cors-preflight-flag export for=request>use-CORS-preflight flag</dfn>. Unless stated
@@ -1021,14 +1044,27 @@ one or more event listeners are registered on an {{XMLHttpRequestUpload}} object
 which is "<code>omit</code>", "<code>same-origin</code>", or
 "<code>include</code>". Unless stated otherwise, it is "<code>omit</code>".
 
-<p class="note no-backref"><a for=/>Request</a>'s
-<a for=request>credentials mode</a> controls the flow of
-<a for=/>credentials</a> during a <a for=/>fetch</a>. When
-<a for=/>request</a>'s <a for=request>mode</a> is
-"<code>navigate</code>", its
-<a for=request>credentials mode</a> is assumed to be
-"<code>include</code>" and <a for=/>fetch</a> does not currently account
-for other values. If <cite>HTML</cite> changes here, this standard will need corresponding changes.
+<div class="note no-backref">
+ <dl>
+  <dt>"<code>omit</code>"
+  <dd>Used to ensure credentials are not included with this request.
+
+  <dt>"<code>same-origin</code>"
+  <dd>Used to include credentials on requests made to same-origin URLs.
+
+  <dt>"<code>include</code>"
+  <dd>Used to always include credentials with this request.
+ </dl>
+
+ <p><a for=/>Request</a>'s
+ <a for=request>credentials mode</a> controls the flow of
+ <a for=/>credentials</a> during a <a for=/>fetch</a>. When
+ <a for=/>request</a>'s <a for=request>mode</a> is
+ "<code>navigate</code>", its
+ <a for=request>credentials mode</a> is assumed to be
+ "<code>include</code>" and <a for=/>fetch</a> does not currently account
+ for other values. If <cite>HTML</cite> changes here, this standard will need corresponding changes.
+</div>
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-use-url-credentials-flag>use-URL-credentials flag</dfn>.
@@ -1090,6 +1126,20 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=concept-request-redirect-mode>redirect mode</dfn>, which is
 "<code>follow</code>", "<code>error</code>", or "<code>manual</code>".
 Unless stated otherwise, it is "<code>follow</code>".
+
+<div class="note no-backref">
+ <dl>
+  <dt>"<code>follow</code>"
+  <dd>Used to follow all redirects incurred when fetching a resource.
+
+  <dt>"<code>error</code>"
+  <dd>This mode ensures that fetch throws an error when a request for a resource is redirected.
+
+  <dt>"<code>manual</code>"
+  <dd>This mode is used to retrieve an <a>opaque-redirect filtered response</a> when a request is
+  redirected so that a redirect can be followed manually.
+ </dl>
+</div>
 
 <p>A <a for=/>request</a> has associated
 <dfn export for=request id=concept-request-integrity-metadata>integrity metadata</dfn>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1024,9 +1024,8 @@ unset.
   a WebSocket connection</a>.
  </dl>
 
- <p>Even though the default <a for=/>request</a>
- <a for=request>mode</a> is "<code>no-cors</code>", standards are highly
- discouraged from using it for new features. It is rather unsafe.
+ <p>Even though the default <a for=/>request</a> <a for=request>mode</a> is "<code>no-cors</code>",
+ standards are highly discouraged from using it for new features. It is rather unsafe.
 </div>
 
 <p>A <a for=/>request</a> has an associated
@@ -1055,14 +1054,11 @@ which is "<code>omit</code>", "<code>same-origin</code>", or
   <dd>Always includes credentials with this request.
  </dl>
 
- <p><a for=/>Request</a>'s
- <a for=request>credentials mode</a> controls the flow of
- <a for=/>credentials</a> during a <a for=/>fetch</a>. When
- <a for=/>request</a>'s <a for=request>mode</a> is
- "<code>navigate</code>", its
- <a for=request>credentials mode</a> is assumed to be
- "<code>include</code>" and <a for=/>fetch</a> does not currently account
- for other values. If <cite>HTML</cite> changes here, this standard will need corresponding changes.
+ <p><a for=/>Request</a>'s <a for=request>credentials mode</a> controls the flow of
+ <a for=/>credentials</a> during a <a for=/>fetch</a>. When <a for=/>request</a>'s
+ <a for=request>mode</a> is "<code>navigate</code>", its <a for=request>credentials mode</a> is
+ assumed to be "<code>include</code>" and <a for=/>fetch</a> does not currently account for other
+ values. If <cite>HTML</cite> changes here, this standard will need corresponding changes.
 </div>
 
 <p>A <a for=/>request</a> has an associated
@@ -1135,8 +1131,8 @@ Unless stated otherwise, it is "<code>follow</code>".
   <dd>Return a <a>network error</a> when a request is met with a redirect.
 
   <dt>"<code>manual</code>"
-  <dd>Retrieves an <a>opaque-redirect filtered response</a> when a request is met with a redirect
-  so that the redirect can be followed manually.
+  <dd>Retrieves an <a>opaque-redirect filtered response</a> when a request is met with a redirect so
+  that the redirect can be followed manually.
  </dl>
 </div>
 
@@ -4950,60 +4946,60 @@ initially a new {{AbortSignal}} object.
 <dl class=domintro>
  <dt><code><var>request</var> = new <a constructor lt="Request()">Request</a>(<var>input</var> [,
  <var>init</var>])</code>
- <dd>Returns a new <var>request</var> whose {{Request/url}} property is <var>input</var> if
- <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
- {{Request}} object.
+ <dd>
+  <p>Returns a new <var>request</var> whose {{Request/url}} property is <var>input</var> if
+  <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
+  {{Request}} object.
 
- <p>The optional <var>init</var> argument is an object whose properties can be set as follows:</p>
+  <p>The optional <var>init</var> argument is an object whose properties can be set as follows:</p>
 
- <dl>
-  <dt>{{RequestInit/method}}
-  <dd>A string to set <var>request</var>'s {{Request/method}}.
+  <dl>
+   <dt>{{RequestInit/method}}
+   <dd>A string to set <var>request</var>'s {{Request/method}}.
 
-  <dt>{{RequestInit/headers}}
-  <dd>A {{Headers}} object, an object literal, or an array of two-item arrays to set
-  <var>request</var>'s {{Request/headers}}.
+   <dt>{{RequestInit/headers}}
+   <dd>A {{Headers}} object, an object literal, or an array of two-item arrays to set
+   <var>request</var>'s {{Request/headers}}.
 
-  <dt>{{RequestInit/body}}
-  <dd>A {{BodyInit}} object or null to set <var>request</var>'s <a for=request>body</a>.
+   <dt>{{RequestInit/body}}
+   <dd>A {{BodyInit}} object or null to set <var>request</var>'s <a for=request>body</a>.
 
-  <dt>{{RequestInit/referrer}}
-  <dd>A string whose value is a same-origin URL, "<code>about:client</code>", or the empty
-  string, to set <var>request</var>'s <a>referrer</a>.
+   <dt>{{RequestInit/referrer}}
+   <dd>A string whose value is a same-origin URL, "<code>about:client</code>", or the empty string,
+   to set <var>request</var>'s <a>referrer</a>.
 
-  <dt>{{RequestInit/referrerPolicy}}
-  <dd>A <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
+   <dt>{{RequestInit/referrerPolicy}}
+   <dd>A <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
 
-  <dt>{{RequestInit/mode}}
-  <dd>A string to indicate whether the request will use CORS, or will be restricted to
-  same-origin URLs. Sets <var>request</var>'s {{Request/mode}}.
+   <dt>{{RequestInit/mode}}
+   <dd>A string to indicate whether the request will use CORS, or will be restricted to same-origin
+   URLs. Sets <var>request</var>'s {{Request/mode}}.
 
-  <dt>{{RequestInit/credentials}}
-  <dd>A string indicating whether credentials will be sent with the request always, never, or
-  only when sent to a same-origin URL. Sets <var>request</var>'s {{Request/credentials}}.
+   <dt>{{RequestInit/credentials}}
+   <dd>A string indicating whether credentials will be sent with the request always, never, or only
+   when sent to a same-origin URL. Sets <var>request</var>'s {{Request/credentials}}.
 
-  <dt>{{RequestInit/cache}}
-  <dd>A string indicating how the request will interact with the browser's cache to set
-  <var>request</var>'s {{Request/cache}}.
+   <dt>{{RequestInit/cache}}
+   <dd>A string indicating how the request will interact with the browser's cache to set
+   <var>request</var>'s {{Request/cache}}.
 
-  <dt>{{RequestInit/redirect}}
-  <dd>A string indicating whether or not <var>request</var> should automatically follow
-  redirects, result in an error, or manually follow redirects. Sets <var>request</var>'s
-  {{Request/redirect}}.
+   <dt>{{RequestInit/redirect}}
+   <dd>A string indicating whether or not <var>request</var> should automatically follow redirects,
+   result in an error, or manually follow redirects. Sets <var>request</var>'s {{Request/redirect}}.
 
-  <dt>{{RequestInit/integrity}}
-  <dd>A cryptographic hash of the resource to be fetched by <var>request</var>. Sets
-  <var>request</var>'s {{Request/integrity}}.
+   <dt>{{RequestInit/integrity}}
+   <dd>A cryptographic hash of the resource to be fetched by <var>request</var>. Sets
+   <var>request</var>'s {{Request/integrity}}.
 
-  <dt>{{RequestInit/keepalive}}
-  <dd>A boolean to set <var>request</var>'s {{Request/keepalive}}.
+   <dt>{{RequestInit/keepalive}}
+   <dd>A boolean to set <var>request</var>'s {{Request/keepalive}}.
 
-  <dt>{{RequestInit/signal}}
-  <dd>An {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
+   <dt>{{RequestInit/signal}}
+   <dd>An {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
 
-  <dt>{{RequestInit/window}}
-  <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
- </dl>
+   <dt>{{RequestInit/window}}
+   <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
+  </dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>
  <dd>Returns <var>request</var>'s HTTP method, which is "<code>GET</code>" by default.
@@ -5031,8 +5027,8 @@ initially a new {{AbortSignal}} object.
  fetching to compute the value of the <var>request</var>'s referrer.
 
  <dt><code><var>request</var> . <a attribute for=Request>mode</a></code>
- <dd>Returns the <a>mode</a> associated with <var>request</var>, which is a string indicating whether
- the request will use CORS, or will be restricted to same-origin URLs.
+ <dd>Returns the <a>mode</a> associated with <var>request</var>, which is a string indicating
+ whether the request will use CORS, or will be restricted to same-origin URLs.
 
  <dt><code><var>request</var> . <a attribute for=Request>credentials</a></code>
  <dd>Returns the <a>credentials mode</a> associated with <var>request</var>, which is a string
@@ -5049,8 +5045,8 @@ initially a new {{AbortSignal}} object.
  will follow redirects by default.
 
  <dt><code><var>request</var> . <a attribute for=Request>integrity</a></code>
- <dd>Returns <var>request</var>'s subresource integrity metadata, which is a cryptographic hash of the
- resource being fetched. Its value may consist of multiple hashes separated by whitespace.
+ <dd>Returns <var>request</var>'s subresource integrity metadata, which is a cryptographic hash of
+ the resource being fetched. Its value may consist of multiple hashes separated by whitespace.
  [[SRI]]
 
  <dt><code><var>request</var> . <a attribute for=Request>keepalive</a></code>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1012,8 +1012,8 @@ unset.
   the requested resource does not understand the <a>CORS protocol</a>.
 
   <dt>"<code>no-cors</code>"
-  <dd>Restricts requests to using <a>CORS-safelisted method</a>s and
-  <a>CORS-safelisted request-header</a>s. Upon success, fetch will return a
+  <dd>Restricts requests to using <a>CORS-safelisted methods</a> and
+  <a>CORS-safelisted request-headers</a>. Upon success, fetch will return a
   <a>opaque filtered response</a>.
 
   <dt>"<code>navigate</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -4965,7 +4965,7 @@ initially a new {{AbortSignal}} object.
   <var>request</var>'s {{Request/headers}}.
 
   <dt>{{RequestInit/body}}
-  <dd>A {{BodyInit}} object or null to set <var>request</var>'s <a>body</a>.
+  <dd>A {{BodyInit}} object or null to set <var>request</var>'s <a for=request>body</a>.
 
   <dt>{{RequestInit/referrer}}
   <dd>A string whose value is a same-origin URL, "<code>about:client</code>", or the empty

--- a/fetch.bs
+++ b/fetch.bs
@@ -4958,52 +4958,51 @@ initially a new {{AbortSignal}} object.
 
  <dl>
   <dt>{{RequestInit/method}}
-  <dd>Set to a string to set <var>request</var>'s {{Request/method}}.
+  <dd>A string to set <var>request</var>'s {{Request/method}}.
 
   <dt>{{RequestInit/headers}}
-  <dd>Set to a {{Headers}} object or an array of two-item arrays to set <var>request</var>'s
-  {{Request/headers}}.
+  <dd>A {{Headers}} object, an object literal, or an array of two-item arrays to set
+  <var>request</var>'s {{Request/headers}}.
 
   <dt>{{RequestInit/body}}
-  <dd>Set to a {{Body}} object or null to set <var>request</var>'s <a>body</a>.
+  <dd>A {{BodyInit}} object or null to set <var>request</var>'s <a>body</a>.
 
   <dt>{{RequestInit/referrer}}
-  <dd>Set to a string whose value is a same-origin URL, "<code>about:client</code>", or the empty
+  <dd>A string whose value is a same-origin URL, "<code>about:client</code>", or the empty
   string, to set <var>request</var>'s <a>referrer</a>.
 
   <dt>{{RequestInit/referrerPolicy}}
-  <dd>Set to a <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
+  <dd>A <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
 
   <dt>{{RequestInit/mode}}
-  <dd>Set to a string to indicate whether the request will use CORS, or will be restricted to
+  <dd>A string to indicate whether the request will use CORS, or will be restricted to
   same-origin URLs. Sets <var>request</var>'s {{Request/mode}}.
 
   <dt>{{RequestInit/credentials}}
-  <dd>Set to a string indicating whether credentials will be sent with the request always, never, or
+  <dd>A string indicating whether credentials will be sent with the request always, never, or
   only when sent to a same-origin URL. Sets <var>request</var>'s {{Request/credentials}}.
 
   <dt>{{RequestInit/cache}}
-  <dd>Set to a string indicating how the request will interact with the browser's cache to set
+  <dd>A string indicating how the request will interact with the browser's cache to set
   <var>request</var>'s {{Request/cache}}.
 
   <dt>{{RequestInit/redirect}}
-  <dd>Set to a string indicating whether or not <var>request</var> should automatically follow
+  <dd>A string indicating whether or not <var>request</var> should automatically follow
   redirects, result in an error, or manually follow redirects. Sets <var>request</var>'s
   {{Request/redirect}}.
 
   <dt>{{RequestInit/integrity}}
-  <dd>Set to a cryptographic has of the resource to be fetched by <var>request</var>. Sets
+  <dd>A cryptographic hash of the resource to be fetched by <var>request</var>. Sets
   <var>request</var>'s {{Request/integrity}}.
 
   <dt>{{RequestInit/keepalive}}
-  <dd>Set to a boolean to set <var>request</var>'s {{Request/keepalive}}.
+  <dd>A boolean to set <var>request</var>'s {{Request/keepalive}}.
 
   <dt>{{RequestInit/signal}}
-  <dd>Set to an {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
+  <dd>An {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
 
   <dt>{{RequestInit/window}}
-  <dd>Can only be null. Used to set <var>request</var>'s internal <a>window</a> object to
-  "<code>no-window</code>".
+  <dd>Can only be null. Used to set disassociate <var>request</var> from any {{Window}}.
  </dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4905,22 +4905,23 @@ initially a new {{AbortSignal}} object.
  <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
  {{Request}} object.
 
- The optional <var>init</var> argument allows for setting properties appearing in {{RequestInit}}
- via object members of the same name. These are the object members that can be used:
+ <p>The optional <var>init</var> argument allows for setting properties appearing in {{RequestInit}}
+ via object members of the same name. These are the object members that can be used:</p>
 
  <dl>
   <dt>{{RequestInit/method}}
   <dd>Set to a string to set <var>request</var>'s {{Request/method}}.
 
   <dt>{{RequestInit/headers}}
-  <dd>Set to a {{Headers}} object to set <var>request</var>'s {{Request/headers}}.
+  <dd>Set to a {{Headers}} object or an array of two-item arrays to set <var>request</var>'s
+  {{Request/headers}}.
 
   <dt>{{RequestInit/body}}
   <dd>Set to a {{Body}} object or null to set <var>request</var>'s <a>body</a>.
 
   <dt>{{RequestInit/referrer}}
-  <dd>Set to a string whose value is a same-origin URL or the empty string to set
-  <var>request</var>'s <a>referrer</a>.
+  <dd>Set to a string whose value is a same-origin URL, "<code>about:client</code>", or the empty
+  string to set <var>request</var>'s <a>referrer</a>.
 
   <dt>{{RequestInit/referrerPolicy}}
   <dd>Set to a <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
@@ -4938,7 +4939,7 @@ initially a new {{AbortSignal}} object.
   <var>request</var>'s {{Request/cache}}.
 
   <dt>{{RequestInit/redirect}}
-  <dd>Set to a string indicating whether or not <var>request</var> should automatically  follow
+  <dd>Set to a string indicating whether or not <var>request</var> should automatically follow
   redirects, result in an error, or manually follow redirects. Sets <var>request</var>'s
   {{Request/redirect}}.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4903,8 +4903,59 @@ initially a new {{AbortSignal}} object.
  <var>init</var>])</code>
  <dd>Returns a new <var>request</var> whose {{Request/url}} property is <var>input</var> if
  <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
- {{Request}} object. The optional <var>init</var> argument allows for setting attributes
- appearing in {{RequestInit}} via object members of the same name.
+ {{Request}} object.
+
+ The optional <var>init</var> argument allows for setting properties appearing in {{RequestInit}}
+ via object members of the same name. These are the object members that can be used:
+
+ <dl>
+  <dt>{{RequestInit/method}}
+  <dd>Set to a string to set <var>request</var>'s {{Request/method}}.
+
+  <dt>{{RequestInit/headers}}
+  <dd>Set to a {{Headers}} object to set <var>request</var>'s {{Request/headers}}.
+
+  <dt>{{RequestInit/body}}
+  <dd>Set to a {{Body}} object or null to set <var>request</var>'s <a>body</a>.
+
+  <dt>{{RequestInit/referrer}}
+  <dd>Set to a string whose value is a same-origin URL or the empty string to set
+  <var>request</var>'s <a>referrer</a>.
+
+  <dt>{{RequestInit/referrerPolicy}}
+  <dd>Set to a <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.
+
+  <dt>{{RequestInit/mode}}
+  <dd>Set to a string to indicate whether the request will use CORS, or will be restricted to
+  same-origin URLs. Sets <var>request</var>'s {{Request/mode}}.
+
+  <dt>{{RequestInit/credentials}}
+  <dd>Set to a string indicating whether credentials will be sent with the request always, never, or
+  only when sent to a same-origin URL. Sets <var>request</var>'s {{Request/credentials}}.
+
+  <dt>{{RequestInit/cache}}
+  <dd>Set to a string indicating how the request will interact with the browser's cache to set
+  <var>request</var>'s {{Request/cache}}.
+
+  <dt>{{RequestInit/redirect}}
+  <dd>Set to a string indicating whether or not <var>request</var> should automatically  follow
+  redirects, result in an error, or manually follow redirects. Sets <var>request</var>'s
+  {{Request/redirect}}.
+
+  <dt>{{RequestInit/integrity}}
+  <dd>Set to a cryptographic has of the resource to be fetched by <var>request</var>. Sets
+  <var>request</var>'s {{Request/integrity}}.
+
+  <dt>{{RequestInit/keepalive}}
+  <dd>Set to a boolean to set <var>request</var>'s {{Request/keepalive}}.
+
+  <dt>{{RequestInit/signal}}
+  <dd>Set to an {{AbortSignal}} to set <var>request</var>'s {{Request/signal}}.
+
+  <dt>{{RequestInit/window}}
+  <dd>Can only be null. Used to set <var>request</var>'s internal <a>window</a> object to
+  "<code>no-window</code>".
+ </dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>
  <dd>Returns <var>request</var>'s HTTP method, which is "<code>GET</code>" by default.
@@ -4933,12 +4984,12 @@ initially a new {{AbortSignal}} object.
 
  <dt><code><var>request</var> . <a attribute for=Request>mode</a></code>
  <dd>Returns the <a>mode</a> associated with <var>request</var>, which is a string indicating whether
- or not the request will use CORS, or will be restricted to same-origin URLs.
+ the request will use CORS, or will be restricted to same-origin URLs.
 
  <dt><code><var>request</var> . <a attribute for=Request>credentials</a></code>
  <dd>Returns the <a>credentials mode</a> associated with <var>request</var>, which is a string
- indicating whether or not credentials will be sent with the request always, never, or only when
- sent to a same-origin URL.
+ indicating whether credentials will be sent with the request always, never, or only when sent to a
+ same-origin URL.
 
  <dt><code><var>request</var> . <a attribute for=Request>cache</a></code>
  <dd>Returns the <a>cache mode</a> associated with <var>request</var>, which is a string indicating

--- a/fetch.bs
+++ b/fetch.bs
@@ -1004,16 +1004,16 @@ unset.
 <div class="note no-backref">
  <dl>
   <dt>"<code>same-origin</code>"
-  <dd>Used to ensure requests are made to same-origin URLs. <a for=/>Fetch</a> will throw an error
-  if the request is not made to a same-origin URL.
+  <dd>Used to ensure requests are made to same-origin URLs. <a for=/>Fetch</a> will return a
+  <a>network error</a> if the request is not made to a same-origin URL.
 
   <dt>"<code>cors</code>"
-  <dd>Ensures that the request being made is a <a>CORS request</a>. Fetch will throw an error if
-  the requested resource does not understand the <a>CORS protocol</a>.
+  <dd>Makes the request a <a>CORS request</a>. Fetch will return a <a>network error</a> if the
+  requested resource does not understand the <a>CORS protocol</a>.
 
   <dt>"<code>no-cors</code>"
   <dd>Restricts requests to using <a>CORS-safelisted methods</a> and
-  <a>CORS-safelisted request-headers</a>. Upon success, fetch will return a
+  <a>CORS-safelisted request-headers</a>. Upon success, fetch will return an
   <a>opaque filtered response</a>.
 
   <dt>"<code>navigate</code>"
@@ -1025,9 +1025,7 @@ unset.
 
  <p>Even though the default <a for=/>request</a>
  <a for=request>mode</a> is "<code>no-cors</code>", standards are highly
- discouraged from using it for new features. It is rather unsafe. "<code>navigate</code>" and
- "<code>websocket</code>" are special values for the HTML Standard.
- [[!HTML]]
+ discouraged from using it for new features. It is rather unsafe.
 </div>
 
 <p>A <a for=/>request</a> has an associated
@@ -1047,13 +1045,13 @@ which is "<code>omit</code>", "<code>same-origin</code>", or
 <div class="note no-backref">
  <dl>
   <dt>"<code>omit</code>"
-  <dd>Used to ensure credentials are not included with this request.
+  <dd>Excludes credentials from this request.
 
   <dt>"<code>same-origin</code>"
-  <dd>Used to include credentials on requests made to same-origin URLs.
+  <dd>Include credentials with requests made to same-origin URLs.
 
   <dt>"<code>include</code>"
-  <dd>Used to always include credentials with this request.
+  <dd>Always includes credentials with this request.
  </dl>
 
  <p><a for=/>Request</a>'s
@@ -1133,11 +1131,11 @@ Unless stated otherwise, it is "<code>follow</code>".
   <dd>Used to follow all redirects incurred when fetching a resource.
 
   <dt>"<code>error</code>"
-  <dd>This mode ensures that fetch throws an error when a request for a resource is redirected.
+  <dd>This mode makes fetch return a <a>network error</a> when a request is met with a redirect.
 
   <dt>"<code>manual</code>"
   <dd>This mode is used to retrieve an <a>opaque-redirect filtered response</a> when a request is
-  redirected so that a redirect can be followed manually.
+  met with a redirect so that the redirect can be followed manually.
  </dl>
 </div>
 
@@ -4971,7 +4969,7 @@ initially a new {{AbortSignal}} object.
 
   <dt>{{RequestInit/referrer}}
   <dd>Set to a string whose value is a same-origin URL, "<code>about:client</code>", or the empty
-  string to set <var>request</var>'s <a>referrer</a>.
+  string, to set <var>request</var>'s <a>referrer</a>.
 
   <dt>{{RequestInit/referrerPolicy}}
   <dd>Set to a <a for=/>referrer policy</a> to set <var>request</var>'s {{Request/referrerPolicy}}.


### PR DESCRIPTION
This PR adds the RequestInit members to the Request domintro box. I wasn't sure if I should be linking to the enums for things like RequestInit.{mode, credentials, etc} to make it easy for people to see the actual valid values of objects or not, so if that is necessary I'll adjust this for sure.

There are also a couple misc wording fixes I made for the lower content I added in an earlier PR.

Makes progress on https://github.com/whatwg/fetch/issues/543


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/620.html" title="Last updated on Jan 13, 2018, 12:36 PM GMT (0e4a7be)">Preview</a> | <a href="https://whatpr.org/fetch/620/fd28675...0e4a7be.html" title="Last updated on Jan 13, 2018, 12:36 PM GMT (0e4a7be)">Diff</a>