### PR TITLE
Additional reasoning for sending Accept-Encoding: identity

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3657,8 +3657,14 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     `<code>Accept-Encoding</code>`/`<code>identity</code>` to <var>httpRequest</var>'s
     <a for=request>header list</a>.
 
-    <p class="note no-backref"><a href="https://jakearchibald.github.io/accept-encoding-range-test/">Many servers</a>
-    mistakenly ignore `<code>Range</code>` headers if a non-identity encoding is accepted.
+    <div class="note no-backref">
+     <p>This avoids a failure when <a lt="handle content codings">handling content codings</a> with
+     a part of an encoded <a for=/>response</a>.
+
+     <p>Additionally,
+     <a href="https://jakearchibald.github.io/accept-encoding-range-test/">many servers</a>
+     mistakenly ignore `<code>Range</code>` headers if a non-identity encoding is accepted.
+    </div>
 
    <li>
     <p>Modify <var>httpRequest</var>'s <a for=request>header list</a> per HTTP. Do not


### PR DESCRIPTION
I hadn't really appreciated this with the initial PR, but preventing encoding solves a pretty big gotcha if developers tried to fetch ranges with `fetch()`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/764.html" title="Last updated on Jun 14, 2018, 12:54 PM GMT (571aa0f)">Preview</a> | <a href="https://whatpr.org/fetch/764/2f3d04d...571aa0f.html" title="Last updated on Jun 14, 2018, 12:54 PM GMT (571aa0f)">Diff</a>