### PR TITLE
Introduce {reload, history, submission}-navigation flags

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1162,6 +1162,18 @@ Unless stated otherwise, it is "<code>basic</code>".
 <p>A <a for=/>request</a> has an associated <dfn export for=request id=done-flag>done flag</dfn>.
 Unless stated otherwise, it is unset.
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=reload-navigation-flag>reload-navigation flag</dfn>. Unless stated
+otherwise, it is unset.
+
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=history-navigation-flag>history-navigation flag</dfn>. Unless stated
+otherwise, it is unset.
+
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=submission-navigation-flag>submission-navigation flag</dfn>. Unless stated
+otherwise, it is unset.
+
 <p class="note no-backref">A <a for=/>request</a>'s
 <a for=request>url list</a>,
 <a for=request>current url</a>,
@@ -4882,6 +4894,9 @@ interface Request {
   readonly attribute RequestRedirect redirect;
   readonly attribute DOMString integrity;
   readonly attribute boolean keepalive;
+  readonly attribute boolean isReloadNavigation;
+  readonly attribute boolean isHistoryNavigation;
+  readonly attribute boolean isSubmissionNavigation;
   readonly attribute AbortSignal signal;
 
   [NewObject] Request clone();
@@ -5039,6 +5054,16 @@ initially a new {{AbortSignal}} object.
  <dd>Returns a boolean indicating whether or not <var>request</var> can outlive the global in which
  it was created.
 
+ <dt><code><var>request</var> . <a attribute for=Request>isReloadNavigation</a></code>
+ <dd>Returns a boolean indicating whether or not <var>request</var> is for a reload navigation.
+
+ <dt><code><var>request</var> . <a attribute for=Request>isHistoryNavigation</a></code>
+ <dd>Returns a boolean indicating whether or not <var>request</var> is for a back or forward
+ navigation.
+
+ <dt><code><var>request</var> . <a attribute for=Request>isSubmissionNavigation</a></code>
+ <dd>Returns a boolean indicating whether or not <var>request</var> is for a submission navigation.
+
  <dt><code><var>request</var> . <a attribute for=Request>signal</a></code>
  <dd>Returns the signal associated with <var>request</var>, which is an
  {{AbortSignal}} object indicating whether or not <var>request</var> has been aborted, and its abort
@@ -5141,8 +5166,11 @@ constructor must run these steps:
  <a for=request>redirect mode</a>,
  <a for=request>integrity metadata</a> is
  <var>request</var>'s
- <a for=request>integrity metadata</a>, and
- <a>keepalive flag</a> is <var>request</var>'s <a>keepalive flag</a>.
+ <a for=request>integrity metadata</a>,
+ <a>keepalive flag</a> is <var>request</var>'s <a>keepalive flag</a>,
+ <a>reload-navigation flag</a> is  <var>request</var>'s <a>reload-navigation flag</a>,
+ <a>history-navigation flag</a> is  <var>request</var>'s <a>history-navigation flag</a>, and
+ <a>submission-navigation flag</a> is  <var>request</var>'s <a>submission-navigation flag</a>.
 
 
  <li>
@@ -5430,6 +5458,18 @@ must return <a for=Request>request</a>'s
 
 <p>The <dfn attribute for=Request><code>keepalive</code></dfn> attribute's getter
 must return true if <a for=Request>request</a>'s <a>keepalive flag</a>
+is set, and false otherwise.
+
+<p>The <dfn attribute for=Request><code>isReloadNavigation</code></dfn> attribute's getter
+must return true if <a for=Request>request</a>'s <a>reload-navigation flag</a>
+is set, and false otherwise.
+
+<p>The <dfn attribute for=Request><code>isHistoryNavigation</code></dfn> attribute's getter
+must return true if <a for=Request>request</a>'s <a>history-navigation flag</a>
+is set, and false otherwise.
+
+<p>The <dfn attribute for=Request><code>isReloadNavigation</code></dfn> attribute's getter
+must return true if <a for=Request>request</a>'s <a>submission-navigation flag</a>
 is set, and false otherwise.
 
 <p>The <dfn attribute for=Request><code>signal</code></dfn> attribute's getter must return the

--- a/fetch.bs
+++ b/fetch.bs
@@ -5468,7 +5468,7 @@ is set, and false otherwise.
 must return true if <a for=Request>request</a>'s <a>history-navigation flag</a>
 is set, and false otherwise.
 
-<p>The <dfn attribute for=Request><code>isReloadNavigation</code></dfn> attribute's getter
+<p>The <dfn attribute for=Request><code>isSubmissionNavigation</code></dfn> attribute's getter
 must return true if <a for=Request>request</a>'s <a>submission-navigation flag</a>
 is set, and false otherwise.
 


### PR DESCRIPTION
This change introduces {reload, history, submission}-navigation flags and
is{Reload, History, Submission}Navigation attributes on Request class.

This is for https://github.com/w3c/ServiceWorker/issues/1167.