### PR TITLE
Editorial: defining header name sorting

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -580,6 +580,20 @@ A: 3
 <p class="note no-backref"><a for="header list">Combine</a> is used by {{XMLHttpRequest}} and the
 <a lt="establish a WebSocket connection">WebSocket protocol handshake</a>.
 
+<p>To <dfn>convert header names to a sorted-lowercase set</dfn>, given a <a for=/>list</a> of
+<a lt=name for=header>names</a> <var>headerNames</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>headerNamesSet</var> be a new <a for/>ordered set</a>.
+
+ <li><p><a for=list>For each</a> <var>name</var> of <var>headerNames</var>, <a for=set>append</a>
+ the result of <a lt=byte-lowercased>byte-lowercasing</a> <var>name</var> to
+ <var>headerNamesSet</var>.
+
+ <li><p>Return the result of <a for=set>sorting</a> <var>headerNamesSet</var> in ascending order
+ with <a>byte less than</a>.
+</ol>
+
 <p>To
 <dfn export for="header list" id=concept-header-list-sort-and-combine>sort and combine</dfn>
 a <a for=/>header list</a> <var>list</var>, run these steps:
@@ -589,9 +603,9 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
  <a for=header>name</a>-<a for=header>value</a> pairs with the key being the <a for=header>name</a>
  and value the <a for=header>value</a>.
 
- <li><p>Let <var>names</var> be all the <a lt=name for=header>names</a> of the
- <a for=/>headers</a> in <var>list</var>, <a>byte-lowercased</a>, with duplicates removed, and
- finally sorted lexicographically.
+ <li><p>Let <var>names</var> be all the result of
+ <a>convert header names to a sorted-lowercase set</a> with the <a lt=name for=header>names</a> of
+ the <a for=/>headers</a> in <var>list</var>.
 
  <li>
   <p><a for=list>For each</a> <var>name</var> in <var>names</var>:
@@ -743,8 +757,8 @@ following is true:
  <var>name</var> of <var>potentiallyUnsafeNames</var>, <a for=list>append</a> <var>name</var> to
  <var>unsafeNames</var>.
 
- <li><p>Return <var>unsafeNames</var>, <a lt="byte-lowercase">byte-lowercased</a>, excluding
- duplicates, and sorted lexicographically.
+ <li><p>Return the result of <a>convert header names to a sorted-lowercase set</a> with
+ <var>unsafeNames</var>.
 </ol>
 
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a>byte-case-insensitive</a> match

--- a/fetch.bs
+++ b/fetch.bs
@@ -603,9 +603,9 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
  <a for=header>name</a>-<a for=header>value</a> pairs with the key being the <a for=header>name</a>
  and value the <a for=header>value</a>.
 
- <li><p>Let <var>names</var> be all the result of
- <a>convert header names to a sorted-lowercase set</a> with the <a lt=name for=header>names</a> of
- the <a for=/>headers</a> in <var>list</var>.
+ <li><p>Let <var>names</var> be the result of
+ <a>convert header names to a sorted-lowercase set</a> with all the <a lt=name for=header>names</a>
+ of the <a for=/>headers</a> in <var>list</var>.
 
  <li>
   <p><a for=list>For each</a> <var>name</var> in <var>names</var>:


### PR DESCRIPTION
@domenic it would probably make the most sense for Infra to define "byte less than", right?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/906.html" title="Last updated on Aug 8, 2019, 8:35 AM UTC (f16e13e)">Preview</a> | <a href="https://whatpr.org/fetch/906/2d0d7bd...f16e13e.html" title="Last updated on Aug 8, 2019, 8:35 AM UTC (f16e13e)">Diff</a>