### PR TITLE
Document CORS safelist exceptions

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -445,6 +445,14 @@ whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
 <p>and whose <a for=header>value</a>, <a lt="extract header values">once extracted</a>, is not
 failure.
 
+<p class="note">Browsers allow limited exceptions to the CORS safelist for non-safelisted
+`<code>Content-Type</code>` values. These exceptions are made for requests that can be triggered by
+web content but whose headers and bodies can be only minimally controlled by the web content.
+Therefore, servers should expect cross-origin web content to be allowed to trigger non-preflighted
+requests with the following non-safelisted `<code>Content-Type</code>` values:
+`<code>application/csp-report</code>`, `<code>application/report</code>`,
+`<code>application/expect-ct-report+json</code>`, `<code>application/ocsp-request</code>`.
+
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a>byte-case-insensitive</a> match
 for `<code>Authorization</code>`.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2253,9 +2253,14 @@ triggered by web content but whose headers and bodies can be only minimally cont
 content. Therefore, servers should expect cross-origin web content to be allowed to trigger
 non-preflighted requests with the following non-safelisted `<code>Content-Type</code>` header
 values:
-`<code>application/csp-report</code>` [[CSP]], `<code>application/report</code>` [[REPORTING]],
-`<code>application/expect-ct-report+json</code>` [[EXPECT-CT]],
-`<code>application/xss-auditor-report</code>`, and `<code>application/ocsp-request</code>` [[OCSP]].
+
+<ul class=brief>
+ <li>`<code>application/csp-report</code>` [[CSP]]
+ <li>`<code>application/report</code>` [[REPORTING]]
+ <li>`<code>application/expect-ct-report+json</code>` [[EXPECT-CT]]
+ <li>`<code>application/xss-auditor-report</code>`
+ <li>`<code>application/ocsp-request</code>` [[OCSP]]
+</ul>
 
 <p>Specifications should avoid introducing new exceptions and should only do so with careful
 consideration for the security consequences. New exceptions can be proposed by

--- a/fetch.bs
+++ b/fetch.bs
@@ -97,6 +97,22 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
         "publisher": "US-CERT",
         "href": "https://www.kb.cert.org/vuls/id/150227",
         "title": "HTTP proxy default configurations allow arbitrary TCP connections."
+    },
+    "REPORTING": {
+        "authors": ["Ilya Grigorik", "Mike West"],
+        "href": "https://wicg.github.io/reporting/",
+        "title": "Reporting API"
+    },
+    "EXPECT-CT": {
+        "authors": [
+            "Emily Stark"
+        ],
+        "href": "https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-02",
+        "publisher": "IETF",
+        "title": "Expect-CT Extension for HTTP"
+    },
+    "OCSP": {
+        "aliasOf": "RFC2560"
     }
 }
 </pre>
@@ -2236,8 +2252,10 @@ Access-Control-Allow-Credentials: true</pre>
 triggered by web content but whose headers and bodies can be only minimally controlled by the web
 content. Therefore, servers should expect cross-origin web content to be allowed to trigger
 non-preflighted requests with the following non-safelisted `<code>Content-Type</code>` header
-values: `<code>application/csp-report</code>`, `<code>application/report</code>`,
-`<code>application/expect-ct-report+json</code>`, and `<code>application/ocsp-request</code>`.
+values:
+`<code>application/csp-report</code>` [[CSP]], `<code>application/report</code>` [[REPORTING]],
+`<code>application/expect-ct-report+json</code>` [[EXPECT-CT]],
+`<code>application/xss-auditor-report</code>`, and `<code>application/ocsp-request</code>` [[OCSP]].
 
 <p>Specifications should avoid introducing new exceptions and should only do so with careful
 consideration for the security consequences. New exceptions can be proposed by

--- a/fetch.bs
+++ b/fetch.bs
@@ -445,7 +445,7 @@ whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
 <p>and whose <a for=header>value</a>, <a lt="extract header values">once extracted</a>, is not
 failure.
 
-<p class="note">There are limited exceptions to the `<code>Content-Type</code>` safelist, as
+<p class="note">There are limited exceptions to the `<code>Content-Type</code>` header safelist, as
 documented in <a href=#cors-protocol-exceptions>CORS protocol exceptions</a>.
 
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a>byte-case-insensitive</a> match
@@ -2232,15 +2232,16 @@ Access-Control-Allow-Credentials: true</pre>
 <h4 id=cors-protocol-exceptions>CORS protocol exceptions</h4>
 
 <p>Specifications have allowed limited exceptions to the CORS safelist for non-safelisted
-`<code>Content-Type</code>` values. These exceptions are made for requests that can be triggered by
-web content but whose headers and bodies can be only minimally controlled by the web content.
-Therefore, servers should expect cross-origin web content to be allowed to trigger non-preflighted
-requests with the following non-safelisted `<code>Content-Type</code>` values:
-`<code>application/csp-report</code>`, `<code>application/report</code>`,
-`<code>application/expect-ct-report+json</code>`, `<code>application/ocsp-request</code>`.
+`<code>Content-Type</code>` header values. These exceptions are made for requests that can be
+triggered by web content but whose headers and bodies can be only minimally controlled by the web
+content. Therefore, servers should expect cross-origin web content to be allowed to trigger
+non-preflighted requests with the following non-safelisted `<code>Content-Type</code>` header
+values: `<code>application/csp-report</code>`, `<code>application/report</code>`,
+`<code>application/expect-ct-report+json</code>`, and `<code>application/ocsp-request</code>`.
 
 <p>Specifications should avoid introducing new exceptions and should only do so with careful
-consideration for the security consequences.
+consideration for the security consequences. New exceptions can be proposed by
+<a href=https://github.com/whatwg/fetch/issues/new>filing an issue</a>.
 
 
 <h3 id=x-content-type-options-header>`<code>X-Content-Type-Options</code>` header</h3>

--- a/fetch.bs
+++ b/fetch.bs
@@ -445,13 +445,8 @@ whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for one of
 <p>and whose <a for=header>value</a>, <a lt="extract header values">once extracted</a>, is not
 failure.
 
-<p class="note">Browsers allow limited exceptions to the CORS safelist for non-safelisted
-`<code>Content-Type</code>` values. These exceptions are made for requests that can be triggered by
-web content but whose headers and bodies can be only minimally controlled by the web content.
-Therefore, servers should expect cross-origin web content to be allowed to trigger non-preflighted
-requests with the following non-safelisted `<code>Content-Type</code>` values:
-`<code>application/csp-report</code>`, `<code>application/report</code>`,
-`<code>application/expect-ct-report+json</code>`, `<code>application/ocsp-request</code>`.
+<p class="note">There are limited exceptions to the `<code>Content-Type</code>` safelist, as
+documented in <a href=#cors-protocol-exceptions>CORS protocol exceptions</a>.
 
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a>byte-case-insensitive</a> match
 for `<code>Authorization</code>`.
@@ -2233,6 +2228,19 @@ Access-Control-Allow-Credentials: true</pre>
  callback will be invoked and any `<code>Set-Cookie</code>` response headers will end up being
  ignored.
 </div>
+
+<h4 id=cors-protocol-exceptions>CORS protocol exceptions</h4>
+
+<p>Specifications have allowed limited exceptions to the CORS safelist for non-safelisted
+`<code>Content-Type</code>` values. These exceptions are made for requests that can be triggered by
+web content but whose headers and bodies can be only minimally controlled by the web content.
+Therefore, servers should expect cross-origin web content to be allowed to trigger non-preflighted
+requests with the following non-safelisted `<code>Content-Type</code>` values:
+`<code>application/csp-report</code>`, `<code>application/report</code>`,
+`<code>application/expect-ct-report+json</code>`, `<code>application/ocsp-request</code>`.
+
+<p>Specifications should avoid introducing new exceptions and should only do so with careful
+consideration for the security consequences.
 
 
 <h3 id=x-content-type-options-header>`<code>X-Content-Type-Options</code>` header</h3>


### PR DESCRIPTION
As discussed in https://github.com/whatwg/fetch/issues/567, browsers have
allowed various cross-origin requests with non-safelisted Content-Type header
values to be sent without CORS preflights. These have occurred either by
accident (and now can't be reversed for compatibility reasons) or because of
design constraints (requests that are implemented outside of the web platform
layer). These CORS exceptions are believed to be safe, but the spec should
document them so that servers know to expect them.

I've added a note about the Content-Type exceptions, but haven't added them to
the safelist, because doing so would imply that web content can trigger
requests with these Content-Type headers and arbitrary bodies. We don't want to
allow fully attacker-controlled requests with these headers, but rather just
want to document the current state where web content can trigger the requests
but not control the headers or bodies.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/estark37/fetch/cors-exceptions.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/e5abf0f...estark37:3d17f9f.html)