### PR TITLE
Editorial: replace UTF-8 encode with isomorphic encode

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3507,10 +3507,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <li><p>If <var>httpRequest</var>'s <a for=request>referrer</a> is a <a for=/>URL</a>, then
    <a for="header list">append</a> `<code>Referer</code>`/<var>httpRequest</var>'s
-   <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>UTF-8 encoded</a>, to
-   <var>httpRequest</var>'s <a for=request>header list</a>.
-   <!-- XXX ideally we have an easier way to convert something ASCII-safe into bytes
-            concept-as-bytes -->
+   <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>,
+   to <var>httpRequest</var>'s <a for=request>header list</a>.
 
    <li><p>If the <i>CORS flag</i> is set, <var>httpRequest</var>'s <a for=request>method</a> is
    neither `<code>GET</code>` nor `<code>HEAD</code>`, or <var>httpRequest</var>'s
@@ -5715,7 +5713,7 @@ method, when invoked, must run these steps:
  <a for=response>status</a> to <var>status</var>.
 
  <li><p><a for="header list">Set</a> `<code>Location</code>` to <var>parsedURL</var>,
- <a lt="url serializer">serialized</a> and <a>UTF-8 encoded</a>, in <var>r</var>'s
+ <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>, in <var>r</var>'s
  <a for=Response>response</a>'s <a for=response>header list</a>.
 
  <li><p>Return <var>r</var>.


### PR DESCRIPTION
This more clearly indicates the input is (supposed to be) ASCII safe.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/742.html" title="Last updated on May 28, 2018, 12:03 PM GMT (60f3384)">Preview</a> | <a href="https://whatpr.org/fetch/742/efe088f...60f3384.html" title="Last updated on May 28, 2018, 12:03 PM GMT (60f3384)">Diff</a>