### PR TITLE
CORB shouldn't block application/dash+xml videos.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2891,7 +2891,7 @@ JSON inside an <code>img</code> element) and blocks them before they reach a web
 the risk of leaking sensitive data by keeping it further from cross-origin web pages.
 
 <p>A <dfn>CORB-protected MIME type</dfn> is an <a>HTML MIME type</a>, a <a>JSON MIME type</a>, or an
-<a>XML MIME type</a> excluding <code>image/svg+xml</code>.
+<a>XML MIME type</a> excluding <code>image/svg+xml</code> and <code>application/dash+xml</code>.
 
 <p class="note no-backref">Even without CORB, accessing the content of cross-origin resources with
 <a>CORB-protected MIME types</a> is either managed by the <a>CORS protocol</a> (e.g., in case of


### PR DESCRIPTION
This addresses https://github.com/whatwg/fetch/issues/886


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/887.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (c4333a5)">Preview</a> | <a href="https://whatpr.org/fetch/887/6a644c6...c4333a5.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (c4333a5)">Diff</a>