### PR TITLE
Allow used body replacement in Request constructor

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5088,9 +5088,6 @@ constructor must run these steps:
   <p>Otherwise (<var>input</var> is a {{Request}} object), run these substeps:
 
   <ol>
-   <li><p>If <var>input</var> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then
-   <a>throw</a> a <code>TypeError</code>.
-
    <li><p>Set <var>request</var> to <var>input</var>'s
    <a for=Request>request</a>.
 
@@ -5348,10 +5345,14 @@ constructor must run these steps:
    <a for=request>use-CORS-preflight flag</a>.
   </ol>
 
+ <li><p>If <var>inputBody</var> is <var>body</var> and <var>input</var> is <a for=Body>disturbed</a>
+ or <a for=Body>locked</a> then <a>throw</a> a <code>TypeError</code>.
+
  <!-- Any steps after this must not throw. -->
 
  <li>
-  <p>If <var>inputBody</var> is non-null, then run these substeps:
+  <p>If <var>inputBody</var> is non-null and <var>inputBody</var> is <var>body</var>, then run these
+  substeps:
 
   <ol>
    <li>
@@ -5366,10 +5367,9 @@ constructor must run these steps:
     <p class="note no-backref">This makes <var>inputBody</var>'s <a for=body>stream</a>
     <a for=ReadableStream>locked</a> and <a for=ReadableStream>disturbed</a> immediately.
 
-   <li><p>If <var>inputBody</var> is <var>body</var>, then set <var>body</var> to a new
-   <a for=/>body</a> whose <a for=body>stream</a> is <var>rs</var>, whose <a for=body>source</a>
-   is <var>inputBody</var>'s <a for=body>source</a> and whose <a for=body>total bytes</a> is
-   <var>inputBody</var>'s <a for=body>total bytes</a>.
+   <li><p>Set <var>body</var> to a new <a for=/>body</a> whose <a for=body>stream</a> is
+   <var>rs</var>, whose <a for=body>source</a> is <var>inputBody</var>'s <a for=body>source</a> and
+   whose <a for=body>total bytes</a> is <var>inputBody</var>'s <a for=body>total bytes</a>.
   </ol>
 
  <li><p>Set <var>r</var>'s <a for=Request>request</a>'s <a for=request>body</a> to <var>body</var>.
@@ -6251,6 +6251,7 @@ Glenn Maynard,
 Graham Klyne,
 Hal Lockhart,
 Hallvord R. M. Steen,
+Harris Hancock,
 Henri Sivonen,
 Henry Story,
 Hiroshige Hayashizaki,

--- a/fetch.bs
+++ b/fetch.bs
@@ -5346,13 +5346,12 @@ constructor must run these steps:
   </ol>
 
  <li><p>If <var>inputBody</var> is <var>body</var> and <var>input</var> is <a for=Body>disturbed</a>
- or <a for=Body>locked</a> then <a>throw</a> a <code>TypeError</code>.
+ or <a for=Body>locked</a>, then <a>throw</a> a <code>TypeError</code>.
 
  <!-- Any steps after this must not throw. -->
 
  <li>
-  <p>If <var>inputBody</var> is non-null and <var>inputBody</var> is <var>body</var>, then run these
-  substeps:
+  <p>If <var>inputBody</var> is non-null and <var>inputBody</var> is <var>body</var>, then:
 
   <ol>
    <li>
@@ -5368,7 +5367,7 @@ constructor must run these steps:
     <a for=ReadableStream>locked</a> and <a for=ReadableStream>disturbed</a> immediately.
 
    <li><p>Set <var>body</var> to a new <a for=/>body</a> whose <a for=body>stream</a> is
-   <var>rs</var>, whose <a for=body>source</a> is <var>inputBody</var>'s <a for=body>source</a> and
+   <var>rs</var>, whose <a for=body>source</a> is <var>inputBody</var>'s <a for=body>source</a>, and
    whose <a for=body>total bytes</a> is <var>inputBody</var>'s <a for=body>total bytes</a>.
   </ol>
 


### PR DESCRIPTION
Currently, the following code snippet replaces `request`'s body as one would expect:

```javascript
let request = new Request(url, { method: "POST", body: "foo" })
request = new Request(request, { body: "bar" })
```

But this snippet throws a TypeError early in Request's constructor:

```javascript
let request = new Request(url, { method: "POST", body: "foo" })
await request.text()  // disturb the body
request = new Request(request, { body: "bar" })  // throws
```

This commit's changes allows the latter code snippet to work like the first one.

Fixes #674.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/675.html" title="Last updated on Mar 15, 2018, 8:10 AM GMT (03a8ac0)">Preview</a> | <a href="https://whatpr.org/fetch/675/ae71682...03a8ac0.html" title="Last updated on Mar 15, 2018, 8:10 AM GMT (03a8ac0)">Diff</a>