### PR TITLE
Split `document` destination for top-level and nested contexts.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -884,6 +884,7 @@ the empty string,
 "<code>font</code>",
 "<code>image</code>",
 "<code>manifest</code>",
+"<code>nested-document</code>",
 "<code>object</code>",
 "<code>paintworklet</code>",
 "<code>report</code>",
@@ -933,7 +934,7 @@ not always relevant and might require different behavior.
    <td>"<code>document</code>"
    <td>HTML's navigate algorithm.
   <tr>
-   <td>"<code>document</code>"
+   <td>"<code>nested-document</code>"
    <td><code>child-src</code>
    <td>HTML's <code>&lt;iframe></code> and <code>&lt;frame></code>
   <tr>
@@ -1304,13 +1305,13 @@ whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworkle
 "<code>object</code>" or "<code>embed</code>".
 
 <p>A <dfn export>non-subresource request</dfn> is a <a for=/>request</a>
-whose <a for=request>destination</a> is "<code>document</code>",
+whose <a for=request>destination</a> is "<code>document</code>", "<code>nested-document</code>",
 "<code>report</code>", "<code>serviceworker</code>", "<code>sharedworker</code>",
 or "<code>worker</code>".
 
 <p>A <dfn export>navigation request</dfn> is a <a for=/>request</a> whose
 <a for=request>destination</a> is
-"<code>document</code>".
+"<code>document</code>" or "<code>nested-document</code>".
 
 <p class=note>See <a for=/>handle fetch</a> for usage of these terms.
 [[!SW]]
@@ -5283,7 +5284,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "image", "manifest", "nested-document", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };


### PR DESCRIPTION
Partially addresses whatwg/fetch#755.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/819.html" title="Last updated on Oct 26, 2018, 2:08 PM GMT (f51d26c)">Preview</a> | <a href="https://whatpr.org/fetch/819/daca6a8...f51d26c.html" title="Last updated on Oct 26, 2018, 2:08 PM GMT (f51d26c)">Diff</a>