### PR TITLE
Editorial: avoid normative keywords in domintro block

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5026,7 +5026,7 @@ initially a new {{AbortSignal}} object.
   <var>input</var> is a string, and <var>input</var>'s {{Request/url}} if <var>input</var> is a
   {{Request}} object.
 
-  <p>The optional <var>init</var> argument is an object whose properties can be set as follows:</p>
+  <p>The <var>init</var> argument is an object whose properties can be set as follows:</p>
 
   <dl>
    <dt>{{RequestInit/method}}
@@ -5059,8 +5059,9 @@ initially a new {{AbortSignal}} object.
    <var>request</var>'s {{Request/cache}}.
 
    <dt>{{RequestInit/redirect}}
-   <dd>A string indicating whether or not <var>request</var> should automatically follow redirects,
-   result in an error, or manually follow redirects. Sets <var>request</var>'s {{Request/redirect}}.
+   <dd>A string indicating whether <var>request</var> follows redirects, results in an error upon
+   encountering a redirect, or returns the redirect (in an opaque fashion). Sets
+   <var>request</var>'s {{Request/redirect}}.
 
    <dt>{{RequestInit/integrity}}
    <dd>A cryptographic hash of the resource to be fetched by <var>request</var>. Sets
@@ -5121,8 +5122,7 @@ initially a new {{AbortSignal}} object.
 
  <dt><code><var>request</var> . <a attribute for=Request>integrity</a></code>
  <dd>Returns <var>request</var>'s subresource integrity metadata, which is a cryptographic hash of
- the resource being fetched. Its value may consist of multiple hashes separated by whitespace.
- [[SRI]]
+ the resource being fetched. Its value consists of multiple hashes separated by whitespace. [[SRI]]
 
  <dt><code><var>request</var> . <a attribute for=Request>keepalive</a></code>
  <dd>Returns a boolean indicating whether or not <var>request</var> can outlive the global in which


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/734.html" title="Last updated on May 24, 2018, 10:45 AM GMT (9479f7c)">Preview</a> | <a href="https://whatpr.org/fetch/734/794dd54...9479f7c.html" title="Last updated on May 24, 2018, 10:45 AM GMT (9479f7c)">Diff</a>