### PR TITLE
Copy priority so service worker pass-through requests don't lose it

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5451,11 +5451,11 @@ constructor must run these steps:
    <dt><a for=request>window</a>
    <dd><var>window</var>.
 
-   <dt><a for=request>origin</a>
-   <dd>"<code>client</code>".
-
    <dt><a for=request>priority</a>
    <dd><var>request</var>'s <a for=request>priority</a>.
+
+   <dt><a for=request>origin</a>
+   <dd>"<code>client</code>".
 
    <dt><a for=request>referrer</a>
    <dd><var>request</var>'s <a for=request>referrer</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5454,6 +5454,9 @@ constructor must run these steps:
    <dt><a for=request>origin</a>
    <dd>"<code>client</code>".
 
+   <dt><a for=request>priority</a>
+   <dd><var>request</var>'s <a for=request>priority</a>.
+
    <dt><a for=request>referrer</a>
    <dd><var>request</var>'s <a for=request>referrer</a>.
 
@@ -5483,9 +5486,6 @@ constructor must run these steps:
 
    <dt><a for=request>history-navigation flag</a>
    <dd><var>request</var>'s <a for=request>history-navigation flag</a>.
-
-   <dt><a for=request>priority</a>
-   <dd><var>request</var>'s <a for=request>priority</a>.
   </dl>
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5484,8 +5484,8 @@ constructor must run these steps:
    <dt><a for=request>history-navigation flag</a>
    <dd><var>request</var>'s <a for=request>history-navigation flag</a>.
 
-    <dt><a for=request>priority</a>
-     <dd><var>request</var>'s <a for=request>priority</a>.
+   <dt><a for=request>priority</a>
+   <dd><var>request</var>'s <a for=request>priority</a>.
   </dl>
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5483,6 +5483,9 @@ constructor must run these steps:
 
    <dt><a for=request>history-navigation flag</a>
    <dd><var>request</var>'s <a for=request>history-navigation flag</a>.
+
+    <dt><a for=request>priority</a>
+     <dd><var>request</var>'s <a for=request>priority</a>.
   </dl>
 
  <li>


### PR DESCRIPTION
H2 priorities are lost when passing through a service worker. https://medium.baqend.com/chromes-service-workers-break-http-2-priorities-649c4e0fa930

Although priorities are hand-wavy right now, it seems right to copy them from one request to another.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/785.html" title="Last updated on Aug 15, 2018, 3:06 PM GMT (f477930)">Preview</a> | <a href="https://whatpr.org/fetch/785/28f06ba...f477930.html" title="Last updated on Aug 15, 2018, 3:06 PM GMT (f477930)">Diff</a>