### PR TITLE
Revisit `destination` for `<iframe>`, `<frame>`, `<embed>`, and `<object>`.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1236,7 +1236,7 @@ not always relevant and might require different behavior.
    <td>CSP, NEL reports.
   <tr>
    <td>"<code>document</code>"
-   <td>HTML's navigate algorithm.
+   <td>HTML's navigate algorithm (top-level only).
   <tr>
    <td>"<code>frame</code>"
    <td><code>child-src</code>
@@ -3265,8 +3265,8 @@ the request.
      <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
      <li>
-      <p>Otherwise, a user agent should set <var>value</var> to the first matching statement, if
-      any, switching on <var>request</var>'s <a for=request>destination</a>:
+      <p>A user agent should set <var>value</var> to the first matching statement, if any, switching
+      on <var>request</var>'s <a for=request>destination</a>:
       <!-- https://github.com/whatwg/fetch/issues/43#issuecomment-97909717 -->
 
       <dl class=switch>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1185,6 +1185,8 @@ the empty string,
 "<code>document</code>",
 "<code>embed</code>",
 "<code>font</code>",
+"<code>frame</code>",
+"<code>iframe</code>",
 "<code>image</code>",
 "<code>manifest</code>",
 "<code>object</code>",
@@ -1228,7 +1230,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=18>""
+   <td rowspan=19>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.
@@ -1236,9 +1238,13 @@ not always relevant and might require different behavior.
    <td>"<code>document</code>"
    <td>HTML's navigate algorithm.
   <tr>
-   <td>"<code>document</code>"
+   <td>"<code>frame</code>"
    <td><code>child-src</code>
-   <td>HTML's <code>&lt;iframe></code> and <code>&lt;frame></code>
+   <td>HTML's <code>&lt;frame></code>
+  <tr>
+   <td>"<code>iframe</code>"
+   <td><code>child-src</code>
+   <td>HTML's <code>&lt;iframe></code>
   <tr>
    <td>""
    <td><code>connect-src</code>
@@ -1604,19 +1610,15 @@ whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworkle
 "<code>script</code>", "<code>style</code>", "<code>track</code>", "<code>video</code>",
 "<code>xslt</code>", or the empty string.
 
-<p>A <dfn export>potential-navigation-or-subresource request</dfn> is a
-<a for=/>request</a> whose
-<a for=request>destination</a> is
-"<code>object</code>" or "<code>embed</code>".
-
 <p>A <dfn export>non-subresource request</dfn> is a <a for=/>request</a>
-whose <a for=request>destination</a> is "<code>document</code>",
-"<code>report</code>", "<code>serviceworker</code>", "<code>sharedworker</code>",
-or "<code>worker</code>".
+whose <a for=request>destination</a> is "<code>document</code>", "<code>embed</code>",
+"<code>frame</code>", "<code>iframe</code>", "<code>object</code>", "<code>report</code>",
+"<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>".
 
 <p>A <dfn export>navigation request</dfn> is a <a for=/>request</a> whose
 <a for=request>destination</a> is
-"<code>document</code>".
+"<code>document</code>", "<code>embed</code>", "<code>frame</code>", "<code>iframe</code>",
+or "<code>object</code>".
 
 <p class=note>See <a for=/>handle fetch</a> for usage of these terms.
 [[!SW]]
@@ -3262,16 +3264,17 @@ the request.
     <ol>
      <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
-     <li><p>If <var>request</var> is a <a>navigation request</a>, a user agent should set
-     <var>value</var> to
-     `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
-
      <li>
       <p>Otherwise, a user agent should set <var>value</var> to the first matching statement, if
       any, switching on <var>request</var>'s <a for=request>destination</a>:
       <!-- https://github.com/whatwg/fetch/issues/43#issuecomment-97909717 -->
 
       <dl class=switch>
+       <dt>"<code>document</code>"
+       <dt>"<code>frame</code>"
+       <dt>"<code>iframe</code>"
+       <dd>`<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`
+
        <dt>"<code>image</code>"
        <dd>`<code>image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5</code>`
 
@@ -5823,7 +5826,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };


### PR DESCRIPTION
As discussed in w3c/webappsec-fetch-metadata#45, splitting 'document' into a set of
destination values that developers can use to determine whether the request is for
a top-level document or a nested document will allow us to simplify Fetch Metadata
checks performed server side.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/948.html" title="Last updated on Jun 5, 2020, 8:23 AM UTC (939613d)">Preview</a> | <a href="https://whatpr.org/fetch/948/9ac2b5b...939613d.html" title="Last updated on Jun 5, 2020, 8:23 AM UTC (939613d)">Diff</a>