### PR TITLE
Update WPT link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ If you can commit to this repository, see the
 ### Tests
 
 Tests can be found in the `fetch/` directory of
-[web-platform-tests](https://github.com/w3c/web-platform-tests).
+[web-platform-tests/wpt](https://github.com/web-platform-tests/wpt).


### PR DESCRIPTION
I opted for the link text to be `web-platform-tests/wpt` to be more descriptive than `wpt`.