### PR TITLE
Add HTTP whitespace back for MIME types

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -241,9 +241,9 @@ means (e.g., <code>data</code> URLs).
 <p><dfn export>HTTP whitespace</dfn> is U+000A LF, U+000D CR, or a <a>HTTP tab or space</a>.
 
 <p class="note no-backref"><a>HTTP whitespace</a> is only useful for specific constructs that are
-reused outside the context of HTTP headers (e.g., <a>MIME types</a>). For HTTP header values using
-<a>HTTP tab or space</a> is preferred and outside that context <a>ASCII whitespace</a> is preferred.
-Unlike <a>ASCII whitespace</a> this excludes U+000C FF.
+reused outside the context of HTTP headers (e.g., <a for=/>MIME types</a>). For HTTP header values
+using <a>HTTP tab or space</a> is preferred and outside that context <a>ASCII whitespace</a> is
+preferred. Unlike <a>ASCII whitespace</a> this excludes U+000C FF.
 
 <p>An <dfn export>HTTP newline byte</dfn> is 0x0A (LF) or 0x0D (CR).
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -241,8 +241,8 @@ means (e.g., <code>data</code> URLs).
 <p><dfn export>HTTP whitespace</dfn> is U+000A LF, U+000D CR, or an <a>HTTP tab or space</a>.
 
 <p class="note no-backref"><a>HTTP whitespace</a> is only useful for specific constructs that are
-reused outside the context of HTTP headers (e.g., <a for=/>MIME types</a>). For HTTP header values
-using <a>HTTP tab or space</a> is preferred and outside that context <a>ASCII whitespace</a> is
+reused outside the context of HTTP headers (e.g., <a for=/>MIME types</a>). For HTTP header values,
+using <a>HTTP tab or space</a> is preferred, and outside that context <a>ASCII whitespace</a> is
 preferred. Unlike <a>ASCII whitespace</a> this excludes U+000C FF.
 
 <p>An <dfn export>HTTP newline byte</dfn> is 0x0A (LF) or 0x0D (CR).

--- a/fetch.bs
+++ b/fetch.bs
@@ -238,6 +238,13 @@ means (e.g., <code>data</code> URLs).
 
 <p>An <dfn export>HTTP tab or space</dfn> is U+0009 TAB or U+0020 SPACE.
 
+<p><dfn export>HTTP whitespace</dfn> is U+000A LF, U+000D CR, or a <a>HTTP tab or space</a>.
+
+<p class="note no-backref"><a>HTTP whitespace</a> is only useful for specific constructs that are
+reused outside the context of HTTP headers (e.g., <a>MIME types</a>). For HTTP header values using
+<a>HTTP tab or space</a> is preferred and outside that context <a>ASCII whitespace</a> is preferred.
+Unlike <a>ASCII whitespace</a> this excludes U+000C FF.
+
 <p>An <dfn export>HTTP newline byte</dfn> is 0x0A (LF) or 0x0D (CR).
 
 <p>An <dfn export>HTTP tab or space byte</dfn> is 0x09 (HT) or 0x20 (SP).

--- a/fetch.bs
+++ b/fetch.bs
@@ -238,7 +238,7 @@ means (e.g., <code>data</code> URLs).
 
 <p>An <dfn export>HTTP tab or space</dfn> is U+0009 TAB or U+0020 SPACE.
 
-<p><dfn export>HTTP whitespace</dfn> is U+000A LF, U+000D CR, or a <a>HTTP tab or space</a>.
+<p><dfn export>HTTP whitespace</dfn> is U+000A LF, U+000D CR, or an <a>HTTP tab or space</a>.
 
 <p class="note no-backref"><a>HTTP whitespace</a> is only useful for specific constructs that are
 reused outside the context of HTTP headers (e.g., <a for=/>MIME types</a>). For HTTP header values


### PR DESCRIPTION
See https://github.com/whatwg/mimesniff/pull/90.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/828.html" title="Last updated on Nov 12, 2018, 9:28 AM GMT (57b9f55)">Preview</a> | <a href="https://whatpr.org/fetch/828/32c7b1c...57b9f55.html" title="Last updated on Nov 12, 2018, 9:28 AM GMT (57b9f55)">Diff</a>