### PR TITLE
Remove Gecko-only quirk

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4222,33 +4222,6 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=body>total bytes</a> to that payload body length.
    <!-- XXX xref payload body -->
 
-   <li>
-    <p>If one of the following is true
-
-    <ul class=brief>
-     <li><p><a>extracting header list values</a> given `<code>Content-Encoding</code>` and
-     <var>response</var>'s <a for=response>header list</a> returns `<code>gzip</code>`, and
-     <a>extracting header list values</a> given `<code>Content-Type</code>` and
-     <var>response</var>'s <a for=response>header list</a> returns `<code>application/gzip</code>`,
-     `<code>application/x-gunzip</code>`, or `<code>application/x-gzip</code>`
-
-     <li><p><a>extracting header list values</a> given `<code>Content-Encoding</code>` and
-     <var>response</var>'s <a for=response>header list</a> returns `<code>compress</code>`, and
-     <a>extracting header list values</a> given `<code>Content-Type</code>` and
-     <var>response</var>'s <a for=response>header list</a> returns
-     `<code>application/compress</code>` or `<code>application/x-compress</code>`
-    </ul>
-
-    <p>then <a for="header list">delete</a> `<code>Content-Encoding</code>` from
-    <var>response</var>'s <a for=response>header list</a>.
-
-    <p class=note>This deals with broken Apache configurations. Ideally HTTP would define this.
-    <!-- https://wiki.whatwg.org/wiki/HTTP -->
-
-    <p class=XXX>Gecko
-    <a href=https://bugzilla.mozilla.org/show_bug.cgi?id=1030660>bug 1030660</a> looks
-    into whether this quirk can be removed.
-
    <li><p>If <var>response</var> is not a
    <a>network error</a> and <var>request</var>'s
    <a for=request>cache mode</a> is not "<code>no-store</code>",


### PR DESCRIPTION
As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1030660 if this is needed at all it should have a different architecture. No other browser is interested in implementing this either.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/816.html" title="Last updated on Oct 17, 2018, 9:17 AM GMT (c03740b)">Preview</a> | <a href="https://whatpr.org/fetch/816/daca6a8...c03740b.html" title="Last updated on Oct 17, 2018, 9:17 AM GMT (c03740b)">Diff</a>