### PR TITLE
Following signals. Fixes #668.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5273,8 +5273,8 @@ constructor must run these steps:
  <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
  <a for=Headers>guard</a> is "<code>request</code>".
 
- <li><p>If <var>signal</var> is not null, then <var>r</var>'s <a for=Request>signal</a>
- <a for=AbortSignal>follows</a> <var>signal</var>.
+ <li><p>If <var>signal</var> is not null, then make <var>r</var>'s <a for=Request>signal</a>
+ <a for=AbortSignal>follow</a> <var>signal</var>.
 
  <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
  associated <a for=Headers>header list</a>.
@@ -5457,8 +5457,8 @@ run these steps:
  <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
  <a for=Request>headers</a>' <a for=Headers>guard</a>.
 
- <li><p><var>clonedRequestObject</var>'s <a for=Request>signal</a> <a for=AbortSignal>follows</a>
- <a>context object</a>'s <a for=Request>signal</a>.
+ <li><p>Make <var>clonedRequestObject</var>'s <a for=Request>signal</a>
+ <a for=AbortSignal>follow</a> <a>context object</a>'s <a for=Request>signal</a>.
 
  <li><p>Return <var>clonedRequestObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5273,13 +5273,8 @@ constructor must run these steps:
  <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
  <a for=Headers>guard</a> is "<code>request</code>".
 
- <li>
-  <p>If <var>signal</var> is not null, then
-  <a for=AbortSignal lt=add>add the following abort steps</a> to <var>signal</var>:
-
-  <ol>
-   <li><p><a for=AbortSignal>Signal abort</a> on <var>r</var>'s <a for=Request>signal</a>.
-  </ol>
+ <li><p>If <var>signal</var> is not null, then <var>r</var>'s <a for=Request>signal</a>
+ <a for=AbortSignal>follows</a> <var>signal</var>.
 
  <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
  associated <a for=Headers>header list</a>.
@@ -5462,18 +5457,8 @@ run these steps:
  <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>context object</a>'s
  <a for=Request>headers</a>' <a for=Headers>guard</a>.
 
- <li><p>If <a>context object</a>'s <a for=Request>signal</a>'s <a for=AbortSignal>aborted flag</a>
- is set, set <var>clonedRequestObject</var> <a for=Request>signal</a>'s
- <a for=AbortSignal>aborted flag</a>.
-
- <li>
-  <p>Otherwise, <a for=AbortSignal>add</a> the following abort steps to <a>context object</a>'s
-  <a for=Request>signal</a>:
-
-  <ol>
-   <li><p><a for=AbortSignal>Signal abort</a> on <var>clonedRequestObject</var>
-   <a for=Request>signal</a>.
-  </ol>
+ <li><p><var>clonedRequestObject</var>'s <a for=Request>signal</a> <a for=AbortSignal>follows</a>
+ <a>context object</a>'s <a for=Request>signal</a>.
 
  <li><p>Return <var>clonedRequestObject</var>.
 </ol>


### PR DESCRIPTION
Handles cases where the signal's aborted flag is already set.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/670.html" title="Last updated on Feb 12, 2018, 8:41 AM GMT (1a4c685)">Preview</a> | <a href="https://whatpr.org/fetch/670/36ef3c8...1a4c685.html" title="Last updated on Feb 12, 2018, 8:41 AM GMT (1a4c685)">Diff</a>