### PR TITLE
Make CORS-preflight fetches set the CORS flag

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4138,8 +4138,8 @@ the <a>CORS protocol</a> is understood. The so-called <a>CORS-preflight request<
 successful it populates the <a>CORS-preflight cache</a> to minimize the
 number of these <a lt="CORS-preflight fetch">fetches</a>.
 
-<p>To perform a <dfn id=cors-preflight-fetch-0>CORS-preflight fetch</dfn> using <var>request</var>, run these
-steps:
+<p>To perform a <dfn id=cors-preflight-fetch-0>CORS-preflight fetch</dfn> using <var>request</var>,
+run these steps:
 
 <ol>
  <li>
@@ -4184,8 +4184,7 @@ steps:
   0x2C is not the way this was implemented, for better or worse.
 
  <li><p>Let <var>response</var> be the result of performing an
- <a>HTTP-network-or-cache fetch</a> using
- <var>preflight</var>.
+ <a>HTTP-network-or-cache fetch</a> using <var>preflight</var> with the <i>CORS flag</i> set.
 
  <li>
   <p>If a <a for=cors>CORS check</a> for <var>request</var> and <var>response</var> returns success


### PR DESCRIPTION
Otherwise a 401 response would not necessarily result in rejection.

Fixes #741.