### PR TITLE
Be clearer about how Fetch creates ReadableStreams.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1872,49 +1872,33 @@ we define common operations for {{ReadableStream}} objects. [[!STREAMS]]
 
 <p>To
 <dfn export for=ReadableStream id=concept-construct-readablestream>construct a <code>ReadableStream</code> object</dfn>
-with given <var>strategy</var>, <var>pull</var> action and <var>cancel</var> action, all of which
-are optional, run these steps:
+with given <var>highWaterMark</var>, <var>sizeAlgorithm</var> algorithm, <var>pull</var> action and
+<var>cancel</var> action, all of which are optional, run these steps:
+
+<p class=note>This algorithm used to take a <var ignore>strategy</var> parameter, whose
+<code>highWaterMark</code> and <code>sizeAlgorithm</code> members were extracted to provide what are
+now separate parameters. If another specification still passes that <var ignore>strategy</var>
+parameter, please update it.
 
 <ol>
- <li><p>Let <var>startAlg</var> be an algorithm that returns <code>undefined</code>.
+ <li><p>Let <var>startAlgorithm</var> be an algorithm that returns <code>undefined</code>.
 
- <li><p>Let <var>pullAlg</var> be an algorithm that returns:
+ <li><p>If <var>pull</var> is absent, set it to an action that returns <code>undefined</code>.
 
- <dl class=switch>
- <dt>If <var>pull</var> is given
- <dd>the result of [=promise-calling=] <var>pull</var>().
- <dt>Otherwise
- <dd>[=a promise resolved with=] <code>undefined</code>.
- </dl>
+ <li><p>Let <var>pullAlgorithm</var> be an algorithm that returns the result of [=promise-calling=]
+ <var>pull</var>().
 
- <li><p>Let <var>cancelAlg</var> be an algorithm that takes a <var>reason</var> and returns:
- <dl class=switch>
- <dt>If <var>cancel</var> is given
- <dd>the result of [=promise-calling=] <var>cancel</var>(<var>reason</var>).
- <dt>Otherwise
- <dd>[=a promise resolved with=] <code>undefined</code>.
- </dl>
+ <li><p>If <var>cancel</var> is absent, set it to an action that returns <code>undefined</code>.
 
- <li><p>Let <var>highWaterMark</var> be:
- <dl class=switch>
- <dt>If <var>strategy</var> is given and <var>strategy</var>.<a spec=streams for="queuing
- strategy">highWaterMark</a> exists
- <dd><var>strategy</var>.<a spec=streams for="queuing strategy">highWaterMark</a>.
- <dt>Otherwise
- <dd><code>1</code>.
- </dl>
+ <li><p>Let <var>cancelAlgorithm</var> be an algorithm that takes a <var>reason</var> and returns
+ the result of [=promise-calling=] <var>cancel</var>(<var>reason</var>).
 
- <li><p>Let <var>sizeAlg</var> be:
- <dl class=switch>
- <dt>If <var>strategy</var> is given and <var>strategy</var>.<a idl spec=streams for="queuing
- strategy" lt="size()">size</a> exists
- <dd><var>strategy</var>.size.
- <dt>Otherwise
- <dd>an algorithm that returns <code>1</code>.
- </dl>
+ <li><p>If <var>highWaterMark</var> is absent, set it to <code>1</code>.
 
-  <li><p>Return [$CreateReadableStream$](<var>startAlg</var>, <var>pullAlg</var>,
- <var>cancelAlg</var>, <var>highWaterMark</var>, <var>sizeAlg</var>).
+ <li><p>If <var>sizeAlgorithm</var> is absent, set it to an algorithm that returns <code>1</code>.
+
+  <li><p>Return [$CreateReadableStream$](<var>startAlgorithm</var>, <var>pullAlgorithm</var>,
+ <var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var>).
 </ol>
 
 <p>To
@@ -4151,10 +4135,11 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
   </ol>
 
  <li>
-  <p>Let <var>strategy</var> be an object. The user agent may choose any object.
+  <p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
-  <p class="note no-backref"><var>strategy</var> is used to control the queuing strategy of
-  <var>stream</var> constructed below.
+ <li>
+  <p>Let <var>sizeAlgorithm</var> be an algorithm that accepts a <a>chunk</a> object and returns a
+  non-negative, non-NaN, non-infinite number, chosen by the user agent.
 
  <li><p>Let <var>pull</var> be an action that <a lt=resumed for=fetch>resumes</a> the ongoing fetch
  if it is <a lt=suspend for=fetch>suspended</a>.
@@ -4165,7 +4150,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
  <li>
   <p>Let <var>stream</var> be the result of
   <a lt="construct a ReadableStream object" for=ReadableStream>constructing</a> a
-  {{ReadableStream}} object with <var>strategy</var>,
+  {{ReadableStream}} object with <var>highWaterMark</var>, <var>sizeAlgorithm</var>,
   <var>pull</var> and <var>cancel</var>.
   <p class="note no-backref">This construction operation will not throw an exception.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1876,18 +1876,45 @@ with given <var>strategy</var>, <var>pull</var> action and <var>cancel</var> act
 are optional, run these steps:
 
 <ol>
- <li><p>Let <var>init</var> be a new object.
+ <li><p>Let <var>startAlg</var> be an algorithm that returns <code>undefined</code>.
 
- <li><p>If <var>pull</var> is given, set <var>init</var>["pull"] to a function that returns
- <var>pull</var>().
+ <li><p>Let <var>pullAlg</var> be an algorithm that returns:
 
- <li><p>If <var>cancel</var> is given, set <var>init</var>["cancel"] to a function taking a
- <var>reason</var> that returns <var>cancel</var>(<var>reason</var>).
+ <dl class=switch>
+ <dt>If <var>pull</var> is given
+ <dd>the result of [=promise-calling=] <var>pull</var>().
+ <dt>Otherwise
+ <dd>[=a promise resolved with=] <code>undefined</code>.
+ </dl>
 
- <li><p>Let <var>stream</var> be the result of calling the initial value of {{ReadableStream}} as
- constructor with <var>init</var> and <var>strategy</var> if given.
+ <li><p>Let <var>cancelAlg</var> be an algorithm that takes a <var>reason</var> and returns:
+ <dl class=switch>
+ <dt>If <var>cancel</var> is given
+ <dd>the result of [=promise-calling=] <var>cancel</var>(<var>reason</var>).
+ <dt>Otherwise
+ <dd>[=a promise resolved with=] <code>undefined</code>.
+ </dl>
 
- <li><p>Return <var>stream</var>.
+ <li><p>Let <var>highWaterMark</var> be:
+ <dl class=switch>
+ <dt>If <var>strategy</var> is given and <var>strategy</var>.<a spec=streams for="queuing
+ strategy">highWaterMark</a> exists
+ <dd><var>strategy</var>.<a spec=streams for="queuing strategy">highWaterMark</a>.
+ <dt>Otherwise
+ <dd><code>1</code>.
+ </dl>
+
+ <li><p>Let <var>sizeAlg</var> be:
+ <dl class=switch>
+ <dt>If <var>strategy</var> is given and <var>strategy</var>.<a idl spec=streams for="queuing
+ strategy" lt="size()">size</a> exists
+ <dd><var>strategy</var>.size.
+ <dt>Otherwise
+ <dd>an algorithm that returns <code>1</code>.
+ </dl>
+
+  <li><p>Return [$CreateReadableStream$](<var>startAlg</var>, <var>pullAlg</var>,
+ <var>cancelAlg</var>, <var>highWaterMark</var>, <var>sizeAlg</var>).
 </ol>
 
 <p>To

--- a/fetch.bs
+++ b/fetch.bs
@@ -1878,11 +1878,11 @@ are optional, run these steps:
 <ol>
  <li><p>Let <var>init</var> be a new object.
 
- <li><p>Set <var>init</var>["pull"] to a function that runs <var>pull</var> if <var>pull</var> is
- given.
+ <li><p>If <var>pull</var> is given, set <var>init</var>["pull"] to a function that returns
+ <var>pull</var>().
 
- <li><p>Set <var>init</var>["cancel"] to a function that runs <var>cancel</var> if
- <var>cancel</var> is given.
+ <li><p>If <var>cancel</var> is given, set <var>init</var>["cancel"] to a function taking a
+ <var>reason</var> that returns <var>cancel</var>(<var>reason</var>).
 
  <li><p>Let <var>stream</var> be the result of calling the initial value of {{ReadableStream}} as
  constructor with <var>init</var> and <var>strategy</var> if given.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1872,8 +1872,8 @@ we define common operations for {{ReadableStream}} objects. [[!STREAMS]]
 
 <p>To
 <dfn export for=ReadableStream id=concept-construct-readablestream>construct a <code>ReadableStream</code> object</dfn>
-with given <var>highWaterMark</var>, <var>sizeAlgorithm</var> algorithm, <var>pull</var> action and
-<var>cancel</var> action, all of which are optional, run these steps:
+optionally with a <var>highWaterMark</var>, <var>sizeAlgorithm</var> algorithm, <var>pull</var>
+action, and <var>cancel</var> action, run these steps:
 
 <p class=note>This algorithm used to take a <var ignore>strategy</var> parameter, whose
 <code>highWaterMark</code> and <code>sizeAlgorithm</code> members were extracted to provide what are
@@ -1881,23 +1881,23 @@ now separate parameters. If another specification still passes that <var ignore>
 parameter, please update it.
 
 <ol>
- <li><p>Let <var>startAlgorithm</var> be an algorithm that returns <code>undefined</code>.
+ <li><p>Let <var>startAlgorithm</var> be an algorithm that returns undefined.
 
- <li><p>If <var>pull</var> is absent, set it to an action that returns <code>undefined</code>.
+ <li><p>If <var>pull</var> is absent, then set it to an action that returns undefined.
 
  <li><p>Let <var>pullAlgorithm</var> be an algorithm that returns the result of [=promise-calling=]
  <var>pull</var>().
 
- <li><p>If <var>cancel</var> is absent, set it to an action that returns <code>undefined</code>.
+ <li><p>If <var>cancel</var> is absent, then set it to an action that returns undefined.
 
  <li><p>Let <var>cancelAlgorithm</var> be an algorithm that takes a <var>reason</var> and returns
  the result of [=promise-calling=] <var>cancel</var>(<var>reason</var>).
 
- <li><p>If <var>highWaterMark</var> is absent, set it to <code>1</code>.
+ <li><p>If <var>highWaterMark</var> is absent, then set it to 1.
 
- <li><p>If <var>sizeAlgorithm</var> is absent, set it to an algorithm that returns <code>1</code>.
+ <li><p>If <var>sizeAlgorithm</var> is absent, then set it to an algorithm that returns 1.
 
-  <li><p>Return [$CreateReadableStream$](<var>startAlgorithm</var>, <var>pullAlgorithm</var>,
+ <li><p>Return [$CreateReadableStream$](<var>startAlgorithm</var>, <var>pullAlgorithm</var>,
  <var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var>).
 </ol>
 
@@ -4134,12 +4134,10 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <li><p>Return a <a>network error</a>.
   </ol>
 
- <li>
-  <p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
+ <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
- <li>
-  <p>Let <var>sizeAlgorithm</var> be an algorithm that accepts a <a>chunk</a> object and returns a
-  non-negative, non-NaN, non-infinite number, chosen by the user agent.
+ <li><p>Let <var>sizeAlgorithm</var> be an algorithm that accepts a <a>chunk</a> object and returns
+ a non-negative, non-NaN, non-infinite number, chosen by the user agent.
 
  <li><p>Let <var>pull</var> be an action that <a lt=resumed for=fetch>resumes</a> the ongoing fetch
  if it is <a lt=suspend for=fetch>suspended</a>.
@@ -4149,9 +4147,10 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
  <li>
   <p>Let <var>stream</var> be the result of
-  <a lt="construct a ReadableStream object" for=ReadableStream>constructing</a> a
-  {{ReadableStream}} object with <var>highWaterMark</var>, <var>sizeAlgorithm</var>,
-  <var>pull</var> and <var>cancel</var>.
+  <a lt="construct a ReadableStream object" for=ReadableStream>constructing</a> a {{ReadableStream}}
+  object with <var>highWaterMark</var>, <var>sizeAlgorithm</var>, <var>pull</var>, and
+  <var>cancel</var>.
+
   <p class="note no-backref">This construction operation will not throw an exception.
 
  <li>


### PR DESCRIPTION
It could be that this should call https://streams.spec.whatwg.org/#create-readable-stream or https://streams.spec.whatwg.org/#create-readable-byte-stream (#267?) instead of trying to go through the `ReadableStream()` constructor, with all the ambiguity about how modifying `Object`'s prototype should affect things.

@domenic


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/781.html" title="Last updated on Aug 9, 2018, 1:25 PM GMT (f514b21)">Preview</a> | <a href="https://whatpr.org/fetch/781/b3492ec...f514b21.html" title="Last updated on Aug 9, 2018, 1:25 PM GMT (f514b21)">Diff</a>