### PR TITLE
Use `interface mixins` instead of `[NoInterfaceObject]`

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4660,9 +4660,8 @@ typedef (Blob or BufferSource or FormData or URLSearchParams or ReadableStream o
 </ol>
 
 
-<pre class=idl>[NoInterfaceObject,
- Exposed=(Window,Worker)]
-interface Body {
+<pre class=idl>
+interface mixin Body {
   readonly attribute ReadableStream? body;
   readonly attribute boolean bodyUsed;
   [NewObject] Promise&lt;ArrayBuffer> arrayBuffer();
@@ -4856,7 +4855,8 @@ interface Request {
 
   [NewObject] Request clone();
 };
-Request implements Body;
+Request includes Body;
+
 dictionary RequestInit {
   ByteString method;
   HeadersInit headers;
@@ -5418,7 +5418,7 @@ interface Response {
 
   [NewObject] Response clone();
 };
-Response implements Body;
+Response includes Body;
 
 dictionary ResponseInit {
   unsigned short status = 200;
@@ -6124,6 +6124,7 @@ Jeff Carpenter,
 Jeff Hodges,
 Jeffrey Yasskin,
 Jesse M. Heines,
+Jinho Bang,
 Jochen Eisinger,
 Jonas Sicking,
 Jonathan Kingston,


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins[1]. So, we can
replace `[NoInterfaceObject]` and `implements` with `interface mixin` and
`includes`.

This following interface is impacted by this change:
  - Body

This fixes #624 issue.

Test: https://github.com/w3c/web-platform-tests/pull/8701

[1] https://github.com/heycam/webidl/commit/45e8173d40ddff8dcf81697326e094bcf8b92920


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/645.html" title="Last updated on Dec 18, 2017, 3:15 PM GMT (dab71e0)">Preview</a> | <a href="https://whatpr.org/fetch/645/fd28675...dab71e0.html" title="Last updated on Dec 18, 2017, 3:15 PM GMT (dab71e0)">Diff</a>