### PR TITLE
Align CH processing model with implementation and HTML#3774

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -644,7 +644,9 @@ production as
 
 <ol>
  <li><p>Let <var>value</var> be <var>header</var>'s <a for=header>value</a>.
- <li><p>If <var>value</var> starts with "Sec-", return true.
+
+ <li><p>If <var>header</var>'s <a for=header>name</a> starts with a <a>byte-case-insensitive</a>
+ match to `Sec-`, return true.
 
  <li>
   <p><a>Byte-lowercase</a> <var>header</var>'s <a for=header>name</a> and switch on the result:

--- a/fetch.bs
+++ b/fetch.bs
@@ -3187,8 +3187,7 @@ the request.
         <dd>a suitable <a href=https://wicg.github.io/netinfo/#ect-request-header-field>ECT value</a>
        </dl>
        
-      <li><p>If <var>request</var> is a cross-origin <a>subresource request</a> and the result of
-       running <a
+      <li><p>If <var>request</var> is a <a>subresource request</a> and the result of running <a
        href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
        <var>request</var> be allowed to use <var>feature</var>?</a>,
        given <var>request</var> and <var>hintName</var>’s

--- a/fetch.bs
+++ b/fetch.bs
@@ -644,6 +644,7 @@ production as
 
 <ol>
  <li><p>Let <var>value</var> be <var>header</var>'s <a for=header>value</a>.
+ <li><p>If <var>value</var> starts with "Sec-", return true.
 
  <li>
   <p><a>Byte-lowercase</a> <var>header</var>'s <a for=header>name</a> and switch on the result:
@@ -1762,6 +1763,10 @@ specified. [[!CSP]]
 <p>A <a for=/>response</a> has an associated
 <dfn for=response id=concept-response-range-requested-flag>range-requested flag</dfn>, which is
 initially unset.
+
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-image-density>image density</dfn>, which is initially set to
+zero.
 
 <p class=note>This is used to ensure to prevent a partial response from an earlier ranged request
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
@@ -3191,6 +3196,7 @@ the request.
 
        <!-- TODO(yoav): Fix the above Feature policy link -->
        <!-- TODO(yoav): Fix the Client hints reference to the HTML one, once it lands -->
+      <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
 
       <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">does not
       contain</a> <var>hintName</var>, a user agent should <a for="header list">append</a>
@@ -3583,6 +3589,12 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <a>queue a fetch-request-done task</a> for <var>request</var>.
   </ol>
 
+ <li><p>If <var>request</var>'s destination is "image" and <var>response</var>'s
+ <a for=response>header list</a> <a for="header list">contains</a>
+  `<code>Content-DPR</code>`, set <var>response</var>'s <a for=response>density</a> value to the
+ result of parsing the header value as float.
+ <!-- TODO: propoerly link parse as float -->
+
  <li><p><a>Queue a fetch task</a> on <var>request</var> to
  <a>process response</a> for <var>response</var>.
 
@@ -3945,6 +3957,20 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
  <a for=request>tainted origin flag</a> is set or <var>request</var>'s <a for=request>origin</a> is
  not <a>same origin</a> with <var>actualResponse</var>'s <a for=response>location URL</a>'s
  <a for=url>origin</a>, then return a <a>network error</a>.
+
+ <li><p><a for=list>For each</a> <var>hintName</var> of <var>request</var>'s
+ <a for=request>client-hints set</a>:
+ <ol>
+  <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
+  <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list"> contains</a>
+  <var>hintName</var> and if the result of running <a
+  href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
+  request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
+  <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
+  policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from
+  <a for=request>header list</a>.
+  [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
+ </ol>
 
  <li>
   <p>If <i>CORS flag</i> is set and <var>actualResponse</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -3186,23 +3186,24 @@ the request.
         <dt>`<code>ECT</code>`
         <dd>a suitable <a href=https://wicg.github.io/netinfo/#ect-request-header-field>ECT value</a>
        </dl>
-
-       <li><p>If the result of running
-       <a href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
+       
+      <li><p>If <var>request</var> is a cross-origin <a>subresource request</a> and the result of
+       running <a
+       href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
        <var>request</var> be allowed to use <var>feature</var>?</a>,
        given <var>request</var> and <var>hintName</var>’s
        <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
-       policy-controlled feature</a>, returns <code>false</code>, then continue.
+       policy-controlled feature</a>, returns <code>false</code>, then skip the next steps and
+       continue to the next <var>hintName</var>.
        [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
 
+       <!-- TODO(yoav): Fix the above Feature policy link -->
+       <!-- TODO(yoav): Fix the Client hints reference to the HTML one, once it lands -->
+       
       <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">does not
       contain</a> <var>hintName</var>, a user agent should <a for="header list">append</a>
       <var>hintName</var>/<var>value</var> to <var>request</var>'s <a for=request>header list</a>.
      </ol>
-
-     <p class=XXX>The above step should be applicable only for same-origin requests. See
-     <a href="https://github.com/whatwg/fetch/issues/800">issue</a> for more details.</p>
-
 
     <li><p>If <var>request</var> is a <a>subresource request</a>, then:
      <ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1764,13 +1764,13 @@ specified. [[!CSP]]
 <dfn for=response id=concept-response-range-requested-flag>range-requested flag</dfn>, which is
 initially unset.
 
-<p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-image-density>image density</dfn>, which is initially set to
-zero.
-
 <p class=note>This is used to ensure to prevent a partial response from an earlier ranged request
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
 description of the attack.
+
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-image-density>image density</dfn>, which is initially set to
+zero.
 
 <p>A <a for=/>response</a> can have an associated
 <dfn export for=response id=concept-response-location-url>location URL</dfn> (null, failure, or a
@@ -2142,7 +2142,11 @@ run these steps:
 <p>A <dfn export id=concept-client-hints-list>client-hints set</dfn> is a
 <a for=/>set</a> of
 <a href=http://httpwg.org/http-extensions/client-hints.html#accept-ch>Client hint tokens</a>, each
-of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`, or
+of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`,
+`<code>Width</code>`, `<code>Device-Memory</code>`, `<code>RTT</code>`, `<code>Downlink</code>`, or
+`<code>ECT</code>`.
+
+
 `<code>Width</code>`.
 
 <h3 id=streams>Streams</h3>
@@ -3591,7 +3595,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
 
  <li><p>If <var>request</var>'s destination is "image" and <var>response</var>'s
  <a for=response>header list</a> <a for="header list">contains</a>
-  `<code>Content-DPR</code>`, set <var>response</var>'s <a for=response>density</a> value to the
+  `<code>Content-DPR</code>`, set <var>response</var>'s <a for=response>image density</a> value to the
  result of parsing the header value as float.
  <!-- TODO: propoerly link parse as float -->
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3179,6 +3179,14 @@ the request.
         <dd>a suitable <a href=https://wicg.github.io/netinfo/#ect-request-header-field>ECT value</a>
        </dl>
 
+       <li><p>If the result of running
+       <a href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
+       <var>request</var> be allowed to use <var>feature</var>?</a>,
+       given <var>request</var> and <var>hintName</var>’s
+       <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
+       policy-controlled feature</a>, returns <code>false</code>, then continue.
+       [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
+
       <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">does not
       contain</a> <var>hintName</var>, a user agent should <a for="header list">append</a>
       <var>hintName</var>/<var>value</var> to <var>request</var>'s <a for=request>header list</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3189,8 +3189,7 @@ the request.
        
       <li><p>If <var>request</var> is a <a>subresource request</a> and the result of running <a
        href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
-       <var>request</var> be allowed to use <var>feature</var>?</a>,
-       given <var>request</var> and <var>hintName</var>’s
+       request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
        <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
        policy-controlled feature</a>, returns <code>false</code>, then skip the next steps and
        continue to the next <var>hintName</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -78,6 +78,14 @@ url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:df
     },
     "OCSP": {
         "aliasOf": "RFC2560"
+    },
+    "FEATURE-POLICY": {
+        "authors": [
+            "Ian Clelland"
+        ],
+        "href": "https://wicg.github.io/feature-policy/",
+        "publisher": "WICG",
+        "title": "Feature Policy"
     }
 }
 </pre>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2134,7 +2134,7 @@ run these steps:
 
 <h3 id=client-hints-set>Client-hints set</h3>
 
-<p>A <dfn export id=concept-client-hints-list for=/>client-hints set</dfn> is a
+<p>A <dfn export id=concept-client-hints-list>client-hints set</dfn> is a
 <a for=/>set</a> of
 <a href=http://httpwg.org/http-extensions/client-hints.html#accept-ch>Client hint tokens</a>, each
 of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`, or

--- a/fetch.bs
+++ b/fetch.bs
@@ -2134,17 +2134,11 @@ run these steps:
 
 <h3 id=client-hints-set>Client-hints set</h3>
 
-<p class=XXX>HTTP Client-Hints requires further integration. More details on the
-<a href="https://github.com/whatwg/fetch/issues/726">issue</a>.
-[[!CLIENT-HINTS]]
-<!-- XXX -->
-
-<p>A <dfn export id=concept-client-hints-list>client-hints set</dfn> is a
+<p>A <dfn export id=concept-client-hints-list for=/>client-hints set</dfn> is a
 <a for=/>set</a> of
 <a href=http://httpwg.org/http-extensions/client-hints.html#accept-ch>Client hint tokens</a>, each
 of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`, or
 `<code>Width</code>`.
-
 
 <h3 id=streams>Streams</h3>
 
@@ -3162,7 +3156,7 @@ the request.
     <li>
 
      <p><a for=list>For each</a> <var>hintName</var> of <var>request</var>'s
-     <a for=client>client-hints set</a>:
+     <a for=request>client-hints set</a>:
 
      <ol>
       <li>
@@ -3186,7 +3180,7 @@ the request.
         <dt>`<code>ECT</code>`
         <dd>a suitable <a href=https://wicg.github.io/netinfo/#ect-request-header-field>ECT value</a>
        </dl>
-       
+
       <li><p>If <var>request</var> is a <a>subresource request</a> and the result of running <a
        href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
        request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
@@ -3197,7 +3191,7 @@ the request.
 
        <!-- TODO(yoav): Fix the above Feature policy link -->
        <!-- TODO(yoav): Fix the Client hints reference to the HTML one, once it lands -->
-       
+
       <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">does not
       contain</a> <var>hintName</var>, a user agent should <a for="header list">append</a>
       <var>hintName</var>/<var>value</var> to <var>request</var>'s <a for=request>header list</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2141,7 +2141,7 @@ run these steps:
 
 <h3 id=client-hints-set>Client-hints set</h3>
 
-<p>A <dfn export id=concept-client-hints-list>client-hints set</dfn> is a
+<p>A <dfn export id=concept-client-hints-set>client-hints set</dfn> is a
 <a for=/>set</a> of
 <a href=http://httpwg.org/http-extensions/client-hints.html#accept-ch>Client hint tokens</a>, each
 of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1296,6 +1296,15 @@ to not have to set <a for=/>request</a>'s <a for=request>referrer</a>.
 <a>environment settings object</a>.
 
 <p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-client-hints-set>client-hints set</dfn>,
+which is a <a lt="client-hints set">client-hints set</a>. Unless stated
+otherwise, it is the empty set.
+
+<p class="note no-backref">This will be used to override a client-hints set associated with
+an <a>environment settings object</a>.
+[[!CLIENT-HINTS]]
+
+<p>A <a for=/>request</a> has an associated
 <dfn id=synchronous-flag export for=request>synchronous flag</dfn>. Unless stated otherwise it is
 unset.
 
@@ -2113,6 +2122,20 @@ run these steps:
 
  <li><p>Return <b>allowed</b>.
 </ol>
+
+
+<h3 id=client-hints-set>Client-hints set</h3>
+
+<p class=XXX>HTTP Client-Hints requires further integration. More details on the
+<a href="https://github.com/whatwg/fetch/issues/726">issue</a>.
+[[!CLIENT-HINTS]]
+<!-- XXX -->
+
+<p>A <dfn export id=concept-client-hints-list>client-hints set</dfn> is a
+<a for=/>set</a> of
+<a href=http://httpwg.org/http-extensions/client-hints.html#accept-ch>Client hint tokens</a>, each
+of which is one of `<code>DPR</code>`, `<code>Save-Data</code>`, `<code>Viewport-Width</code>`, or
+`<code>Width</code>`.
 
 
 <h3 id=streams>Streams</h3>
@@ -3062,6 +3085,10 @@ the request.
    <a for=request>origin</a> to  <var>request</var>'s
    <a for=request>client</a>'s <a for="environment settings object">origin</a>.
 
+   <li><p>Set <var>request</var>'s <a for=request>client-hints set</a> to be a <a for=list>clone</a>
+   of the <a for="environment settings object">client-hints set</a> of the <var>request</var>'s
+   <a for=request>client</a>'s <a for="environment settings object">global object</a>.
+
    <li>
     <p>If <var>request</var>'s <a for=request>header list</a>
     <a for="header list">does not contain</a> `<code>Accept</code>`, then:
@@ -3107,20 +3134,73 @@ the request.
     HTTP/1 fetches.
 
    <li>
-    <p>If <var>request</var> is a <a>subresource request</a>, then:
+    <p>If <var>request</var> is a <a>navigation request</a>, a user agent should, for each
+    <a for=/>header</a> <a for=header>name</a> (<var>hintName</var>) in the first column of the
+    following table, if <var>request</var>'s <a for=request>header list</a>
+    <a for="header list">does not contain</a> <var>hintName</var>, then
+    <a for="header list">append</a>
+    <var>hintName</var>/the value given in the same row on the second column, to
+    <var>request</var>'s <a for=request>header list</a>.
 
-    <ol>
-     <li><p>Let <var>record</var> be a new
-     <a for="fetch group">fetch record</a> consisting of
-     <var>request</var> and this instance of the
-     <a for=/>fetch</a> algorithm.
+    <table>
+     <tbody><tr>
+      <th><a for=header>Name</a>
+      <th><a for=header>Value</a>
+     <tr>
+      <td>`<code>Save-Data</code>`
+      <td>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#save-data>save-data value</a>
+    </table>
 
-     <li><p>Append <var>record</var> to <var>request</var>'s
-     <a for=request>client</a>'s
-     <a for=fetch>fetch group</a> list of
-     <a for="fetch group">fetch records</a>.
-    </ol>
-  </ol>
+    <li>
+
+     <p><a for=list>For each</a> <var>hintName</var> of <var>request</var>'s
+     <a for=client>client-hints set</a>:
+
+     <ol>
+      <li>
+       <p>Let <var>value</var> be the first matching statement, switching on <var>hintName</var>:
+
+       <dl class=switch>
+        <dt>`<code>DPR</code>`
+        <dd>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#dpr>dpr value</a>
+        <dt>`<code>Save-Data</code>`
+        <dd>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#save-data>save-data value</a>
+        <dt>`<code>Viewport-Width</code>`
+        <dd>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#viewport-width>viewport-width value</a>
+        <dt>`<code>Width</code>`
+        <dd>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#width>width value</a>
+        <dt>`<code>Device-Memory</code>`
+        <dd>a suitable <a href=https://w3c.github.io/device-memory/#sec-device-memory-client-hint-header>Device-Memory value</a>
+        <dt>`<code>RTT</code>`
+        <dd>a suitable <a href=https://wicg.github.io/netinfo/#rtt-request-header-field>RTT value</a>
+        <dt>`<code>Downlink</code>`
+        <dd>a suitable <a href=https://wicg.github.io/netinfo/#downlink-request-header-field>Downlink value</a>
+        <dt>`<code>ECT</code>`
+        <dd>a suitable <a href=https://wicg.github.io/netinfo/#ect-request-header-field>ECT value</a>
+       </dl>
+
+      <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">does not
+      contain</a> <var>hintName</var>, a user agent should <a for="header list">append</a>
+      <var>hintName</var>/<var>value</var> to <var>request</var>'s <a for=request>header list</a>.
+     </ol>
+
+     <p class=XXX>The above step should be applicable only for same-origin requests. See
+     <a href="https://github.com/whatwg/fetch/issues/800">issue</a> for more details.</p>
+
+
+    <li><p>If <var>request</var> is a <a>subresource request</a>, then:
+     <ol>
+      <li><p>Let <var>record</var> be a new
+      <a for="fetch group">fetch record</a> consisting of
+      <var>request</var> and this instance of the
+      <a for=/>fetch</a> algorithm.
+
+      <li><p>Append <var>record</var> to <var>request</var>'s
+      <a for=request>client</a>'s
+      <a for=fetch>fetch group</a> list of
+      <a for="fetch group">fetch records</a>.
+     </ol>
+   </ol>
 
  <li>
   <p><a>If aborted</a>, then:


### PR DESCRIPTION
This PR tackles a part of https://github.com/whatwg/fetch/issues/726, by copying the request's client-hints list from the environment settings object's one (as defined in https://github.com/whatwg/html/pull/3774). It also aligns the addition of CH headers to current implementations, and adds the Device-Memory, RTT, Downlink and ECT hints.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/773.html" title="Last updated on Mar 26, 2019, 9:25 AM UTC (5067615)">Preview</a> | <a href="https://whatpr.org/fetch/773/6a644c6...5067615.html" title="Last updated on Mar 26, 2019, 9:25 AM UTC (5067615)">Diff</a>