### PR TITLE
WebSocket handshake has no referrer

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5850,6 +5850,7 @@ therefore not shareable, a WebSocket connection is very close to identical to an
  <a for=request>url</a> is <var>requestURL</var>,
  <a for=request>client</a> is <var>client</var>,
  <a>service-workers mode</a> is "<code>none</code>",
+ <a for=request>referrer</a> is "<code>no-referrer</code>",
  <a>synchronous flag</a> is set,
  <a for=request>mode</a> is "<code>websocket</code>",
  <a for=request>credentials mode</a> is


### PR DESCRIPTION
Fixes #630.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fetch.spec.whatwg.org/branch-snapshots/annevk/ws-no-referrer/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fetch/8ab040a...46984f2.html)