### PR TITLE
Move definition of "reload-navigation flag"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1148,6 +1148,8 @@ determine whether requests or responses are to be blocked in a given context. [[
 <dfn export for=request id=concept-request-reload-navigation-flag>reload-navigation flag</dfn>.
 Unless stated otherwise, it is unset.
 
+<p class="note no-backref">This flag is for exclusive use by HTML's navigate algorithm. [[!HTML]]
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -1174,8 +1176,6 @@ Unless stated otherwise, it is "<code>basic</code>".
 
 <p>A <a for=/>request</a> has an associated <dfn export for=request id=done-flag>done flag</dfn>.
 Unless stated otherwise, it is unset.
-
-<p class="note no-backref">This flag is for exclusive use by HTML's navigate algorithm. [[!HTML]]
 
 <p class="note no-backref">A <a for=/>request</a>'s <a for=request>tainted origin flag</a>,
 <a for=request>url list</a>, <a for=request>current url</a>, <a for=request>redirect count</a>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1144,6 +1144,10 @@ are generally populated from attributes and flags on the HTML element responsibl
 <a for=/>request</a>. They are used by various algorithms in <cite>Content Security Policy</cite> to
 determine whether requests or responses are to be blocked in a given context. [[!CSP]]
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-reload-navigation-flag>reload-navigation flag</dfn>.
+Unless stated otherwise, it is unset.
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -1169,10 +1173,6 @@ which is "<code>basic</code>", "<code>cors</code>", or "<code>opaque</code>".
 Unless stated otherwise, it is "<code>basic</code>".
 
 <p>A <a for=/>request</a> has an associated <dfn export for=request id=done-flag>done flag</dfn>.
-Unless stated otherwise, it is unset.
-
-<p>A <a for=/>request</a> has an associated
-<dfn export for=request id=concept-request-reload-navigation-flag>reload-navigation flag</dfn>.
 Unless stated otherwise, it is unset.
 
 <p class="note no-backref">This flag is for exclusive use by HTML's navigate algorithm. [[!HTML]]


### PR DESCRIPTION
This is a refactoring change.

Fixes #732.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/739.html" title="Last updated on May 28, 2018, 10:08 AM GMT (de45648)">Preview</a> | <a href="https://whatpr.org/fetch/739/af45ce3...de45648.html" title="Last updated on May 28, 2018, 10:08 AM GMT (de45648)">Diff</a>