### PR TITLE
Editorial: Use "append" to modify the header list

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4397,7 +4397,7 @@ run these steps:
   does not matter as this algorithm uses <a>HTTP-network-or-cache fetch</a> rather than
   <a>HTTP fetch</a>.
 
- <li><p><a for="header list">Set</a> `<a http-header><code>Access-Control-Request-Method</code></a>`
+ <li><p><a for="header list">Append</a> `<a http-header><code>Access-Control-Request-Method</code></a>`
  to <var>request</var>'s <a for=request>method</a> in <var>preflight</var>'s
  <a for=request>header list</a>.
 
@@ -4411,7 +4411,7 @@ run these steps:
    <li><p>Let <var>value</var> be the items in <var>headers</var> separated from each other by
    `<code>,</code>`.
 
-   <li><p><a for="header list">Set</a>
+   <li><p><a for="header list">Append</a>
    `<a http-header><code>Access-Control-Request-Headers</code></a>` to <var>value</var> in
    <var>preflight</var>'s <a for=request>header list</a>.
   </ol>
@@ -6035,7 +6035,7 @@ method, when invoked, must run these steps:
  <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>status</a> to <var>status</var>.
 
- <li><p><a for="header list">Set</a> `<code>Location</code>` to <var>parsedURL</var>,
+ <li><p><a for="header list">Append</a> `<code>Location</code>` to <var>parsedURL</var>,
  <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>, in <var>r</var>'s
  <a for=Response>response</a>'s <a for=response>header list</a>.
 
@@ -6770,6 +6770,7 @@ Tom Schuster,
 Tomás Aparicio,
 保呂毅 (Tsuyoshi Horo),
 Tyler Close,
+Ujjwal Sharma,
 Vignesh Shanmugam,
 Vladimir Dzhuvinov,
 Wayne Carr,


### PR DESCRIPTION
Use "append" instead of "set" to modify the header list, improving
consistency (#758).

/cc @annevk @youennf


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/807.html" title="Last updated on Sep 10, 2018, 12:33 PM GMT (2bd2f6b)">Preview</a> | <a href="https://whatpr.org/fetch/807/1bda545...2bd2f6b.html" title="Last updated on Sep 10, 2018, 12:33 PM GMT (2bd2f6b)">Diff</a>