### PR TITLE
Use request's current url as base URL in redirects

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3402,6 +3402,9 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
       </ul>
 
       <p>then return a <a>network error</a>.
+
+     <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaqueredirect</code>", then
+     return <var>response</var>.
     </ol>
   </ol>
 
@@ -3479,8 +3482,8 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
    `<code>Location</code>` and <var>actualResponse</var>'s <a for=response>header list</a>.
 
    <li><p>If <var>location</var> is a <a for=header>value</a>, then set <var>location</var> to the
-   result of <a lt="url parser">parsing</a> <var>location</var> with <var>actualResponse</var>'s
-   <a for=response>URL</a>.
+   result of <a lt="url parser">parsing</a> <var>location</var> with <var>request</var>'s
+   <a for=request>current URL</a>.
 
    <li><p>Set <var>actualResponse</var>'s
    <a for=response>location URL</a> to <var>location</var>.


### PR DESCRIPTION
As the response's url list is not set at this point using that doesn not work. We could potentially set it earlier, but that brings along other complications that this setup avoid.

This also returns opaque redirect responses earlier, to avoid having them processed twice, which was simply wrong (and would become extra wrong here).

Fixes #631.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/633.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (0ae5dca)">Preview</a> | <a href="https://whatpr.org/fetch/633/5bd61e0...0ae5dca.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (0ae5dca)">Diff</a>