### PR TITLE
Change Response's statusText's default

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5922,7 +5922,7 @@ Response includes Body;
 
 dictionary ResponseInit {
   unsigned short status = 200;
-  ByteString statusText = "OK";
+  ByteString statusText = "";
   HeadersInit headers;
 };
 


### PR DESCRIPTION
The empty string is a better default as the field is optional in HTTP and rather meaningless. This way if you change the status and forget about statusText it won't give the mistaken impression things are OK.

Tests: ...

Fixes #698.