### PR TITLE
Use UTF-8 decode without BOM for multipart/form-data

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5536,9 +5536,10 @@ runs the associated steps:
 
     <p>Each part whose `<code>Content-Disposition</code>` header does not contain a
     `<code>filename</code>` parameter must be parsed into an <a for=FormData>entry</a> whose value
-    is the <a>UTF-8 decoded</a> content of the part. <span class=note>This is done regardless of the
-    presence or the value of a `<code>Content-Type</code>` header and regardless of the presence or
-    the value of a `<code>charset</code>` parameter.</span></p>
+    is the <a lt="UTF-8 decode without BOM">UTF-8 decoded without BOM</a> content of the part.
+    <span class=note>This is done regardless of the presence or the value of a
+    `<code>Content-Type</code>` header and regardless of the presence or the value of a
+    `<code>charset</code>` parameter.</span></p>
 
     <p class=note>A part whose `<code>Content-Disposition</code>` header contains a
     `<code>name</code>` parameter whose value is `<code>_charset_</code>` is parsed like any other


### PR DESCRIPTION
Tests: https://github.com/web-platform-tests/wpt/pull/17589?

Closes #650.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/915.html" title="Last updated on Jul 2, 2019, 12:38 PM UTC (ba239a1)">Preview</a> | <a href="https://whatpr.org/fetch/915/cc80ec5...ba239a1.html" title="Last updated on Jul 2, 2019, 12:38 PM UTC (ba239a1)">Diff</a>