### PR TITLE
Associate import() with the "script" destination

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -873,7 +873,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>script</code>"
    <td><code>script-src</code>
-   <td>HTML's <code>&lt;script></code>, <code>importScripts()</code>
+   <td>HTML's <code>&lt;script></code>, <code>importScripts()</code>, <code>import()</code>
   <tr>
    <td>"<code>serviceworker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>


### PR DESCRIPTION
Before this patch, the Fetch spec says nothing about the destination of
dynamic/static import(). This patch clarifies it.

importScripts() that is a similar feature of import() is associated with the
"script" destinaton, so import() should also be associated with the "script"
destination.

cc: @nyaxt


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/724.html" title="Last updated on May 14, 2018, 4:39 AM GMT (ac10f0a)">Preview</a> | <a href="https://whatpr.org/fetch/724/3a896ef...ac10f0a.html" title="Last updated on May 14, 2018, 4:39 AM GMT (ac10f0a)">Diff</a>