### PR TITLE
Only allow blob: URLs that point to Blob objects

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2936,9 +2936,9 @@ steps:
      <a>object</a>.
 
      <li>
-      <p>If <var>request</var>'s <a for=request>method</a> is not
-      `<code>GET</code>` or <var>blob</var> is null, then return a
-      <a>network error</a>.
+      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>`,
+      <var>blob</var> is null, or <var>blob</var> is not a {{Blob}} object, then return a
+      <a>network error</a>. [[!FILEAPI]]
 
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction
       serves no useful purpose other than being interoperable.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2936,12 +2936,11 @@ steps:
      <a>object</a>.
 
      <li>
-      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>`,
-      <var>blob</var> is null, or <var>blob</var> is not a {{Blob}} object, then return a
-      <a>network error</a>. [[!FILEAPI]]
+      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>` or
+      <var>blob</var> is not a {{Blob}} object, then return a <a>network error</a>. [[!FILEAPI]]
 
-      <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction
-      serves no useful purpose other than being interoperable.
+      <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
+      other than being interoperable.
 
      <li><p>Let <var>response</var> be a new
      <a for=/>response</a>.


### PR DESCRIPTION
The reason this works is that https://html.spec.whatwg.org/#concept-media-load-resource (HTML's media element fetching algorithm) special cases MediaSource and MediaStream and handles them way before Fetch is hit.

Tests: ...

Fixes #457.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/708.html" title="Last updated on Apr 18, 2018, 11:52 AM GMT (0374f9e)">Preview</a> | <a href="https://whatpr.org/fetch/708/fd8ee5c...0374f9e.html" title="Last updated on Apr 18, 2018, 11:52 AM GMT (0374f9e)">Diff</a>