### PR TITLE
Remove Reporting API from CORS exceptions

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -76,11 +76,6 @@ url: https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:d
         "href": "https://www.kb.cert.org/vuls/id/150227",
         "title": "HTTP proxy default configurations allow arbitrary TCP connections."
     },
-    "REPORTING": {
-        "authors": ["Ilya Grigorik", "Mike West"],
-        "href": "https://wicg.github.io/reporting/",
-        "title": "Reporting API"
-    },
     "EXPECT-CT": {
         "authors": [
             "Emily Stark"
@@ -2397,7 +2392,6 @@ values:
 
 <ul class=brief>
  <li>`<code>application/csp-report</code>` [[CSP]]
- <li>`<code>application/report</code>` [[REPORTING]]
  <li>`<code>application/expect-ct-report+json</code>` [[EXPECT-CT]]
  <li>`<code>application/xss-auditor-report</code>`
  <li>`<code>application/ocsp-request</code>` [[OCSP]]
@@ -6593,6 +6587,7 @@ Domenic Denicola,
 Dominic Farolino,
 Dominique Hazaël-Massieux,
 Doug Turner,
+Douglas Creager,
 Eero Häkkinen,
 Ehsan Akhgari,
 Emily Stark,


### PR DESCRIPTION
As of w3c/reporting#41, the Reporting spec sends CORS preflights for report uploads if the origin of the collector is different than the origin of the reports in the upload.  That means we can remove Reporting from the CORS protocol exception list.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/776.html" title="Last updated on Jul 9, 2018, 1:17 PM GMT (61605e1)">Preview</a> | <a href="https://whatpr.org/fetch/776/e6cbef2...61605e1.html" title="Last updated on Jul 9, 2018, 1:17 PM GMT (61605e1)">Diff</a>