### PR TITLE
Preserve HEAD method on 303 redirect

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3590,13 +3590,18 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
  with <var>request</var>'s <a for=request>current url</a>'s <a for=url>origin</a>, then set
  <var>request</var>'s <a for=request>tainted origin flag</a>.
 
- <li><p>If either <var>actualResponse</var>'s <a for=response>status</a> is
- <code>301</code> or <code>302</code> and <var>request</var>'s
- <a for=request>method</a> is `<code>POST</code>`, or
- <var>actualResponse</var>'s <a for=response>status</a> is
- <code>303</code>, set <var>request</var>'s <a for=request>method</a>
- to `<code>GET</code>` and <var>request</var>'s <a for=request>body</a>
- to null.
+ <li>
+  <p>If one of the following is true
+
+  <ul class=brief>
+   <li><p><var>actualResponse</var>'s <a for=response>status</a> is <code>301</code> or
+   <code>302</code> and <var>request</var>'s <a for=request>method</a> is `<code>POST</code>`
+   <li><p><var>actualResponse</var>'s <a for=response>status</a> is <code>303</code> and
+   <var>request</var>'s <a for=request>method</a> is not `<code>HEAD</code>`
+  </ul>
+
+  <p>then set <var>request</var>'s <a for=request>method</a> to `<code>GET</code>` and
+  <var>request</var>'s <a for=request>body</a> to null.
 
  <li>
   <p>If <var>request</var>'s <a for=request>body</a> is non-null, then set <var>request</var>'s


### PR DESCRIPTION
Tests: already tested by fetch/api/redirect/redirect-method.any.js.

Fixes #753.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/796.html" title="Last updated on Aug 17, 2018, 2:28 PM GMT (ab512d2)">Preview</a> | <a href="https://whatpr.org/fetch/796/6c1174d...ab512d2.html" title="Last updated on Aug 17, 2018, 2:28 PM GMT (ab512d2)">Diff</a>