### PR TITLE
Editorial: consistify "one of the following" usage

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -424,8 +424,8 @@ each other by 0x2C 0x20, in order.
     <p>If one of the following is true
 
     <ul class=brief>
-     <li><var>value</var> contains a byte less than 0x20 that is not 0x09 HT
-     <li><var>value</var> contains 0x22 ("), 0x28 (left parenthesis), 0x29 (right parenthesis),
+     <li><p><var>value</var> contains a byte less than 0x20 that is not 0x09 HT
+     <li><p><var>value</var> contains 0x22 ("), 0x28 (left parenthesis), 0x29 (right parenthesis),
      0x3A (:), 0x3C (&lt;), 0x3E (>), 0x3F (?), 0x40 (@), 0x5B ([), 0x5C (\), 0x5D (]), 0x7B ({),
      0x7D (}), or 0x7F DEL
     </ul>
@@ -3400,27 +3400,25 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
      <a for=internal>internal response</a> otherwise.
 
      <li>
-      <p>If one of the following conditions is true, then return a <a>network error</a>:
+      <p>If one of the following is true
 
       <ul class=brief>
-       <li><var>response</var>'s
-       <a for=response>type</a> is "<code>error</code>".
+       <li><p><var>response</var>'s <a for=response>type</a> is "<code>error</code>"
 
-       <li><var>request</var>'s <a for=request>mode</a> is "<code>same-origin</code>" and
-       <var>response</var>'s <a for=response>type</a> is "<code>cors</code>".
+       <li><p><var>request</var>'s <a for=request>mode</a> is "<code>same-origin</code>" and
+       <var>response</var>'s <a for=response>type</a> is "<code>cors</code>"
 
-       <li><var>request</var>'s <a for=request>mode</a> is not
-       "<code>no-cors</code>" and <var>response</var>'s
-       <a for=response>type</a> is "<code>opaque</code>".
+       <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>no-cors</code>" and
+       <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>"
 
-       <li><var>request</var>'s <a for=request>redirect mode</a> is
-       not "<code>manual</code>" and <var>response</var>'s
-       <a for=response>type</a> is "<code>opaqueredirect</code>".
+       <li><var>request</var>'s <a for=request>redirect mode</a> is not "<code>manual</code>" and
+       <var>response</var>'s <a for=response>type</a> is "<code>opaqueredirect</code>"
 
-       <li><var>request</var>'s <a for=request>redirect mode</a> is
-       not "<code>follow</code>" and <var>response</var>'s
-       <a for=response>url list</a> has more than one item.
+       <li><var>request</var>'s <a for=request>redirect mode</a> is not "<code>follow</code>" and
+       <var>response</var>'s <a for=response>url list</a> has more than one item
       </ul>
+
+      <p>then return a <a>network error</a>.
     </ol>
   </ol>
 
@@ -4246,28 +4244,26 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <!-- XXX xref payload body -->
 
    <li>
-    <p><a for="header list">Delete</a>
-    `<code>Content-Encoding</code>` from <var>response</var>'s
-    <a for=response>header list</a> if one of the following
-    conditions is true:
+    <p>If one of the following is true
 
     <ul class=brief>
-     <li><p><a>Extracting header list values</a> given `<code>Content-Encoding</code>` and
-     <var>response</var>'s <a for=response>header list</a> returns
-     `<code>gzip</code>`, and <a>extracting header list values</a> given `<code>Content-Type</code>`
-     and <var>response</var>'s <a for=response>header list</a> returns
-     `<code>application/gzip</code>`, `<code>application/x-gunzip</code>`, or
-     `<code>application/x-gzip</code>`.
+     <li><p><a>extracting header list values</a> given `<code>Content-Encoding</code>` and
+     <var>response</var>'s <a for=response>header list</a> returns `<code>gzip</code>`, and
+     <a>extracting header list values</a> given `<code>Content-Type</code>` and
+     <var>response</var>'s <a for=response>header list</a> returns `<code>application/gzip</code>`,
+     `<code>application/x-gunzip</code>`, or `<code>application/x-gzip</code>`
 
-     <li><p><a>Extracting header list values</a> given `<code>Content-Encoding</code>` and
+     <li><p><a>extracting header list values</a> given `<code>Content-Encoding</code>` and
      <var>response</var>'s <a for=response>header list</a> returns `<code>compress</code>`, and
      <a>extracting header list values</a> given `<code>Content-Type</code>` and
      <var>response</var>'s <a for=response>header list</a> returns
-     `<code>application/compress</code>` or `<code>application/x-compress</code>.
+     `<code>application/compress</code>` or `<code>application/x-compress</code>`
     </ul>
 
-    <p class=note>This deals with broken Apache configurations. Ideally HTTP would define
-    this.
+    <p>then <a for="header list">delete</a> `<code>Content-Encoding</code>` from
+    <var>response</var>'s <a for=response>header list</a>.
+
+    <p class=note>This deals with broken Apache configurations. Ideally HTTP would define this.
     <!-- https://wiki.whatwg.org/wiki/HTTP -->
 
     <p class=XXX>Gecko
@@ -5613,17 +5609,18 @@ constructor must run these steps:
      <li><p>If <var>parsedReferrer</var> is failure, then <a>throw</a> a <code>TypeError</code>.
 
      <li>
-      <p>If one of the following conditions is true, then set <var>request</var>'s
-      <a for=request>referrer</a> to "<code>client</code>":
+      <p>If one of the following is true
 
       <ul class=brief>
-       <li><var>parsedReferrer</var>'s <a>cannot-be-a-base-URL flag</a> is set,
+       <li><p><var>parsedReferrer</var>'s <a>cannot-be-a-base-URL flag</a> is set,
        <a for=url>scheme</a> is "<code>about</code>", and <a for=url>path</a> contains a single
-       string "<code>client</code>".
+       string "<code>client</code>"
 
-       <li><var>parsedReferrer</var>'s <a for=url>origin</a> is not <a>same origin</a> with
+       <li><p><var>parsedReferrer</var>'s <a for=url>origin</a> is not <a>same origin</a> with
        <var>origin</var>
       </ul>
+
+      <p>then set <var>request</var>'s <a for=request>referrer</a> to "<code>client</code>".
       <!-- This can happen when you create a fresh request with values from an older request.
            Throwing would be rather hostile as preventing it requires implementing the same-origin
            check in developer space. -->


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/797.html" title="Last updated on Aug 17, 2018, 2:37 PM GMT (0adb713)">Preview</a> | <a href="https://whatpr.org/fetch/797/6c1174d...0adb713.html" title="Last updated on Aug 17, 2018, 2:37 PM GMT (0adb713)">Diff</a>