### PR TITLE
Safelist request headers starting with `Sec-`

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -645,8 +645,12 @@ production as
 <ol>
  <li><p>Let <var>value</var> be <var>header</var>'s <a for=header>value</a>.
 
- <li>
-  <p><a>Byte-lowercase</a> <var>header</var>'s <a for=header>name</a> and switch on the result:
+ <li><p>Let <var>lowercase name</var> be the <a>byte-lowercase</a> <var>header</var>'s <a
+ for=header>name</a>.
+
+ <li><p>If <var>lowercase name</var> starts with `<code>sec-</code>`, return true.
+
+ <li><p>Switch on <var>lowercase name</var>:
 
   <dl class=switch>
    <dt>`<code>accept</code>`


### PR DESCRIPTION
As discussed with @annevk on https://github.com/w3c/resource-hints/issues/74#issuecomment-473916086, this PR makes sure that `Sec-` prefixed request headers are always CORS-safe.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/880.html" title="Last updated on Mar 21, 2019, 9:19 AM UTC (5c99ed6)">Preview</a> | <a href="https://whatpr.org/fetch/880/265974f...5c99ed6.html" title="Last updated on Mar 21, 2019, 9:19 AM UTC (5c99ed6)">Diff</a>