### PR TITLE
Change the default referrer policy to 'strict-origin-when-cross-origin'.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3310,8 +3310,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
    <li>
     <p>If <var>request</var>'s <a for=request>referrer policy</a>
     is the empty string, then set <var>request</var>'s
-    <a for=request>referrer policy</a> to
-    "<code>strict-origin-when-cross-origin</code>".
+    <a for=request>referrer policy</a> to the <a for=/>default referrer policy</a>.
 
    <li>
     <p>If <var>request</var>'s <a for=request>referrer</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3311,10 +3311,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
     <p>If <var>request</var>'s <a for=request>referrer policy</a>
     is the empty string, then set <var>request</var>'s
     <a for=request>referrer policy</a> to
-    "<code>no-referrer-when-downgrade</code>".
-
-    <p class="note no-backref">We use "<code>no-referrer-when-downgrade</code>" because it is the
-    historical default.
+    "<code>strict-origin-when-cross-origin</code>".
 
    <li>
     <p>If <var>request</var>'s <a for=request>referrer</a>


### PR DESCRIPTION
This addresses
https://github.com/w3c/webappsec-referrer-policy/pull/125, among other
things.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/952.html" title="Last updated on Oct 15, 2019, 9:25 AM UTC (dd7a662)">Preview</a> | <a href="https://whatpr.org/fetch/952/ae6435f...dd7a662.html" title="Last updated on Oct 15, 2019, 9:25 AM UTC (dd7a662)">Diff</a>