### PR TITLE
Remove brief to unhide the note in fetch-redirect

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3929,7 +3929,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
  <li>
   <p>Return the result of performing a <a for=main>main fetch</a> using <var>request</var> with
 
-  <ul class=brief>
+  <ul class>
    <li><p><i>CORS flag</i> if set and
    <li>
     <p><i>recursive flag</i> set if <var>request</var>'s <a for=request>redirect mode</a> is not

--- a/fetch.bs
+++ b/fetch.bs
@@ -3929,7 +3929,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
  <li>
   <p>Return the result of performing a <a for=main>main fetch</a> using <var>request</var> with
 
-  <ul class>
+  <ul>
    <li><p><i>CORS flag</i> if set and
    <li>
     <p><i>recursive flag</i> set if <var>request</var>'s <a for=request>redirect mode</a> is not


### PR DESCRIPTION
a simple fix


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/914.html" title="Last updated on Jul 4, 2019, 2:28 AM UTC (cf898fa)">Preview</a> | <a href="https://whatpr.org/fetch/914/49b92ee...cf898fa.html" title="Last updated on Jul 4, 2019, 2:28 AM UTC (cf898fa)">Diff</a>