### PR TITLE
Editorial: remove leftover sentence

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -468,9 +468,6 @@ each other by 0x2C 0x20, in order.
  <li><p>Return true.
 </ol>
 
-<p>and whose <a for=header>value</a>, <a lt="extract header values">once extracted</a>, is not
-failure.
-
 <p class="note">There are limited exceptions to the `<code>Content-Type</code>` header safelist, as
 documented in <a href=#cors-protocol-exceptions>CORS protocol exceptions</a>.
 


### PR DESCRIPTION
This was forgotten in 9288c8f85c809a0ac371be6843ad2cf4046ee35b.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/815.html" title="Last updated on Oct 17, 2018, 9:00 AM GMT (78fca7b)">Preview</a> | <a href="https://whatpr.org/fetch/815/daca6a8...78fca7b.html" title="Last updated on Oct 17, 2018, 9:00 AM GMT (78fca7b)">Diff</a>