### PR TITLE
Return network error for scheme-fetch for ftp/file

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2998,10 +2998,8 @@ steps:
  <dt>"<code>file</code>"
  <dt>"<code>ftp</code>"
  <dd>
-  <p>For now, unfortunate as it is, <code>file</code> and <code>ftp</code> <a for=/>URLs</a> are
-  left as an exercise for the reader.
-
-  <p>When in doubt, return a <a>network error</a>.
+     
+  <p>Return a <a>network error</a>.
 
  <dt>"<code>filesystem</code>" <!-- flag below also applies to "indexeddb" -->
  <dd>


### PR DESCRIPTION
Currently, it's defined as "exercise for the reader".
I suggest changing the wording to default to network error.

Is this acceptable?
If yes, is this patch OK or do we want to add a note?

CCing @evilpie


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/699.html" title="Last updated on Apr 13, 2018, 10:28 AM GMT (5ea9140)">Preview</a> | <a href="https://whatpr.org/fetch/699/5b7dae0...5ea9140.html" title="Last updated on Apr 13, 2018, 10:28 AM GMT (5ea9140)">Diff</a>