### PR TITLE
Block AFP ports (427, 548)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1690,7 +1690,8 @@ run these steps:
  <tr><td>143<td>imap2
  <tr><td>179<td>bgp
  <tr><td>389<td>ldap
- <tr><td>465<td>smtp+ssl
+ <tr><td>427<td>afp (alternate)
+ <tr><td>465<td>smtp (alternate)
  <tr><td>512<td>print / exec
  <tr><td>513<td>login
  <tr><td>514<td>shell
@@ -1700,24 +1701,25 @@ run these steps:
  <tr><td>531<td>chat
  <tr><td>532<td>netnews
  <tr><td>540<td>uucp
+ <tr><td>548<td>afp
  <tr><td>556<td>remotefs
  <tr><td>563<td>nntp+ssl
- <tr><td>587<td>smtp
+ <tr><td>587<td>smtp (outgoing)
  <tr><td>601<td>syslog-conn
  <tr><td>636<td>ldap+ssl
  <tr><td>993<td>ldap+ssl
  <tr><td>995<td>pop3+ssl
  <tr><td>2049<td>nfs
- <tr><td>3659<td>apple-sasl<!-- not in Gecko, Apple addition adopted by Chrome -->
+ <tr><td>3659<td>apple-sasl
  <tr><td>4045<td>lockd
  <tr><td>6000<td>x11
- <tr><td>6665<td>irc (alternate)<!-- not in Gecko, Apple addition adopted by Chrome -->
- <tr><td>6666<td>irc (alternate)<!-- not in Gecko, Apple addition adopted by Chrome -->
- <tr><td>6667<td>irc (default)<!-- not in Gecko, Apple addition adopted by Chrome -->
- <tr><td>6668<td>irc (alternate)<!-- not in Gecko, Apple addition adopted by Chrome -->
- <tr><td>6669<td>irc (alternate)<!-- not in Gecko, Apple addition adopted by Chrome -->
+ <tr><td>6665<td>irc (alternate)
+ <tr><td>6666<td>irc (alternate)
+ <tr><td>6667<td>irc (default)
+ <tr><td>6668<td>irc (alternate)
+ <tr><td>6669<td>irc (alternate)
 </table>
-<!-- http://www-archive.mozilla.org/projects/netlib/PortBanning.html -->
+<!-- https://www-archive.mozilla.org/projects/netlib/PortBanning.html -->
 
 
 <h3 dfn export lt="should response to request be blocked due to mime type" id=should-response-to-request-be-blocked-due-to-mime-type?>Should
@@ -6434,6 +6436,7 @@ Srirama Chandra Sekhar Mogali,
 Steven Salat,
 Sunava Dutta,
 Surya Ismail,
+Takashi Toyoshima,
 吉野剛史 (Takeshi Yoshino),
 Thomas Roessler,
 Thomas Wisniewski,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1718,6 +1718,7 @@ run these steps:
  <tr><td>6667<td>irc (default)
  <tr><td>6668<td>irc (alternate)
  <tr><td>6669<td>irc (alternate)
+ <tr><td>6697<td>irc+tls
 </table>
 <!-- https://www-archive.mozilla.org/projects/netlib/PortBanning.html -->
 


### PR DESCRIPTION
Also remove some obsolete comments.

Fixes #694.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/738.html" title="Last updated on May 30, 2018, 1:40 PM GMT (fbcaa6f)">Preview</a> | <a href="https://whatpr.org/fetch/738/78a8dcd...fbcaa6f.html" title="Last updated on May 30, 2018, 1:40 PM GMT (fbcaa6f)">Diff</a>