### PR TITLE
Set response's CSP list once

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2799,6 +2799,9 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
+ <li><p><a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>Set <var>internalResponse</var>'s CSP list</a>.
+ [[!CSP]]
+
  <li>
   <p>If <var>response</var> is not a <a>network error</a> and any
   of the following algorithms returns <b>blocked</b>, then set <var>response</var> and
@@ -3072,9 +3075,6 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
        not "<code>follow</code>" and <var>response</var>'s
        <a for=response>url list</a> has more than one item.
       </ul>
-
-     <li><p>Execute <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
-     on <var>actualResponse</var>. [[!CSP]]
     </ol>
   </ol>
 
@@ -3916,10 +3916,6 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <p class=XXX>Gecko
     <a href=https://bugzilla.mozilla.org/show_bug.cgi?id=1030660>bug 1030660</a> looks
     into whether this quirk can be removed.
-
-   <li><p>Execute
-   <a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>set <var>response</var>'s CSP list</a>
-   on <var>response</var>. [[!CSP]]
 
    <li><p>If <var>response</var> is not a
    <a>network error</a> and <var>request</var>'s


### PR DESCRIPTION
Fixes #364.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/701.html" title="Last updated on Apr 17, 2018, 11:01 AM GMT (9bb9f09)">Preview</a> | <a href="https://whatpr.org/fetch/701/5b7dae0...9bb9f09.html" title="Last updated on Apr 17, 2018, 11:01 AM GMT (9bb9f09)">Diff</a>