### PR TITLE
"Set" Structured Header values in header lists.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -16,7 +16,6 @@ url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content; type:dfn
 url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value; type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
-url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-1;text:structured header;type:dfn;spec:header-structure
 url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.1;text:serializing structured headers;type:dfn;spec:header-structure
 </pre>
 
@@ -572,22 +571,23 @@ A: 3
  <var>name</var> and <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
 
-<p>To <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured
-header</dfn> <a for=header>name</a>/<a>structured header</a>
-<var>name</var>/<var>structured header</var> pair in a <a for=/>header list</a> <var>list</var>, run
-these steps:
+<p>To
+<dfn export for="header list" id=concept-header-list-set-structured-header>set a structured header</dfn>
+<a for=header>name</a>/structured header value <var>name</var>/<var>structuredValue</var> pair in a
+<a for=/>header list</a> <var>list</var>, run these steps:
+<!-- XXX xref "structured header value" once it lands in an RFC -->
 
 <ol>
- <li>Let <var>serialized value</var> be the result of executing the <a>serializing structured
- headers</a> algorithm on <var>structured header</var>.
- <li><a for="header list">Set</a> <var>name</var>/<var>serialized value</var> in <var>list</var>.
+ <li><p>Let <var>serializedValue</var> be the result of executing the
+ <a>serializing structured headers</a> algorithm on <var>structuredValue</var>.
+
+ <li><p><a for="header list">Set</a> <var>name</var>/<var>serializedValue</var> in <var>list</var>.
 </ol>
 
 <p class="note">Structured header values are defined as objects which HTTP can (eventually)
-serialize in interesting and efficient ways. [[!HEADER-STRUCTURE]] For the moment, Fetch only
-supports setting these objects in <a for=/>header lists</a> by first serializing them into a
-string representation. As structured header serialization evolves, this algorithm will likely
-become more efficient.
+serialize in interesting and efficient ways. For the moment, Fetch only supports setting these
+objects in <a for=/>header lists</a> by serializing them. In the future the fact that they are
+objects might be preserved end-to-end. [[!HEADER-STRUCTURE]]
 
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
 <a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair in a

--- a/fetch.bs
+++ b/fetch.bs
@@ -575,7 +575,7 @@ A: 3
 <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured header</dfn>
 <a for=header>name</a>/structured header value <var>name</var>/<var>structuredValue</var> pair in a
 <a for=/>header list</a> <var>list</var>, run these steps:
-<!-- XXX xref "structured header value" once it lands in an RFC -->
+<!-- XXX xref "structured header value" once it lands in a RFC -->
 
 <ol>
  <li><p>Let <var>serializedValue</var> be the result of executing the

--- a/fetch.bs
+++ b/fetch.bs
@@ -16,6 +16,8 @@ url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content; type:dfn
 url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value; type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
+url:https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#introduction;text:structured header;type:dfn;spec:header-structure
+url:https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#text-serialize;text:serializing structured headers;type:dfn;spec:header-structure
 </pre>
 
 <pre class=biblio>
@@ -81,6 +83,12 @@ url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:df
     },
     "OCSP": {
         "aliasOf": "RFC2560"
+    },
+    "HEADER-STRUCTURE": {
+        "authors": ["Mark Nottingham","Paul-Henning Kamp"],
+        "href": "https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html",
+        "publisher": "IETF",
+        "title": "Structured Headers for HTTP"
     }
 }
 </pre>
@@ -563,6 +571,22 @@ A: 3
  <li><p>Otherwise, <a for=list>append</a> a new <a for=/>header</a> whose <a for=header>name</a> is
  <var>name</var> and <a for=header>value</a> is <var>value</var> to <var>list</var>.
 </ol>
+
+<p>To <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured
+header</dfn> <a for=header>name</a>/<a>structured header</a>
+<var>name</var>/<var>structured header</var> pair in a <a for=/>header list</a> <var>list</var>, run
+these steps:
+
+<ol>
+ <li>Let <var>serialized value</var> be the result of executing the <a>serializing structured
+ headers</a> algorithm on <var>structured header</var>.
+ <li><a for="header list">Set</a> <var>name</var>/<var>serialized value</var> in <var>list</var>.
+</ol>
+
+<p class="note">Structured header values are defined as objects which HTTP can (eventually)
+serialize in interesting and efficient ways. [[!HEADER-STRUCTURE]] For the moment, Fetch only
+supports setting these objects in <a for=/>header lists</a> by first serializing them into a
+string representation.
 
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
 <a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair in a

--- a/fetch.bs
+++ b/fetch.bs
@@ -12,10 +12,11 @@ Translate IDs: typedefdef-bodyinit bodyinit,dictdef-requestinit requestinit,type
 <pre class=anchors>
 url:https://tools.ietf.org/html/rfc7230#section-3.1.1;text:method;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-name;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content; type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value; type:dfn;spec:http
+url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content;type:dfn;spec:http
+url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-2;text:structured header value;type:dfn;spec:header-structure
 url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.1;text:serializing structured headers;type:dfn;spec:header-structure
 </pre>
 
@@ -573,9 +574,8 @@ A: 3
 
 <p>To
 <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured header</dfn>
-<a for=header>name</a>/structured header value <var>name</var>/<var>structuredValue</var> pair in a
-<a for=/>header list</a> <var>list</var>, run these steps:
-<!-- XXX xref "structured header value" once it lands in a RFC -->
+<a for=header>name</a>/<a>structured header value</a> <var>name</var>/<var>structuredValue</var>
+pair in a <a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li><p>Let <var>serializedValue</var> be the result of executing the
@@ -584,7 +584,7 @@ A: 3
  <li><p><a for="header list">Set</a> <var>name</var>/<var>serializedValue</var> in <var>list</var>.
 </ol>
 
-<p class="note">Structured header values are defined as objects which HTTP can (eventually)
+<p class="note"><a>Structured header values</a> are defined as objects which HTTP can (eventually)
 serialize in interesting and efficient ways. For the moment, Fetch only supports setting these
 objects in <a for=/>header lists</a> by serializing them. In the future the fact that they are
 objects might be preserved end-to-end. [[!HEADER-STRUCTURE]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -16,8 +16,8 @@ url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content; type:dfn
 url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value; type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
-url:https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#introduction;text:structured header;type:dfn;spec:header-structure
-url:https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#text-serialize;text:serializing structured headers;type:dfn;spec:header-structure
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-1;text:structured header;type:dfn;spec:header-structure
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.1;text:serializing structured headers;type:dfn;spec:header-structure
 </pre>
 
 <pre class=biblio>
@@ -86,7 +86,7 @@ url:https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
     },
     "HEADER-STRUCTURE": {
         "authors": ["Mark Nottingham","Paul-Henning Kamp"],
-        "href": "https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html",
+        "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
         "publisher": "IETF",
         "title": "Structured Headers for HTTP"
     }
@@ -586,7 +586,8 @@ these steps:
 <p class="note">Structured header values are defined as objects which HTTP can (eventually)
 serialize in interesting and efficient ways. [[!HEADER-STRUCTURE]] For the moment, Fetch only
 supports setting these objects in <a for=/>header lists</a> by first serializing them into a
-string representation.
+string representation. As structured header serialization evolves, this algorithm will likely
+become more efficient.
 
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
 <a for=header>name</a>/<a for=header>value</a> <var>name</var>/<var>value</var> pair in a


### PR DESCRIPTION
As discussed in w3c/webappsec-fetch-metadata#40, this patch takes a
small first step towards supporting Structure Header values in Fetch by
wrapping header lists' existing "set" algorithm with a version that
first serializes a Structured Header object into a string
representation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/925.html" title="Last updated on Sep 13, 2019, 1:52 PM UTC (fb49277)">Preview</a> | <a href="https://whatpr.org/fetch/925/ce287b0...fb49277.html" title="Last updated on Sep 13, 2019, 1:52 PM UTC (fb49277)">Diff</a>