### PR TITLE
Editorial: drop parenthesis around variables

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -302,9 +302,9 @@ for consistency.
 <p class="note no-backref">A <a for=/>header list</a> is essentially a
 specialized multimap. An ordered list of key-value pairs with potentially duplicate keys.
 
-<p>A <a for=/>header list</a> (<var>list</var>)
+<p>A <a for=/>header list</a> <var>list</var>
 <dfn export for="header list" lt="contains|does not contain">contains</dfn> a <a for=header>name</a>
-(<var>name</var>) if <var>list</var> <a for=list>contains</a> a <a for=/>header</a> whose
+<var>name</var> if <var>list</var> <a for=list>contains</a> a <a for=/>header</a> whose
 <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>.
 
 <p>To <dfn export for="header list" id=concept-header-list-get>get</dfn> a <a for=header>name</a>
@@ -318,8 +318,8 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 </ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-append>append</dfn> a
-<a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair to a
-<a for=/>header list</a> (<var>list</var>), run these steps:
+<a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair to a
+<a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li>
@@ -335,13 +335,13 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 </ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-delete>delete</dfn> a
-<a for=header>name</a> (<var>name</var>) from a <a for=/>header list</a> (<var>list</var>),
+<a for=header>name</a> <var>name</var> from a <a for=/>header list</a> <var>list</var>,
 <a for=list>remove</a> all <a for=/>headers</a> whose <a for=header>name</a> is a
 <a>byte-case-insensitive</a> match for <var>name</var> from <var>list</var>.
 
 <p>To <dfn export for="header list" id=concept-header-list-set>set</dfn> a
-<a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair in a
-<a for=/>header list</a> (<var>list</var>), run these steps:
+<a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair in a
+<a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
@@ -353,8 +353,8 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 </ol>
 
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
-<a for=header>name</a>/<a for=header>value</a> (<var>name</var>/<var>value</var>) pair in a
-<a for=/>header list</a> (<var>list</var>), run these steps:
+<a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair in a
+<a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li><p>If <var>list</var> <a for="header list">contains</a> <var>name</var>, then set the
@@ -370,7 +370,7 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
 
 <p>To
 <dfn export for="header list" id=concept-header-list-sort-and-combine>sort and combine</dfn>
-a <a for=/>header list</a> (<var>list</var>), run these steps:
+a <a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li><p>Let <var>headers</var> be an empty <a for=/>list</a> of
@@ -419,7 +419,7 @@ production as
 <var>potentialValue</var>.
 
 <p>A <dfn export for=header id=concept-header-value-combined>combined value</dfn>, given a
-<a for=header>name</a> (<var>name</var>) and <a for=/>header list</a> (<var>list</var>), is the
+<a for=header>name</a> <var>name</var> and <a for=/>header list</a> <var>list</var>, is the
 <a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var> whose
 <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated from
 each other by 0x2C 0x20, in order.
@@ -637,7 +637,7 @@ given a <a for=/>header</a> <var>header</var>, run these steps:
 
 <p>To
 <dfn export lt="extract header list values|extracting header list values">extract header list values</dfn>
-given a <a for=header>name</a> (<var>name</var>) and a <a for=/>header list</a> (<var>list</var>),
+given a <a for=header>name</a> <var>name</var> and a <a for=/>header list</a> <var>list</var>,
 run these steps:
 
 <ol>
@@ -671,7 +671,7 @@ run these steps:
 
 <p>To
 <dfn export for="header list" lt="extract a MIME type|extracting a MIME type" id=concept-header-extract-mime-type>extract a MIME type</dfn>
-from a <a for=/>header list</a> (<var>headers</var>), run these steps:
+from a <a for=/>header list</a> <var>headers</var>, run these steps:
 
 <ol>
  <li><p>Let <var>mimeType</var> be the result of <a>extracting header list values</a> given
@@ -4753,7 +4753,7 @@ objects.</span>
 
 <p>To <dfn export for=Headers id=concept-headers-append>append</dfn> a
 <a for=header>name</a>/<a for=header>value</a>
-(<var>name</var>/<var>value</var>) pair to a
+<var>name</var>/<var>value</var> pair to a
 {{Headers}} object (<var>headers</var>), run these steps:
 
 <ol>
@@ -6737,8 +6737,9 @@ Ondřej Žára,
 Philip Jägenstedt,
 R. Auburn,
 Raphael Kubo da Costa,
-Ryan Sleevi,
+Rondinelly,
 Rory Hewitt,
+Ryan Sleevi,
 Sébastien Cevey,
 Sendil Kumar N,
 Shao-xuan Kang,


### PR DESCRIPTION
I hope this PR has what should be done(#817).

If need some adjustment, I can do.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/830.html" title="Last updated on Nov 7, 2018, 11:35 AM GMT (1893d47)">Preview</a> | <a href="https://whatpr.org/fetch/830/3fb65a0...1893d47.html" title="Last updated on Nov 7, 2018, 11:35 AM GMT (1893d47)">Diff</a>