### PR TITLE
Don't append controls for upstream caches.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3699,29 +3699,6 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    `<code>If-Range</code>`, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".
 
-   <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>no-cache</code>" and
-   <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">does not contain</a>
-   `<code>Cache-Control</code>`, then <a for="header list">append</a>
-   `<code>Cache-Control</code>`/`<code>max-age=0</code>` to
-   <var>httpRequest</var>'s <a for=request>header list</a>.
-
-   <li>
-    <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is "<code>no-store</code>" or
-    "<code>reload</code>", then:
-
-    <ol>
-     <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
-     <a for="header list">does not contain</a> `<code>Pragma</code>`, then
-     <a for="header list">append</a> `<code>Pragma</code>`/`<code>no-cache</code>` to
-     <var>httpRequest</var>'s <a for=request>header list</a>.
-
-     <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
-     <a for="header list">does not contain</a> `<code>Cache-Control</code>`, then
-     <a for="header list">append</a> `<code>Cache-Control</code>`/`<code>no-cache</code>` to
-     <var>httpRequest</var>'s <a for=request>header list</a>.
-     <!-- Technically this only applies to HTTP/1.1 and up -->
-    </ol>
-
    <li>
     <p>If <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">contains</a>
     `<code>Range</code>`, then <a for="header list">append</a>


### PR DESCRIPTION
The developer may want to control the local cache separately from those
upstream; if they want to control both, they can append their own
request headers.

Fixes #722.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/788.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (7cb2a7b)">Preview</a> | <a href="https://whatpr.org/fetch/788/7e088f6...7cb2a7b.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (7cb2a7b)">Diff</a>