### PR TITLE
Treat resources requested via FTP as binary data.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3701,10 +3701,32 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   </ol>
 
  <dt>"<code>file</code>"
+ <dd>
+  <p>For now, unfortunate as it is, <code>file</code> <a for=/>URLs</a> are left as an exercise for
+  the reader.
+
+  <p>When in doubt, return a <a>network error</a>.
+
  <dt>"<code>ftp</code>"
  <dd>
-  <p>For now, unfortunate as it is, <code>file</code> and <code>ftp</code> <a for=/>URLs</a> are
-  left as an exercise for the reader.
+  <p>For now, unfortunate as it is, <code>ftp</code> <a for=/>URLs</a> are mostly left as an
+  exercise for the reader.
+
+  <ol>
+   <li>Let <var>body</var> be the result of the user agent obtaining content from
+   <var>request</var>'s <a for=request>current URL</a> from the network via FTP [[!RFC959]].
+
+   <li>Let </var>mime</var> be "<code>application/octet-stream</code>".
+
+   <li>If <var>body</var> is the result of the user agent generating a directory listing page for
+   the result of FTP's LIST command, then set |mime| to "<code>text/ftp-dir</code>".
+
+   <li>Return a <a for=/>response</a> whose <a for="response">status message</a> is
+   `<code>OK</code>`, <a for=response>header list</a> consists of a single <a for=/>header</a>
+   whose <a for=header>name</a> is `<code>Content-Type</code>` and whose <a for=header>value</a> is
+   <var>mime</var>, <a for=response>body</a> is <var>body</var>, and
+   <a for=response>HTTPS state</a> is "<code>none</code>".
+  </ol>
 
   <p>When in doubt, return a <a>network error</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3713,15 +3713,15 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
   exercise for the reader.
 
   <ol>
-   <li>Let <var>body</var> be the result of the user agent obtaining content from
-   <var>request</var>'s <a for=request>current URL</a> from the network via FTP [[!RFC959]].
+   <li><p>Let <var>body</var> be the result of the user agent obtaining content from
+   <var>request</var>'s <a for=request>current URL</a> from the network via FTP. [[!RFC959]]
 
-   <li>Let </var>mime</var> be "<code>application/octet-stream</code>".
+   <li><p>Let </var>mime</var> be `<code>application/octet-stream</code>`.
 
-   <li>If <var>body</var> is the result of the user agent generating a directory listing page for
-   the result of FTP's LIST command, then set |mime| to "<code>text/ftp-dir</code>".
+   <li><p>If <var>body</var> is the result of the user agent generating a directory listing page for
+   the result of FTP's LIST command, then set |mime| to `<code>text/ftp-dir</code>`.
 
-   <li>Return a <a for=/>response</a> whose <a for="response">status message</a> is
+   <li><p>Return a <a for=/>response</a> whose <a for="response">status message</a> is
    `<code>OK</code>`, <a for=response>header list</a> consists of a single <a for=/>header</a>
    whose <a for=header>name</a> is `<code>Content-Type</code>` and whose <a for=header>value</a> is
    <var>mime</var>, <a for=response>body</a> is <var>body</var>, and


### PR DESCRIPTION
Downloading resources over FTP is dangerous in itself, as FTP is a non-securable
protocol. But rendering resources as 'text/html' or similar is even more
dangerous for a variety of reasons (explored to some extent in the blink-dev@
thread linked below). This patch forces FTP resources into an
'application/octet-stream' MIME type, which should prevent them from rendering
as HTML in user agents.

https://groups.google.com/a/chromium.org/d/msg/blink-dev/eopgOoY1QLs/e1tIefOxAAAJ

Closes whatwg/html#4178


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/839.html" title="Last updated on Nov 30, 2018, 8:21 AM GMT (55e9f18)">Preview</a> | <a href="https://whatpr.org/fetch/839/0b2bc05...55e9f18.html" title="Last updated on Nov 30, 2018, 8:21 AM GMT (55e9f18)">Diff</a>