### PR TITLE
Let Origin header honor referrer policy for non CORS request

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1548,6 +1548,30 @@ run these steps:
  <li><p>If <var>request</var>'s <a for=request>tainted origin flag</a> is set, then return
  `<code>null</code>`.
 
+ <li><p>If <var>request</var>'s <i>CORS flag</i> is unset, then switch on <var>request</var>'s
+ <a for=request>referrer policy</a>:
+
+    <dl class=switch>
+     <dt>"<code>no-referrer</code>"
+     <dd><p> return `<code>null</code>`.
+    </dl>
+
+    <dl class=switch>
+     <dt>"<code>no-referrer-when-downgrade</code>"
+     <dt>"<code>strict-origin</code>"
+     <dt>"<code>strict-origin-when-cross-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>current URL</a>'s <var>scheme</var> is
+     "<code>http</code>" and <var>request</var>'s <a for=request>origin</a>'s
+     <var>scheme</var> is "<code>https</code>", then return `<code>null</code>`.
+    </dl>
+
+    <dl class=switch>
+     <dt>"<code>same-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then return
+     `<code>null</code>`.
+    </dl>
+
  <li><p>Return <var>request</var>'s <a for=request>origin</a>,
  <a lt="ASCII serialization of an origin">serialized</a> and <a>isomorphic encoded</a>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4068,39 +4068,42 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>,
    to <var>httpRequest</var>'s <a for=request>header list</a>.
 
-   <li><p>If the <i>CORS flag</i> is set, <var>httpRequest</var>'s <a for=request>method</a> is
-   neither `<code>GET</code>` nor `<code>HEAD</code>`, or <var>httpRequest</var>'s
-   <a for=request>mode</a> is "<code>websocket</code>", then:
+   <li><p>Run these steps:
    <ol>
-    <li><p>Let <var>origin</var> be the result of <a>serializing a request origin</a> with
+    <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
     <var>httpRequest</var>.
-    <li><p>If <var>request</var>'s <i>CORS flag</i> is unset, then switch on
-    <var>httpRequest</var>'s <a for=request>referrer policy</a>:
+    <li><p>If the <i>CORS flag</i> is set, or <var>httpRequest</var>'s <a for=request>mode</a> is
+    "<code>websocket</code>", then <a for="header list">append</a>
+    `<code>Origin</code>`/<var>serializedOrigin</var> to
+    <var>httpRequest</var>'s <a for=request>header list</a>.
+    <li><p>Otherwise, if <var>httpRequest</var>'s <a for=request>method</a> is neither
+    `<code>GET</code>` nor `<code>HEAD</code>`, then switch on <var>httpRequest</var>'s
+    <a for=request>referrer policy</a>:
 
     <dl class=switch>
      <dt>"<code>no-referrer</code>"
-     <dd><p>Set <var>origin</var> to `<code>null</code>`.
-    </dl>
+     <dd><p><a for="header list">Append</a> `<code>Origin</code>`/`<code>null</code>` to
+     <var>httpRequest</var>'s <a for=request>header list</a>.
 
-    <dl class=switch>
      <dt>"<code>no-referrer-when-downgrade</code>"
      <dt>"<code>strict-origin</code>"
      <dt>"<code>strict-origin-when-cross-origin</code>"
-     <dd><p>If <var>request</var>'s <a for=request>current URL</a>'s <var>scheme</var> is
-     "<code>http</code>" and <var>request</var>'s <a for=request>origin</a>'s
-     <var>scheme</var> is "<code>https</code>", then set <var>origin</var> to
-     `<code>null</code>`.
-    </dl>
+     <dd><p>If <var>request</var>'s <a for=request>origin</a>'s <var>scheme</var> is
+     "<code>https</code>" and <var>request</var>'s <a for=request>current URL</a>'s
+     <var>scheme</var> is "<code>http</code>", then <a for="header list">append</a>
+     `<code>Origin</code>`/`<code>null</code>` to <var>httpRequest</var>'s
+     <a for=request>header list</a>.
 
-    <dl class=switch>
      <dt>"<code>same-origin</code>"
      <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
-     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
-     <var>origin</var> to `<code>null</code>`.
-    </dl>
+     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then
+     <a for="header list">append</a> `<code>Origin</code>`/`<code>null</code>` to
+     <var>httpRequest</var>'s <a for=request>header list</a>.
 
-    <li><a for="header list">Append</a> `<code>Origin</code>`/<var>origin</var> to
-    <var>httpRequest</var>'s <a for=request>header list</a>.
+     <dt>Otherwise
+     <dd><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
+     <var>httpRequest</var>'s <a for=request>header list</a>.
+    </dl>
    </ol>
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1548,30 +1548,6 @@ run these steps:
  <li><p>If <var>request</var>'s <a for=request>tainted origin flag</a> is set, then return
  `<code>null</code>`.
 
- <li><p>If <var>request</var>'s <i>CORS flag</i> is unset, then switch on <var>request</var>'s
- <a for=request>referrer policy</a>:
-
-    <dl class=switch>
-     <dt>"<code>no-referrer</code>"
-     <dd><p> return `<code>null</code>`.
-    </dl>
-
-    <dl class=switch>
-     <dt>"<code>no-referrer-when-downgrade</code>"
-     <dt>"<code>strict-origin</code>"
-     <dt>"<code>strict-origin-when-cross-origin</code>"
-     <dd><p>If <var>request</var>'s <a for=request>current URL</a>'s <var>scheme</var> is
-     "<code>http</code>" and <var>request</var>'s <a for=request>origin</a>'s
-     <var>scheme</var> is "<code>https</code>", then return `<code>null</code>`.
-    </dl>
-
-    <dl class=switch>
-     <dt>"<code>same-origin</code>"
-     <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
-     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then return
-     `<code>null</code>`.
-    </dl>
-
  <li><p>Return <var>request</var>'s <a for=request>origin</a>,
  <a lt="ASCII serialization of an origin">serialized</a> and <a>isomorphic encoded</a>.
 </ol>
@@ -4094,9 +4070,38 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <li><p>If the <i>CORS flag</i> is set, <var>httpRequest</var>'s <a for=request>method</a> is
    neither `<code>GET</code>` nor `<code>HEAD</code>`, or <var>httpRequest</var>'s
-   <a for=request>mode</a> is "<code>websocket</code>", then <a for="header list">append</a>
-   `<code>Origin</code>`/the result of <a>serializing a request origin</a> with
-   <var>httpRequest</var>, to <var>httpRequest</var>'s <a for=request>header list</a>.
+   <a for=request>mode</a> is "<code>websocket</code>", then:
+   <ol>
+    <li><p>Let <var>origin</var> be the result of <a>serializing a request origin</a> with
+    <var>httpRequest</var>.
+    <li><p>If <var>request</var>'s <i>CORS flag</i> is unset, then switch on
+    <var>httpRequest</var>'s <a for=request>referrer policy</a>:
+
+    <dl class=switch>
+     <dt>"<code>no-referrer</code>"
+     <dd><p>Set <var>origin</var> to `<code>null</code>`.
+    </dl>
+
+    <dl class=switch>
+     <dt>"<code>no-referrer-when-downgrade</code>"
+     <dt>"<code>strict-origin</code>"
+     <dt>"<code>strict-origin-when-cross-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>current URL</a>'s <var>scheme</var> is
+     "<code>http</code>" and <var>request</var>'s <a for=request>origin</a>'s
+     <var>scheme</var> is "<code>https</code>", then set <var>origin</var> to
+     `<code>null</code>`.
+    </dl>
+
+    <dl class=switch>
+     <dt>"<code>same-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
+     <var>origin</var> to `<code>null</code>`.
+    </dl>
+
+    <li><a for="header list">Append</a> `<code>Origin</code>`/<var>origin</var> to
+    <var>httpRequest</var>'s <a for=request>header list</a>.
+   </ol>
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should

--- a/fetch.bs
+++ b/fetch.bs
@@ -4068,15 +4068,16 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>,
    to <var>httpRequest</var>'s <a for=request>header list</a>.
 
-   <li><p>Run these steps:
-   <ol>
-    <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
-    <var>httpRequest</var>.
-    <li><p>If the <i>CORS flag</i> is set, or <var>httpRequest</var>'s <a for=request>mode</a> is
-    "<code>websocket</code>", then <a for="header list">append</a>
-    `<code>Origin</code>`/<var>serializedOrigin</var> to
-    <var>httpRequest</var>'s <a for=request>header list</a>.
-    <li><p>Otherwise, if <var>httpRequest</var>'s <a for=request>method</a> is neither
+   <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+   <var>httpRequest</var>.
+
+   <li><p>If the <i>CORS flag</i> is set, or <var>httpRequest</var>'s <a for=request>mode</a> is
+   "<code>websocket</code>", then <a for="header list">append</a>
+   `<code>Origin</code>`/<var>serializedOrigin</var> to <var>httpRequest</var>'s
+   <a for=request>header list</a>.
+
+   <li>
+    <p>Otherwise, if <var>httpRequest</var>'s <a for=request>method</a> is neither
     `<code>GET</code>` nor `<code>HEAD</code>`, then switch on <var>httpRequest</var>'s
     <a for=request>referrer policy</a>:
 
@@ -4104,7 +4105,10 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
      <dd><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
      <var>httpRequest</var>'s <a for=request>header list</a>.
     </dl>
-   </ol>
+
+    <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
+    for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
+    with the server, e.g., via using the <a>CORS protocol</a>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should

--- a/fetch.bs
+++ b/fetch.bs
@@ -1554,6 +1554,54 @@ run these steps:
 
 <hr>
 
+<p>To <dfn>append a request Origin header</dfn>, given a <a for=/>request</a> <var>request</var>
+with an optional <i>CORS flag</i>, run these steps:
+
+<ol>
+  <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+  <var>request</var>.
+
+  <li><p>If the <i>CORS flag</i> is set, or <var>request</var>'s <a for=request>mode</a> is
+  "<code>websocket</code>", then <a for="header list">append</a>
+  `<code>Origin</code>`/<var>serializedOrigin</var> to <var>request</var>'s
+  <a for=request>header list</a>.
+
+  <li><p>Otherwise, if <var>request</var>'s <a for=request>method</a> is neither `<code>GET</code>`
+  nor `<code>HEAD</code>`, then:
+  <ol>
+    <li> Switch on <var>request</var>'s <a for=request>referrer policy</a>:
+
+    <dl class=switch>
+      <dt>"<code>no-referrer</code>"
+      <dd><p>Set <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>"<code>no-referrer-when-downgrade</code>"
+      <dt>"<code>strict-origin</code>"
+      <dt>"<code>strict-origin-when-cross-origin</code>"
+      <dd><p>If <var>request</var>'s <a for=request>origin</a> is a <a>tuple origin</a>, its
+      <var>scheme</var> is "<code>https</code>" and <var>request</var>'s
+      <a for=request>current URL</a>'s <var>scheme</var> is not "<code>https</code>", then set
+      <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>"<code>same-origin</code>"
+      <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+      <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
+      <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>Otherwise
+      <dd>Do nothing.
+    </dl>
+    <li><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
+    <var>request</var>'s <a for=request>header list</a>.
+  </ol>
+</ol>
+
+  <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
+  for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
+  with the server, e.g., via using the <a>CORS protocol</a>.
+
+<hr>
+
 <p>To <dfn export for=request id=concept-request-clone>clone</dfn> a
 <a for=/>request</a> <var>request</var>, run these steps:
 
@@ -4068,47 +4116,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>,
    to <var>httpRequest</var>'s <a for=request>header list</a>.
 
-   <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
-   <var>httpRequest</var>.
-
-   <li><p>If the <i>CORS flag</i> is set, or <var>httpRequest</var>'s <a for=request>mode</a> is
-   "<code>websocket</code>", then <a for="header list">append</a>
-   `<code>Origin</code>`/<var>serializedOrigin</var> to <var>httpRequest</var>'s
-   <a for=request>header list</a>.
-
-   <li>
-    <p>Otherwise, if <var>httpRequest</var>'s <a for=request>method</a> is neither
-    `<code>GET</code>` nor `<code>HEAD</code>`, then switch on <var>httpRequest</var>'s
-    <a for=request>referrer policy</a>:
-
-    <dl class=switch>
-     <dt>"<code>no-referrer</code>"
-     <dd><p><a for="header list">Append</a> `<code>Origin</code>`/`<code>null</code>` to
-     <var>httpRequest</var>'s <a for=request>header list</a>.
-
-     <dt>"<code>no-referrer-when-downgrade</code>"
-     <dt>"<code>strict-origin</code>"
-     <dt>"<code>strict-origin-when-cross-origin</code>"
-     <dd><p>If <var>request</var>'s <a for=request>origin</a>'s <var>scheme</var> is
-     "<code>https</code>" and <var>request</var>'s <a for=request>current URL</a>'s
-     <var>scheme</var> is "<code>http</code>", then <a for="header list">append</a>
-     `<code>Origin</code>`/`<code>null</code>` to <var>httpRequest</var>'s
-     <a for=request>header list</a>.
-
-     <dt>"<code>same-origin</code>"
-     <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
-     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then
-     <a for="header list">append</a> `<code>Origin</code>`/`<code>null</code>` to
-     <var>httpRequest</var>'s <a for=request>header list</a>.
-
-     <dt>Otherwise
-     <dd><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
-     <var>httpRequest</var>'s <a for=request>header list</a>.
-    </dl>
-
-    <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
-    for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
-    with the server, e.g., via using the <a>CORS protocol</a>.
+   <li><p><a>Append a request Origin header</a> for <var>httpRequest</var> with <i>CORS flag</i> if
+   set.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should

--- a/fetch.bs
+++ b/fetch.bs
@@ -1554,54 +1554,6 @@ run these steps:
 
 <hr>
 
-<p>To <dfn>append a request Origin header</dfn>, given a <a for=/>request</a> <var>request</var>
-with an optional <i>CORS flag</i>, run these steps:
-
-<ol>
-  <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
-  <var>request</var>.
-
-  <li><p>If the <i>CORS flag</i> is set, or <var>request</var>'s <a for=request>mode</a> is
-  "<code>websocket</code>", then <a for="header list">append</a>
-  `<code>Origin</code>`/<var>serializedOrigin</var> to <var>request</var>'s
-  <a for=request>header list</a>.
-
-  <li><p>Otherwise, if <var>request</var>'s <a for=request>method</a> is neither `<code>GET</code>`
-  nor `<code>HEAD</code>`, then:
-  <ol>
-    <li> Switch on <var>request</var>'s <a for=request>referrer policy</a>:
-
-    <dl class=switch>
-      <dt>"<code>no-referrer</code>"
-      <dd><p>Set <var>serializedOrigin</var> to `<code>null</code>`.
-
-      <dt>"<code>no-referrer-when-downgrade</code>"
-      <dt>"<code>strict-origin</code>"
-      <dt>"<code>strict-origin-when-cross-origin</code>"
-      <dd><p>If <var>request</var>'s <a for=request>origin</a> is a <a>tuple origin</a>, its
-      <var>scheme</var> is "<code>https</code>" and <var>request</var>'s
-      <a for=request>current URL</a>'s <var>scheme</var> is not "<code>https</code>", then set
-      <var>serializedOrigin</var> to `<code>null</code>`.
-
-      <dt>"<code>same-origin</code>"
-      <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
-      <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
-      <var>serializedOrigin</var> to `<code>null</code>`.
-
-      <dt>Otherwise
-      <dd>Do nothing.
-    </dl>
-    <li><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
-    <var>request</var>'s <a for=request>header list</a>.
-  </ol>
-</ol>
-
-  <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
-  for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
-  with the server, e.g., via using the <a>CORS protocol</a>.
-
-<hr>
-
 <p>To <dfn export for=request id=concept-request-clone>clone</dfn> a
 <a for=/>request</a> <var>request</var>, run these steps:
 
@@ -2406,6 +2358,54 @@ origin                           = <a for=url>scheme</a> "://" <a for=url>host</
 <p class="note no-backref">This supplants the `<code>Origin</code>`
 <a for=/>header</a>.
 [[ORIGIN]]
+
+<hr>
+
+<p>To <dfn id=append-a-request-origin-header>append a request `<code>Origin</code>` header</dfn>,
+given a <a for=/>request</a> <var>request</var> with an optional <i>CORS flag</i>, run these steps:
+
+<ol>
+  <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+  <var>request</var>.
+
+  <li><p>If the <i>CORS flag</i> is set, or <var>request</var>'s <a for=request>mode</a> is
+  "<code>websocket</code>", then <a for="header list">append</a>
+  `<code>Origin</code>`/<var>serializedOrigin</var> to <var>request</var>'s
+  <a for=request>header list</a>.
+
+  <li><p>Otherwise, if <var>request</var>'s <a for=request>method</a> is neither `<code>GET</code>`
+  nor `<code>HEAD</code>`, then:
+  <ol>
+    <li> Switch on <var>request</var>'s <a for=request>referrer policy</a>:
+
+    <dl class=switch>
+      <dt>"<code>no-referrer</code>"
+      <dd><p>Set <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>"<code>no-referrer-when-downgrade</code>"
+      <dt>"<code>strict-origin</code>"
+      <dt>"<code>strict-origin-when-cross-origin</code>"
+      <dd><p>If <var>request</var>'s <a for=request>origin</a> is a <a>tuple origin</a>, its
+      <var>scheme</var> is "<code>https</code>" and <var>request</var>'s
+      <a for=request>current URL</a>'s <var>scheme</var> is not "<code>https</code>", then set
+      <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>"<code>same-origin</code>"
+      <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+      <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
+      <var>serializedOrigin</var> to `<code>null</code>`.
+
+      <dt>Otherwise
+      <dd>Do nothing.
+    </dl>
+    <li><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
+    <var>request</var>'s <a for=request>header list</a>.
+  </ol>
+</ol>
+
+  <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
+  for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
+  with the server, e.g., via using the <a>CORS protocol</a>.
 
 
 <h3 id=http-cors-protocol>CORS protocol</h3>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2365,47 +2365,51 @@ origin                           = <a for=url>scheme</a> "://" <a for=url>host</
 given a <a for=/>request</a> <var>request</var> with an optional <i>CORS flag</i>, run these steps:
 
 <ol>
-  <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
-  <var>request</var>.
+ <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+ <var>request</var>.
 
-  <li><p>If the <i>CORS flag</i> is set, or <var>request</var>'s <a for=request>mode</a> is
-  "<code>websocket</code>", then <a for="header list">append</a>
-  `<code>Origin</code>`/<var>serializedOrigin</var> to <var>request</var>'s
-  <a for=request>header list</a>.
+ <li><p>If the <i>CORS flag</i> is set or <var>request</var>'s <a for=request>mode</a> is
+ "<code>websocket</code>", then <a for="header list">append</a>
+ `<code>Origin</code>`/<var>serializedOrigin</var> to <var>request</var>'s
+ <a for=request>header list</a>.
 
-  <li><p>Otherwise, if <var>request</var>'s <a for=request>method</a> is neither `<code>GET</code>`
-  nor `<code>HEAD</code>`, then:
+ <li>
+  <p>Otherwise, if <var>request</var>'s <a for=request>method</a> is neither `<code>GET</code>` nor
+  `<code>HEAD</code>`, then:
+
   <ol>
-    <li> Switch on <var>request</var>'s <a for=request>referrer policy</a>:
+   <li>
+    <p>Switch on <var>request</var>'s <a for=request>referrer policy</a>:
 
     <dl class=switch>
-      <dt>"<code>no-referrer</code>"
-      <dd><p>Set <var>serializedOrigin</var> to `<code>null</code>`.
+     <dt>"<code>no-referrer</code>"
+     <dd><p>Set <var>serializedOrigin</var> to `<code>null</code>`.
 
-      <dt>"<code>no-referrer-when-downgrade</code>"
-      <dt>"<code>strict-origin</code>"
-      <dt>"<code>strict-origin-when-cross-origin</code>"
-      <dd><p>If <var>request</var>'s <a for=request>origin</a> is a <a>tuple origin</a>, its
-      <var>scheme</var> is "<code>https</code>" and <var>request</var>'s
-      <a for=request>current URL</a>'s <var>scheme</var> is not "<code>https</code>", then set
-      <var>serializedOrigin</var> to `<code>null</code>`.
+     <dt>"<code>no-referrer-when-downgrade</code>"
+     <dt>"<code>strict-origin</code>"
+     <dt>"<code>strict-origin-when-cross-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>origin</a> is a <a>tuple origin</a>, its
+     <var>scheme</var> is "<code>https</code>", and <var>request</var>'s
+     <a for=request>current URL</a>'s <var>scheme</var> is not "<code>https</code>", then set
+     <var>serializedOrigin</var> to `<code>null</code>`.
 
-      <dt>"<code>same-origin</code>"
-      <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
-      <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
-      <var>serializedOrigin</var> to `<code>null</code>`.
+     <dt>"<code>same-origin</code>"
+     <dd><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+     <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
+     <var>serializedOrigin</var> to `<code>null</code>`.
 
-      <dt>Otherwise
-      <dd>Do nothing.
+     <dt>Otherwise
+     <dd>Do nothing.
     </dl>
-    <li><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
-    <var>request</var>'s <a for=request>header list</a>.
+
+   <li><p><a for="header list">Append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
+   <var>request</var>'s <a for=request>header list</a>.
   </ol>
 </ol>
 
-  <p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account
-  for all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a>
-  with the server, e.g., via using the <a>CORS protocol</a>.
+<p class=note>A <a for=/>request</a>'s <a for=request>referrer policy</a> is taken into account for
+all fetches where the fetcher did not explicitly opt into sharing their <a for=/>origin</a> with the
+server, e.g., via using the <a>CORS protocol</a>.
 
 
 <h3 id=http-cors-protocol>CORS protocol</h3>
@@ -4116,8 +4120,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <a for=request>referrer</a>, <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>,
    to <var>httpRequest</var>'s <a for=request>header list</a>.
 
-   <li><p><a>Append a request Origin header</a> for <var>httpRequest</var> with <i>CORS flag</i> if
-   set.
+   <li><p><a>Append a request `<code>Origin</code>` header</a> for <var>httpRequest</var> with the
+   <i>CORS flag</i> if set.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should


### PR DESCRIPTION
Let Origin header honor referrer policy for non CORS request

Tests: https://github.com/web-platform-tests/wpt/pull/14260


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/908.html" title="Last updated on Jun 26, 2019, 12:41 PM UTC (81c4f70)">Preview</a> | <a href="https://whatpr.org/fetch/908/49b92ee...81c4f70.html" title="Last updated on Jun 26, 2019, 12:41 PM UTC (81c4f70)">Diff</a>