### PR TITLE
Check Feature Policy before attaching Client Hints

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -86,6 +86,14 @@ url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:df
     },
     "OCSP": {
         "aliasOf": "RFC2560"
+    },
+    "FEATURE-POLICY": {
+        "authors": [
+            "Ian Clelland"
+        ],
+        "href": "https://wicg.github.io/feature-policy/",
+        "publisher": "WICG",
+        "title": "Feature Policy"
     }
 }
 </pre>
@@ -2814,13 +2822,14 @@ the request.
         </dl>
 
        <li><p>If the result of running
-       <a href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should?
-       request be allowed to use feature</a>,
+       <a href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
+       <var>request</var> be allowed to use <var>feature</var>?</a>,
        given <var>request</var> and <var>hintName</var>’s
        <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
        policy-controlled feature</a>, returns <code>true</code>, the user agent should
        <a for="header list">append</a> <var>hintName</var>/<var>value</var> to <var>request</var>'s
        <a for=request>header list</a>.
+       [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
       </ol>
 
      <li><p>Let <var>record</var> be a new

--- a/fetch.bs
+++ b/fetch.bs
@@ -2813,8 +2813,14 @@ the request.
          <dd>a suitable <a href=http://httpwg.org/http-extensions/client-hints.html#width>width value</a>
         </dl>
 
-       <li><p>A user agent should <a for="header list">append</a>
-       <var>hintName</var>/<var>value</var> to <var>request</var>'s <a for=request>header list</a>.
+       <li><p>If the result of running
+       <a href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should?
+       request be allowed to use feature</a>,
+       given <var>request</var> and <var>hintName</var>’s
+       <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
+       policy-controlled feature</a>, returns <code>true</code>, the user agent should
+       <a for="header list">append</a> <var>hintName</var>/<var>value</var> to <var>request</var>'s
+       <a for=request>header list</a>.
       </ol>
 
      <li><p>Let <var>record</var> be a new


### PR DESCRIPTION
This PR is part of an attempt to address https://github.com/WICG/feature-policy/issues/129 – using Feature Policy to let authors opt-into sending specific Client Hints to specific origins.

The overall, basic idea is:

1. A new set of policy-controlled features – one for each Client Hint header field – [is defined in the Client Hints spec](https://github.com/httpwg/http-extensions/pull/696).
2. A new algorithm which determines whether a request is able to use a policy-controlled feature [is defined in the Feature Policy spec](https://github.com/WICG/feature-policy/pull/220).
3. The step in Fetch that appends Client Hint headers calls the new algorithm, checking if a request is allowed to use a Client Hint’s policy-controlled feature before appending the Client Hint header. That change is contained in this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/811.html" title="Last updated on Sep 24, 2018, 4:51 PM GMT (8760549)">Preview</a> | <a href="https://whatpr.org/fetch/811/daca6a8...8760549.html" title="Last updated on Sep 24, 2018, 4:51 PM GMT (8760549)">Diff</a>