### PR TITLE
Stop saying WebSocket auth is disallowed

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6301,12 +6301,11 @@ therefore not shareable, a WebSocket connection is very close to identical to an
 <p><dfn>Fail the WebSocket connection</dfn> and <dfn>the WebSocket connection is established</dfn>
 are defined by The WebSocket Protocol. [[!WSP]]
 
-<p class=warning>The reason redirects are not followed, HTTP authentication will not function, and
-this handshake is generally restricted is because that could introduce serious security problems in
-a web browser context. For example, consider a host with a WebSocket server at one path and an open
-HTTP redirector at another. Suddenly, any script that can be given a particular WebSocket URL can be
-tricked into communicating to (and potentially sharing secrets with) any host on the internet, even
-if the script checks that the URL has the right hostname.
+<p class=warning>The reason redirects are not followed is because it could introduce serious
+security problems in a web browser context. For example, consider a host with a WebSocket server at
+one path and an open HTTP redirector at another. Suddenly, any script that can be given a particular
+WebSocket URL can be tricked into communicating to (and potentially sharing secrets with) any host
+on the internet, even if the script checks that the URL has the right hostname.
 <!-- https://www.ietf.org/mail-archive/web/hybi/current/msg06951.html -->
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6301,11 +6301,12 @@ therefore not shareable, a WebSocket connection is very close to identical to an
 <p><dfn>Fail the WebSocket connection</dfn> and <dfn>the WebSocket connection is established</dfn>
 are defined by The WebSocket Protocol. [[!WSP]]
 
-<p class=warning>The reason redirects are not followed is because it could introduce serious
-security problems in a web browser context. For example, consider a host with a WebSocket server at
-one path and an open HTTP redirector at another. Suddenly, any script that can be given a particular
-WebSocket URL can be tricked into communicating to (and potentially sharing secrets with) any host
-on the internet, even if the script checks that the URL has the right hostname.
+<p class=warning>The reason redirects are not followed and this handshake is generally restricted is
+because it could introduce serious security problems in a web browser context. For example, consider
+a host with a WebSocket server at one path and an open HTTP redirector at another. Suddenly, any
+script that can be given a particular WebSocket URL can be tricked into communicating to (and
+potentially sharing secrets with) any host on the internet, even if the script checks that the URL
+has the right hostname.
 <!-- https://www.ietf.org/mail-archive/web/hybi/current/msg06951.html -->
 
 


### PR DESCRIPTION
Remove the warning that HTTP authentication is prohibited for
WebSockets.

See #565 for background.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/761.html" title="Last updated on Jun 15, 2018, 2:21 PM GMT (21e683d)">Preview</a> | <a href="https://whatpr.org/fetch/761/2f3d04d...21e683d.html" title="Last updated on Jun 15, 2018, 2:21 PM GMT (21e683d)">Diff</a>