### PR TITLE
WindowOrWorkerGlobalScope is a mixin

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5716,7 +5716,7 @@ run these steps:
 <h3 id=fetch-method>Fetch method</h3>
 
 <pre class=idl>
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   [NewObject] Promise&lt;Response> fetch(RequestInfo input, optional RequestInit init);
 };</pre>
 


### PR DESCRIPTION
...and so extensions should use [`partial interface mixin`](https://heycam.github.io/webidl/#partial-interface-mixin) rather than `interface mixin`.

See also https://github.com/whatwg/html/pull/3650


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch-1/719.html" title="Last updated on Apr 27, 2018, 10:43 AM GMT (4b3690b)">Preview</a> | <a href="https://whatpr.org/fetch/719/d5d0840...4b3690b.html" title="Last updated on Apr 27, 2018, 10:43 AM GMT (4b3690b)">Diff</a>