### PR TITLE
CORB: nosniff handling

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2346,12 +2346,20 @@ X-Content-Type-Options           = "nosniff" ; case-insensitive</pre>
  <li><p>If <var>destination</var> is "<code>style</code>" and <var>mimeType</var>
  (ignoring parameters) is not `<code>text/css</code>`, then return <b>blocked</b>.
 
+ <li><p>If <var>destination</var> is
+     "<code>audio</code>",
+     "<code>font</code>",
+     "<code>image</code>",
+     "<code>track</code>" or
+     "<code>video</code>"
+ and <var>mimeType</var> (ignoring parameters) is
+     a <a>HTML MIME type</a>,
+     a <a>JSON MIME type</a> or
+     an <a>XML MIME type</a> (except "<code>image/svg+xml</code>")
+ then return <b>blocked</b>.
+
  <li><p>Return <b>allowed</b>.
 </ol>
-
-<p class="note no-backref">Only <a for=/>request</a> <a for=request>destinations</a> that are
-<a for=request/destination>script-like</a> or "<code>style</code>" are considered as any exploits
-pertain to them. Also, considering "<code>image</code>" was not compatible with deployed content.
 
 
 


### PR DESCRIPTION
# Motivation for the changes

Allowing blocking of HTML/JSON/XML [nosniff](https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?) responses going to image (or audio/video/font/track) destinations covers most of scenarios where [CORB](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md) is actually [observable in the wild today](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md#Quantifying-CORB-impact-on-existing-websites).

# Explaining why blocking via net error is okay

Note that 1) CORB explainer asks to block a protected response by injecting an empty body (see the "[How does CORB “block” a response?](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md#How-does-CORB-block-a-response)" section in the explainer) and 2) the Fetch spec asks to block a nosniff responses by injecting a network error (see the "[Main fetch](https://fetch.spec.whatwg.org/#main-fetch)" section, item 10). 

This difference might matter for some destinations (e.g. XHR and `fetch()`), but shouldn't matter for destinations covered here.  For example - [HTMLImageElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement)' `onerror` event will fire _both_ in case of a network error _and_ in case of a decode error (e.g. one triggered by the empty body injected by CORB).

One potential difference is the timing of when the network error VS decode error is observed.  In practice, this timing difference shouldn't matter though - CORB can be seen as a very slow network proxy that postpones the network error until the image decoding actually happens.