### PR TITLE
Remove unnecessary body transmission for service worker trapped requests

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3044,8 +3044,6 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
     <p>If <var>response</var> is not null, then run these substeps:
 
     <ol>
-     <li><p><a for=request>Transmit body</a> for <var>request</var>.
-
      <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
      <a>filtered response</a>, and to <var>response</var>'s
      <a for=internal>internal response</a> otherwise.


### PR DESCRIPTION
As the request is trapped by service worker, there is no need to transmit the body to network.

See #572 for more info.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/678.html" title="Last updated on Mar 6, 2018, 8:59 AM GMT (a572aed)">Preview</a> | <a href="https://whatpr.org/fetch/678/ae71682...a572aed.html" title="Last updated on Mar 6, 2018, 8:59 AM GMT (a572aed)">Diff</a>