### PR TITLE
More eargerly send RST_STREAM on redirects

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3116,14 +3116,11 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
 
   <ol>
    <li>
-    <p>If <var>actualResponse</var>'s <a for=response>status</a> is not
-    <code>303</code>, <var>request</var>'s <a for=request>body</a> is not
-    <a for=body>done</a>, and the
-    <a>connection</a> uses HTTP/2, then user agents may, and are even
-    encouraged to, transmit an <code>RST_STREAM</code> frame.
+    <p>If <var>actualResponse</var>'s <a for=response>status</a> is not <code>303</code>,
+    <var>request</var>'s <a for=request>body</a> is not null, and the <a>connection</a> uses HTTP/2,
+    then user agents may, and are even encouraged to, transmit an <code>RST_STREAM</code> frame.
 
-    <p class=note><code>303</code> is excluded as certain communities ascribe special status to
-    it.
+    <p class=note><code>303</code> is excluded as certain communities ascribe special status to it.
 
    <li><p>Let <var>location</var> be the result of <a>extracting header list values</a> given
    `<code>Location</code>` and <var>actualResponse</var>'s <a for=response>header list</a>.
@@ -3821,8 +3818,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
   <ol>
    <li><p>Let <var>aborted</var> be the termination's aborted flag.
 
-   <li><p>If <var>connection</var> is an HTTP/2 connection, then transmit an
-   "<code>RST_STREAM</code>" to cancel the underlying stream.
+   <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
    <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
 
@@ -3983,8 +3979,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <li><p>Otherwise, if <var>stream</var> is <a for=ReadableStream>readable</a>,
    <a abstract-op>error</a> <var>stream</var> with a <code>TypeError</code>.
 
-   <li><p>If <var>connection</var> is an HTTP/2 connection, then transmit an
-   "<code>RST_STREAM</code>" to cancel the underlying stream.
+   <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
    <li>
     <p>Otherwise, the user agent should close <var>connection</var> unless it would be bad for


### PR DESCRIPTION
Checking if body is not done had a problem in that if body's stream is null it would end up not working as "done" tries to read internal slots from a body's stream.

This also makes the language around RST_STREAM frames consistent.

Fixes #635.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://fetch.spec.whatwg.org/branch-snapshots/annevk/body-stream-can-be-null/" title="Last updated on Nov 24, 2017, 11:12 AM GMT">Preview</a> | <a href="https://s3.amazonaws.com/pr-preview/whatwg/fetch/f8a6a5d...e6e3228.html" title="Last updated on Nov 24, 2017, 11:12 AM GMT">Diff</a>