### PR TITLE
Refactor the CORS check

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3479,15 +3479,12 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
    <var>request</var> with <i>CORS flag</i> if set.
 
    <li>
-    <p>If <i>CORS flag</i> is set and a <a for=cors>CORS check</a> for
-    <var>request</var> and <var>response</var> returns failure, then return a
-    <a>network error</a>.
+    <p>If <i>CORS flag</i> is set and a <a>CORS check</a> for <var>request</var> and
+    <var>response</var> returns failure, then return a <a>network error</a>.
 
-    <p class="note no-backref">As the <a for=cors>CORS check</a> is not to be
-    applied to <a for=/>responses</a> whose
-    <a for=response>status</a> is <code>304</code> or <code>407</code>, or
-    <a for=/>responses</a> from a service worker for that matter, it is
-    applied here.
+    <p class="note no-backref">As the <a>CORS check</a> is not to be applied to
+    <a for=/>responses</a> whose <a for=response>status</a> is <code>304</code> or <code>407</code>,
+    or <a for=/>responses</a> from a service worker for that matter, it is applied here.
   </ol>
 
  <li>
@@ -4422,14 +4419,13 @@ run these steps:
  <a>HTTP-network-or-cache fetch</a> using <var>preflight</var> with the <i>CORS flag</i> set.
 
  <li>
-  <p>If a <a for=cors>CORS check</a> for <var>request</var> and <var>response</var> returns success
-  and <var>response</var>'s <a for=response>status</a> is an <a>ok status</a>, then:
+  <p>If a <a>CORS check</a> for <var>request</var> and <var>response</var> returns success and
+  <var>response</var>'s <a for=response>status</a> is an <a>ok status</a>, then:
   <!-- CORS said 200 here but nobody implemented that:
        https://lists.w3.org/Archives/Public/public-webappsec/2013Feb/0078.html -->
 
-  <p class="note no-backref">The <a for=cors>CORS check</a> is done
-  on <var>request</var> rather than <var>preflight</var> to ensure the correct
-  <a for=request>credentials mode</a> is used.
+  <p class="note no-backref">The <a>CORS check</a> is done on <var>request</var> rather than
+  <var>preflight</var> to ensure the correct <a for=request>credentials mode</a> is used.
 
   <ol>
    <li><p>Let <var>methods</var> be the result of <a>extracting header list values</a> given
@@ -4599,38 +4595,33 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 
 <h3 id=cors-check>CORS check</h3>
 
-<p>To perform a <dfn id=concept-cors-check for=cors>CORS check</dfn> for a
-<var>request</var> and <var>response</var>, run these steps:
+<p>To perform a <dfn id=concept-cors-check>CORS check</dfn> for a <var>request</var> and
+<var>response</var>, run these steps:
 
 <ol>
- <li>
-  <p>Let <var>origin</var> be the result of <a>extracting header list values</a> given
-  `<a http-header><code>Access-Control-Allow-Origin</code></a>` and <var>response</var>'s
-  <a for=response>header list</a>.
-
-  <p class=note>The above will fail for network errors, as they have no headers.
+ <li><p>Let <var>origin</var> be the result of <a for="header list">getting</a>
+ `<a http-header><code>Access-Control-Allow-Origin</code></a>` from <var>response</var>'s
+ <a for=response>header list</a>.
 
  <li>
-  <p>If <var>origin</var> is null or failure, return failure.
+  <p>If <var>origin</var> is null, then return failure.
 
   <p class=note>Null is not `<code>null</code>`.
 
- <li><p>If <var>request</var>'s
- <a for=request>credentials mode</a> is not
- "<code>include</code>" and <var>origin</var> is `<code>*</code>`, return success.
+ <li><p>If <var>request</var>'s <a for=request>credentials mode</a> is not "<code>include</code>"
+ and <var>origin</var> is `<code>*</code>`, then return success.
 
  <li><p>If the result of <a>serializing a request origin</a> with <var>request</var> is not
  <var>origin</var>, then return failure.
 
- <li><p>If <var>request</var>'s
- <a for=request>credentials mode</a> is not
- "<code>include</code>", return success.
+ <li><p>If <var>request</var>'s <a for=request>credentials mode</a> is not "<code>include</code>",
+ then return success.
 
- <li><p>Let <var>credentials</var> be the result of <a>extracting header list values</a> given
- `<a http-header><code>Access-Control-Allow-Credentials</code></a>` and <var>response</var>'s
+ <li><p>Let <var>credentials</var> be the result of <a for="header list">getting</a>
+ `<a http-header><code>Access-Control-Allow-Credentials</code></a>` from <var>response</var>'s
  <a for=response>header list</a>.
 
- <li><p>If <var>credentials</var> is `<code>true</code>`, return success.
+ <li><p>If <var>credentials</var> is `<code>true</code>`, then return success.
 
  <li><p>Return failure.
 </ol>


### PR DESCRIPTION
In particular, make it use header list's get operation to retrieve the Access-Control-Allow-Origin and Access-Control-Allow-Credentials values.

Tests: https://github.com/web-platform-tests/wpt/pull/13815.