### PR TITLE
Change name from target client id to replaces client id

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -734,7 +734,7 @@ requests, but not service worker requests. It references an
 <a>environment settings object</a> for a worker request.
 
 <p>A <a for=/>request</a> has an associated
-<dfn id=concept-request-target-client-id export for=request>target client id</dfn>
+<dfn id=concept-request-replaces-client-id export for=request>replaces client id</dfn>
 (a string). Unless stated otherwise it is the empty string.
 
 <p class="note no-backref">This is only used by <a>navigation requests</a>. It is the


### PR DESCRIPTION
We had decided to change the name of FetchEvent.targetClientId to
.replacesClientId to clarify the meaning that this client is a to be replaced
client: https://github.com/w3c/ServiceWorker/issues/1091#issuecomment-342569083.
Accordingly, this changes the name of the request's target client id item to
replaces client id.

Related issue: https://github.com/w3c/ServiceWorker/issues/1245.

SW PR: https://github.com/w3c/ServiceWorker/pull/1333.
HTML PR: https://github.com/whatwg/html/pull/3788.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/774.html" title="Last updated on Jul 1, 2018, 11:25 PM GMT (bc2ba08)">Preview</a> | <a href="https://whatpr.org/fetch/774/e6cbef2...bc2ba08.html" title="Last updated on Jul 1, 2018, 11:25 PM GMT (bc2ba08)">Diff</a>