### PR TITLE
Set CORS preflight requests' `mode` to `cors`.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4779,7 +4779,7 @@ run these steps:
   <a for=request>origin</a> is <var>request</var>'s <a for=request>origin</a>,
   <a for=request>referrer</a> is <var>request</var>'s <a for=request>referrer</a>,
   <a for=request>referrer policy</a> is <var>request</var>'s <a for=request>referrer policy</a>,
-  <a for=request>mode</a> is `<code>cors</code>`, and
+  <a for=request>mode</a> is "<code>cors</code>", and
   <a for=request>tainted origin flag</a> is <var>request</var>'s
   <a for=request>tainted origin flag</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4773,13 +4773,13 @@ run these steps:
  <li>
   <p>Let <var>preflight</var> be a new <a for=/>request</a> whose
   <a for=request>method</a> is `<code>OPTIONS</code>`,
-  <a for=request>mode</a> is `<code>cors</code>`,
   <a for=request>URL</a> is <var>request</var>'s <a for=request>current URL</a>,
   <a for=request>initiator</a> is <var>request</var>'s <a for=request>initiator</a>,
   <a for=request>destination</a> is <var>request</var>'s <a for=request>destination</a>,
   <a for=request>origin</a> is <var>request</var>'s <a for=request>origin</a>,
   <a for=request>referrer</a> is <var>request</var>'s <a for=request>referrer</a>,
-  <a for=request>referrer policy</a> is <var>request</var>'s <a for=request>referrer policy</a>, and
+  <a for=request>referrer policy</a> is <var>request</var>'s <a for=request>referrer policy</a>,
+  <a for=request>mode</a> is `<code>cors</code>`, and
   <a for=request>tainted origin flag</a> is <var>request</var>'s
   <a for=request>tainted origin flag</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4773,6 +4773,7 @@ run these steps:
  <li>
   <p>Let <var>preflight</var> be a new <a for=/>request</a> whose
   <a for=request>method</a> is `<code>OPTIONS</code>`,
+  <a for=request>mode</a> is `<code>cors</code>`,
   <a for=request>URL</a> is <var>request</var>'s <a for=request>current URL</a>,
   <a for=request>initiator</a> is <var>request</var>'s <a for=request>initiator</a>,
   <a for=request>destination</a> is <var>request</var>'s <a for=request>destination</a>,


### PR DESCRIPTION
CORS preflight requests' `mode` is now exposed via the `Sec-Fetch-Mode` header, and it
makes sense to set it to `cors`, as it's part of the CORS protocol.

Fixes https://github.com/w3c/webappsec-fetch-metadata/issues/35.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/916.html" title="Last updated on Jul 16, 2019, 12:31 PM UTC (f74a395)">Preview</a> | <a href="https://whatpr.org/fetch/916/7e088f6...f74a395.html" title="Last updated on Jul 16, 2019, 12:31 PM UTC (f74a395)">Diff</a>