### PR TITLE
Take tainted origin flag into account for the same origin check

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2997,8 +2997,8 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
 
   <dl class=switch>
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is
-   <a>same origin</a> with <var>request</var>'s <a for=request>origin</a> and <i>CORS flag</i> is
-   unset
+   <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, <var>request</var>'s
+   <a for=request>tainted origin flag</a> is unset, and the <i>CORS flag</i> is unset
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
    "<code>data</code>"
    <dt><var>request</var>'s <a for=request>mode</a> is


### PR DESCRIPTION
This also addresses #737 in that now A -> B -> A would be considered cross-origin even for "no-cors", but leaving that open for further plumbing in HTML et al to override that in select cases (e.g., `<img>`).

Fixes #756.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/834.html" title="Last updated on Nov 19, 2018, 10:02 AM GMT (dca2295)">Preview</a> | <a href="https://whatpr.org/fetch/834/ba2fb9c...dca2295.html" title="Last updated on Nov 19, 2018, 10:02 AM GMT (dca2295)">Diff</a>