### PR TITLE
Export "determine nosniff".

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2874,8 +2874,8 @@ response <a for=/>header</a> can be used to require checking of a <a for=/>respo
 `<code>Content-Type</code>` <a for=/>header</a> against the <a for=request>destination</a> of a
 <a for=/>request</a>.
 
-<p>To <dfn export for="header list">determine nosniff</dfn>, given a <a for=/>header list</a>
-<var>list</var>, run these steps:
+<p>To <dfn export>determine nosniff</dfn>, given a <a for=/>header list</a> <var>list</var>, run
+these steps:
 
 <ol>
  <li><p>Let <var>values</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -2874,8 +2874,8 @@ response <a for=/>header</a> can be used to require checking of a <a for=/>respo
 `<code>Content-Type</code>` <a for=/>header</a> against the <a for=request>destination</a> of a
 <a for=/>request</a>.
 
-<p>To <dfn>determine nosniff</dfn>, given a <a for=/>header list</a> <var>list</var>, run these
-steps:
+<p>To <dfn export for="header list">determine nosniff</dfn>, given a <a for=/>header list</a>
+<var>list</var>, run these steps:
 
 <ol>
  <li><p>Let <var>values</var> be the result of


### PR DESCRIPTION
I'm not certain it's right to scope this under `header list`, but "determine nosniff" doesn't seem like it scopes itself well enough to leave it global.

I'm hoping to call this (or anything better you might suggest) from https://github.com/WICG/webpackage/pull/348, where @mikewest encouraged me to require the new format to always be served with the nosniff header.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/851.html" title="Last updated on Dec 19, 2018, 10:28 PM UTC (4bba761)">Preview</a> | <a href="https://whatpr.org/fetch/851/c6b3a75...4bba761.html" title="Last updated on Dec 19, 2018, 10:28 PM UTC (4bba761)">Diff</a>