### PR TITLE
Change the default value of credentials mode to same-origin

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1344,7 +1344,7 @@ one or more event listeners are registered on an {{XMLHttpRequestUpload}} object
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-credentials-mode>credentials mode</dfn>,
 which is "<code>omit</code>", "<code>same-origin</code>", or
-"<code>include</code>". Unless stated otherwise, it is "<code>omit</code>".
+"<code>include</code>". Unless stated otherwise, it is "<code>same-origin</code>".
 
 <div class="note no-backref">
  <dl>


### PR DESCRIPTION
This is a follow-up PR to https://github.com/whatwg/fetch/pull/585. The document is not updated so it is quite confusing to many people.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/900.html" title="Last updated on May 1, 2019, 1:20 AM UTC (c8486ea)">Preview</a> | <a href="https://whatpr.org/fetch/900/6a644c6...c8486ea.html" title="Last updated on May 1, 2019, 1:20 AM UTC (c8486ea)">Diff</a>