### PR TITLE
Fix: Appending a header to headers with "request-no-cors" guard

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -602,11 +602,10 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
   <p><a for=list>For each</a> <var>name</var> in <var>names</var>:
 
   <ol>
-   <li>
-    <p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var>
-    from <var>list</var>.
+   <li><p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var>
+   from <var>list</var>.
 
-    <p class="note no-backref"><var>value</var> cannot be null.
+   <li><p>Assert: <var>value</var> is not null.
 
    <li><p><a for=list>Append</a> <var>name</var>-<var>value</var> to <var>headers</var>.
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5121,8 +5121,8 @@ objects.</span>
    <li><p>Let <var>temporaryValue</var> be the result of <a>getting</a> <var>name</var> from
    <var>headers</var>'s <a for=Headers>header list</a>.
 
-   <li><p>If <var>temporaryValue</var> is null, then set <var>temporaryValue</var> to the empty
-   string.
+   <li><p>If <var>temporaryValue</var> is null, then set <var>temporaryValue</var> to
+   <var>value</var>.
 
    <li><p>Otherwise, set <var>temporaryValue</var> to <var>temporaryValue</var>, followed by
    0x2C 0x20, followed by <var>value</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5122,8 +5122,11 @@ objects.</span>
    <li><p>Let <var>temporaryValue</var> be the <a>combined value</a> with <var>name</var> and
    <var>headers</var>'s <a for=Headers>header list</a>.
 
-   <li><p>Set <var>temporaryValue</var> to <var>temporaryValue</var>, followed by 0x2C 0x20,
-   followed by <var>value</var>.
+   <li><p>If <var>temporaryValue</var> is the empty string, then set <var>temporaryValue</var> to
+   <var>value</var>.
+
+   <li><p>Otherwise, set <var>temporaryValue</var> to <var>temporaryValue</var>, followed by
+   0x2C 0x20, followed by <var>value</var>.
 
    <li><p>If <var>name</var>/<var>temporaryValue</var> is not a
    <a>no-CORS-safelisted request-header</a>, then return.

--- a/fetch.bs
+++ b/fetch.bs
@@ -389,7 +389,9 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
  <li><p>If <var>list</var> <a for="header list">does not contain</a> <var>name</var>, then return
  null.
 
- <li><p>Return the <a for="header">combined value</a> with <var>name</var> and <var>list</var>.
+ <li><p>Return the <a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var>
+ whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated
+ from each other by 0x2C 0x20, in order.
 </ol>
 
 <p>To
@@ -600,8 +602,11 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
   <p><a for=list>For each</a> <var>name</var> in <var>names</var>:
 
   <ol>
-   <li><p>Let <var>value</var> be the <a for=header>combined value</a> with <var>name</var> and
-   <var>list</var>.
+   <li>
+    <p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var>
+    from <var>list</var>.
+
+    <p class="note no-backref"><var>value</var> cannot be null.
 
    <li><p><a for=list>Append</a> <var>name</var>-<var>value</var> to <var>headers</var>.
   </ol>
@@ -632,12 +637,6 @@ production as
 <p>To <dfn export for=header/value id=concept-header-value-normalize>normalize</dfn> a
 <var>potentialValue</var>, remove any leading and trailing <a>HTTP whitespace bytes</a> from
 <var>potentialValue</var>.
-
-<p>A <dfn export for=header id=concept-header-value-combined>combined value</dfn>, given a
-<a for=header>name</a> <var>name</var> and <a for=/>header list</a> <var>list</var>, is the
-<a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var> whose
-<a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated from
-each other by 0x2C 0x20, in order.
 
 <hr>
 
@@ -3004,8 +3003,8 @@ Cross-Origin-Resource-Policy     = %x73.61.6D.65.2D.6F.72.69.67.69.6E / %x73.61.
   <var>request</var>'s <a for=request>tainted origin flag</a> is not checked.
 
  <li>
-  <p>Let <var>policy</var> be the <a>combined value</a> with
-  `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` and <var>response</var>'s
+  <p>Let <var>policy</var> be the result of <a for="header list">getting</a>
+  `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
   <a for=response>header list</a>.
 
   <p class=note>This means that `<code>Cross-Origin-Resource-Policy: same-site, same-origin</code>`
@@ -5119,11 +5118,11 @@ objects.</span>
   <p>Otherwise, if <var>headers</var>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>":
 
   <ol>
-   <li><p>Let <var>temporaryValue</var> be the <a>combined value</a> with <var>name</var> and
+   <li><p>Let <var>temporaryValue</var> be the result of <a>getting</a> <var>name</var> from
    <var>headers</var>'s <a for=Headers>header list</a>.
 
-   <li><p>If <var>temporaryValue</var> is the empty string, then set <var>temporaryValue</var> to
-   <var>value</var>.
+   <li><p>If <var>temporaryValue</var> is null, then set <var>temporaryValue</var> to the empty
+   string.
 
    <li><p>Otherwise, set <var>temporaryValue</var> to <var>temporaryValue</var>, followed by
    0x2C 0x20, followed by <var>value</var>.
@@ -5234,11 +5233,8 @@ invoked, must run these steps:
 <ol>
  <li><p>If <var>name</var> is not a <a for=header>name</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>header list</a>
- <a for="header list">does not contain</a> <var>name</var>, then return null.
-
- <li><p>Return the <a for=header>combined value</a> with <var>name</var> and the
- <a>context object</a>'s <a for=Headers>header list</a>.
+ <li><p>Return the result of <a for="header list">getting</a> <var>name</var> from <a>context
+ object</a>'s <a for=Headers>header list</a>.
 </ol>
 
 <p>The <dfn export for=Headers method><code>has(<var>name</var>)</code></dfn> method,

--- a/fetch.bs
+++ b/fetch.bs
@@ -5119,8 +5119,8 @@ objects.</span>
   <p>Otherwise, if <var>headers</var>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>":
 
   <ol>
-   <li><p>Let <var>temporaryValue</var> be the result of <a>getting</a> <var>name</var> from
-   <var>headers</var>'s <a for=Headers>header list</a>.
+   <li><p>Let <var>temporaryValue</var> be the result of <a for="header list">getting</a>
+   <var>name</var> from <var>headers</var>'s <a for=Headers>header list</a>.
 
    <li><p>If <var>temporaryValue</var> is null, then set <var>temporaryValue</var> to
    <var>value</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -389,9 +389,7 @@ specialized multimap. An ordered list of key-value pairs with potentially duplic
  <li><p>If <var>list</var> <a for="header list">does not contain</a> <var>name</var>, then return
  null.
 
- <li><p>Return the <a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var>
- whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated
- from each other by 0x2C 0x20, in order.
+ <li><p>Return the <a for="header">combined value</a> with <var>name</var> and <var>list</var>.
 </ol>
 
 <p>To
@@ -602,10 +600,8 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
   <p><a for=list>For each</a> <var>name</var> in <var>names</var>:
 
   <ol>
-   <li><p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var>
-   from <var>list</var>.
-
-   <li><p>Assert: <var>value</var> is not null.
+   <li><p>Let <var>value</var> be the <a for=header>combined value</a> with <var>name</var> and
+   <var>list</var>.
 
    <li><p><a for=list>Append</a> <var>name</var>-<var>value</var> to <var>headers</var>.
   </ol>
@@ -636,6 +632,12 @@ production as
 <p>To <dfn export for=header/value id=concept-header-value-normalize>normalize</dfn> a
 <var>potentialValue</var>, remove any leading and trailing <a>HTTP whitespace bytes</a> from
 <var>potentialValue</var>.
+
+<p>A <dfn export for=header id=concept-header-value-combined>combined value</dfn>, given a
+<a for=header>name</a> <var>name</var> and <a for=/>header list</a> <var>list</var>, is the
+<a lt=value for=header>values</a> of all <a for=/>headers</a> in <var>list</var> whose
+<a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated from
+each other by 0x2C 0x20, in order.
 
 <hr>
 
@@ -3002,8 +3004,8 @@ Cross-Origin-Resource-Policy     = %x73.61.6D.65.2D.6F.72.69.67.69.6E / %x73.61.
   <var>request</var>'s <a for=request>tainted origin flag</a> is not checked.
 
  <li>
-  <p>Let <var>policy</var> be the result of <a for="header list">getting</a>
-  `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+  <p>Let <var>policy</var> be the <a>combined value</a> with
+  `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` and <var>response</var>'s
   <a for=response>header list</a>.
 
   <p class=note>This means that `<code>Cross-Origin-Resource-Policy: same-site, same-origin</code>`
@@ -5232,8 +5234,11 @@ invoked, must run these steps:
 <ol>
  <li><p>If <var>name</var> is not a <a for=header>name</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>Return the result of <a for="header list">getting</a> <var>name</var> from <a>context
- object</a>'s <a for=Headers>header list</a>.
+ <li><p>If the <a>context object</a>'s <a for=Headers>header list</a>
+ <a for="header list">does not contain</a> <var>name</var>, then return null.
+
+ <li><p>Return the <a for=header>combined value</a> with <var>name</var> and the
+ <a>context object</a>'s <a for=Headers>header list</a>.
 </ol>
 
 <p>The <dfn export for=Headers method><code>has(<var>name</var>)</code></dfn> method,


### PR DESCRIPTION
If the headers doesn't contain entries for |name|, |temporaryValue|
should be |value|, not the combined value followed by 0x2c 0x20
followed by |value|.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/840.html" title="Last updated on Nov 28, 2018, 1:14 AM GMT (991adf3)">Preview</a> | <a href="https://whatpr.org/fetch/840/0b2bc05...991adf3.html" title="Last updated on Nov 28, 2018, 1:14 AM GMT (991adf3)">Diff</a>