### PR TITLE
Add TAO check

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1549,7 +1549,7 @@ Unless stated otherwise, it is unset.
 Unless stated otherwise, it is unset.
 
 <p>A <a for=/>request</a> has an associated
-<dfn export for=request id=timing-allow-failed-flag>timing allow failed flag</dfn>. Unless stated
+<dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
 <p class="note no-backref">A <a for=/>request</a>'s <a for=request>tainted origin flag</a>,
@@ -1810,8 +1810,8 @@ being provided to an API that didn't make a range request. See the flag's usage 
 description of the attack.
 
 <p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-allow-passed-flag>timing allow passed flag</dfn>, which
-is initially unset.
+<dfn for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>, which is
+initially unset.
 
 <p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
@@ -4979,7 +4979,7 @@ run these steps:
 <p>A <dfn>cache entry</dfn> consists of:
 
 <ul class=brief>
- <li><dfn id=concept-cache-origin for="cache entry">serialized origin</dfn> (a
+ <li><dfn id=concept-cache-origin for="cache entry">byte-serialized origin</dfn> (a
  <a for=/>byte sequence</a>)
  <li><dfn id=concept-cache-url for="cache entry">URL</dfn> (a <a for=/>URL</a>)
  <li><dfn id=concept-cache-max-age for="cache entry">max-age</dfn> (a number of seconds)
@@ -5002,7 +5002,7 @@ be removed before that moment arrives.
   <p>Let <var>entry</var> be a <a>cache entry</a>, initialized as follows:
 
   <dl>
-   <dt><a for="cache entry">serialized origin</a>
+   <dt><a for="cache entry">byte-serialized origin</a>
    <dd><p>The result of <a>byte-serializing a request origin</a> with <var>request</var>
 
    <dt><a for="cache entry">URL</a>
@@ -5027,15 +5027,15 @@ be removed before that moment arrives.
 
 <p>To <dfn id=concept-cache-clear>clear cache entries</dfn>, given a <var>request</var>,
 <a for=list>remove</a> any <a>cache entries</a> in the user agent's <a>CORS-preflight cache</a>
-whose <a for="cache entry">serialized origin</a> is the result of
+whose <a for="cache entry">byte-serialized origin</a> is the result of
 <a>byte-serializing a request origin</a> with <var>request</var> and whose
 <a for="cache entry">URL</a> is <var>request</var>'s <a for=request>current URL</a>.
 
 <p>There is a <dfn id=concept-cache-match>cache entry match</dfn> for a <a>cache entry</a>
 <var>entry</var> with <var>request</var> if <var>entry</var>'s
-<a for="cache entry">serialized origin</a> is the result of <a>byte-serializing a request origin</a>
-with <var>request</var>, <var>entry</var>'s <a for="cache entry">URL</a> is <var>request</var>'s
-<a for=request>current URL</a>, and one of
+<a for="cache entry">byte-serialized origin</a> is the result of
+<a>byte-serializing a request origin</a> with <var>request</var>, <var>entry</var>'s
+<a for="cache entry">URL</a> is <var>request</var>'s <a for=request>current URL</a>, and one of
 
 <ul class=brief>
  <li><var>entry</var>'s <a for="cache entry">credentials</a> is true

--- a/fetch.bs
+++ b/fetch.bs
@@ -1590,11 +1590,15 @@ run these steps:
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>tainted origin flag</a> is set, then return
- `<code>null</code>`.
+ "<code>null</code>".
 
  <li><p>Return <var>request</var>'s <a for=request>origin</a>,
- <a lt="ASCII serialization of an origin">serialized</a> and <a>isomorphic encoded</a>.
+ <a lt="ASCII serialization of an origin">serialized</a>.
 </ol>
+
+<p><dfn>Byte-serializing a request origin</dfn>, given a <a for=/>request</a> <var>request</var>,
+is to return the result of <a>serializing a request origin</a> with <var>request</var>,
+<a>isomorphic encoded</a>.
 
 <hr>
 
@@ -2430,8 +2434,8 @@ origin                           = <a for=url>scheme</a> "://" <a for=url>host</
 given a <a for=/>request</a> <var>request</var> with an optional <i>CORS flag</i>, run these steps:
 
 <ol>
- <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
- <var>request</var>.
+ <li><p>Let <var>serializedOrigin</var> be the result of <a>byte-serializing a request origin</a>
+ with <var>request</var>.
 
  <li><p>If the <i>CORS flag</i> is set or <var>request</var>'s <a for=request>mode</a> is
  "<code>websocket</code>", then <a for="header list">append</a>
@@ -3542,7 +3546,8 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
- <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
+ <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
+ <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
 
  <li><p><a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>Set <var>internalResponse</var>'s CSP list</a>.
  [[!CSP]]
@@ -4998,7 +5003,7 @@ be removed before that moment arrives.
 
   <dl>
    <dt><a for="cache entry">serialized origin</a>
-   <dd><p>The result of <a>serializing a request origin</a> with <var>request</var>
+   <dd><p>The result of <a>byte-serializing a request origin</a> with <var>request</var>
 
    <dt><a for="cache entry">URL</a>
    <dd><p><var>request</var>'s <a for=request>current URL</a>
@@ -5023,13 +5028,13 @@ be removed before that moment arrives.
 <p>To <dfn id=concept-cache-clear>clear cache entries</dfn>, given a <var>request</var>,
 <a for=list>remove</a> any <a>cache entries</a> in the user agent's <a>CORS-preflight cache</a>
 whose <a for="cache entry">serialized origin</a> is the result of
-<a>serializing a request origin</a> with <var>request</var> and whose <a for="cache entry">URL</a>
-is <var>request</var>'s <a for=request>current URL</a>.
+<a>byte-serializing a request origin</a> with <var>request</var> and whose
+<a for="cache entry">URL</a> is <var>request</var>'s <a for=request>current URL</a>.
 
 <p>There is a <dfn id=concept-cache-match>cache entry match</dfn> for a <a>cache entry</a>
 <var>entry</var> with <var>request</var> if <var>entry</var>'s
-<a for="cache entry">serialized origin</a> is the result of <a>serializing a request origin</a> with
-<var>request</var>, <var>entry</var>'s <a for="cache entry">URL</a> is <var>request</var>'s
+<a for="cache entry">serialized origin</a> is the result of <a>byte-serializing a request origin</a>
+with <var>request</var>, <var>entry</var>'s <a for="cache entry">URL</a> is <var>request</var>'s
 <a for=request>current URL</a>, and one of
 
 <ul class=brief>
@@ -5078,7 +5083,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>request</var>'s <a for=request>credentials mode</a> is not "<code>include</code>"
  and <var>origin</var> is `<code>*</code>`, then return success.
 
- <li><p>If the result of <a>serializing a request origin</a> with <var>request</var> is not
+ <li><p>If the result of <a>byte-serializing a request origin</a> with <var>request</var> is not
  <var>origin</var>, then return failure.
 
  <li><p>If <var>request</var>'s <a for=request>credentials mode</a> is not "<code>include</code>",
@@ -5103,20 +5108,19 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then return
  failure.
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>", then return success.
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>", then
+ return success.
 
  <li><p>Let <var>values</var> be the result of
- <a for="header list">getting, decoding, and splitting</a>
- `<code>Timing-Allow-Origin</code></a>` from <var>response</var>'s <a for=response>header list</a>.
+ <a for="header list">getting, decoding, and splitting</a> `<code>Timing-Allow-Origin</code>` from
+ <var>response</var>'s <a for=response>header list</a>.
 
- <li><p>If <var>values</var> contains `<code>*</code>`, then return success.
+ <li><p>If <var>values</var> <a for=list>contains</a> "<code>*</code>", then return success.
 
- <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
- <var>request</var>.
+ <li><p>If <var>values</var> <a for=list>contains</a> the result of
+ <a>serializing a request origin</a> with <var>request</var>, then return success.
 
- <li><p>If <var>values</var> contains <var>serializedOrigin</var>, then return success.
-
- <li><p>Otherwise, return failure.
+ <li><p>Return failure.
 </ol>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1806,7 +1806,7 @@ being provided to an API that didn't make a range request. See the flag's usage 
 description of the attack.
 
 <p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-allow-failed-flag>timing allow check flag</dfn>, which
+<dfn for=response id=concept-response-timing-allow-passed-flag>timing allow passed flag</dfn>, which
 is initially unset.
 
 <p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
@@ -3542,7 +3542,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
- <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set <var>internalResponse</var>'s <a for=response>timing allow check flag</a>.
+ <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
 
  <li><p><a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>Set <var>internalResponse</var>'s CSP list</a>.
  [[!CSP]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -3542,6 +3542,8 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
+ <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then set <var>internalResponse</var>'s <a for=response>timing allow failed flag</a>.
+
  <li><p><a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>Set <var>internalResponse</var>'s CSP list</a>.
  [[!CSP]]
 
@@ -3910,8 +3912,7 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
     or <a for=/>responses</a> from a service worker for that matter, it is applied here.
 
    <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
-   then set <var>request</var>'s <a for=request>timing allow failed flag</a> and set
-   <var>response</var>'s <a for=response>timing allow failed flag</a>.
+   then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
   </ol>
 
  <li>
@@ -5106,16 +5107,16 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <var>response</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
  <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return success.
 
- <li><p>Let <var>serializedOrigin</var> be <var>request</var>'s <a for=request>origin</a>,
- <a lt="ASCII serialization of an origin">serialized</a> and <a>isomorphic encoded</a>.
-
  <li><p>Let <var>values</var> be the result of
  <a for="header list">getting, decoding, and splitting</a>
  `<code>Timing-Allow-Origin</code></a>` from <var>response</var>'s <a for=response>header list</a>.
 
  <li><p>If <var>values</var> contains `<code>*</code>`, then return success.
 
- <li><p>Otherwise, if <var>values</var> contains <var>serializedOrigin</var>, then return success.
+ <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+ <var>request</var>.
+
+ <li><p>If <var>values</var> contains <var>serializedOrigin</var>, then return success.
 
  <li><p>Otherwise, return failure.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1548,10 +1548,15 @@ Unless stated otherwise, it is unset.
 <p>A <a for=/>request</a> has an associated <dfn export for=request id=done-flag>done flag</dfn>.
 Unless stated otherwise, it is unset.
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=timing-allow-failed-flag>timing allow failed flag</dfn>. Unless stated
+otherwise, it is unset.
+
 <p class="note no-backref">A <a for=/>request</a>'s <a for=request>tainted origin flag</a>,
 <a for=request>URL list</a>, <a for=request>current URL</a>, <a for=request>redirect count</a>,
-<a for=request>response tainting</a>, and <a for=request>done flag</a> are used as bookkeeping
-details by the <a for=/>fetch</a> algorithm.
+<a for=request>response tainting</a>, <a for=request>done flag</a>, and
+<a for=request>timing allow failed flag</a> are used as bookkeeping details by the
+<a for=/>fetch</a> algorithm.
 
 <hr>
 
@@ -3896,6 +3901,9 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
     or <a for=/>responses</a> from a service worker for that matter, it is applied here.
   </ol>
 
+ <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure, then
+  set <var>request</var>'s <a for=request>timing allow failed flag</a>.
+
  <li>
   <p>If <var>actualResponse</var>'s <a for=response>status</a> is a <a>redirect status</a>, then:
 
@@ -5072,6 +5080,34 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>credentials</var> is `<code>true</code>`, then return success.
 
  <li><p>Return failure.
+</ol>
+
+
+<h3 id=tao-check>TAO check</h3>
+
+<p>To perform a <dfn id=concept-tao-check>TAO check</dfn> for a <var>request</var> and
+<var>response</var>, run these steps:
+
+<ol>
+ <li><p>If <var>response</var>'s <a for=request>timing allow failed flag</a> is set, then return
+ failure.
+
+ <li><p>If <var>request</var>'s <a for=request>tainted origin flag</a> is unset and
+ <var>response</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
+ <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return success.
+
+ <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
+ <var>request</var>.
+
+ <li><p>Let <var>values</var> be the result of
+ <a for="header list">getting, decoding, and splitting</a>
+ `<code>Timing-Allow-Origin</code></a>` from <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>If <var>values</var> contains `<code>*</code>`, then return success.
+
+ <li><p>Otherwise, if <var>values</var> contains <var>serializedOrigin</var>, then return success.
+
+ <li><p>Otherwise, return failure.
 </ol>
 
 
@@ -7207,6 +7243,7 @@ Mohammed Zubair Ahmed<!-- M-ZubairAhmed; GitHub -->,
 Moritz Kneilmann,
 Ms2ger,
 Nico Schlömer,
+Nicolás Peña Moreno,
 Nikhil Marathe,
 Nikki Bee,
 Nikunj Mehta,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3899,10 +3899,10 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
     <p class="note no-backref">As the <a>CORS check</a> is not to be applied to
     <a for=/>responses</a> whose <a for=response>status</a> is <code>304</code> or <code>407</code>,
     or <a for=/>responses</a> from a service worker for that matter, it is applied here.
-  </ol>
 
- <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure, then
-  set <var>request</var>'s <a for=request>timing allow failed flag</a>.
+   <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
+   then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
+  </ol>
 
  <li>
   <p>If <var>actualResponse</var>'s <a for=response>status</a> is a <a>redirect status</a>, then:
@@ -5092,7 +5092,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>response</var>'s <a for=request>timing allow failed flag</a> is set, then return
  failure.
 
- <li><p>If <var>request</var>'s <a for=request>tainted origin flag</a> is unset and
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>basic</code>" and
  <var>response</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
  <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return success.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1806,7 +1806,7 @@ being provided to an API that didn't make a range request. See the flag's usage 
 description of the attack.
 
 <p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-allow-failed-flag>timing allow failed flag</dfn>, which
+<dfn for=response id=concept-response-timing-allow-failed-flag>timing allow check flag</dfn>, which
 is initially unset.
 
 <p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
@@ -3542,7 +3542,7 @@ with a <i>CORS flag</i> and <i>recursive flag</i>, run these steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
- <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then set <var>internalResponse</var>'s <a for=response>timing allow failed flag</a>.
+ <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set <var>internalResponse</var>'s <a for=response>timing allow check flag</a>.
 
  <li><p><a href=https://w3c.github.io/webappsec-csp/#set-response-csp-list>Set <var>internalResponse</var>'s CSP list</a>.
  [[!CSP]]
@@ -5103,9 +5103,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then return
  failure.
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>" and
- <var>response</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
- <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return success.
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>", then return success.
 
  <li><p>Let <var>values</var> be the result of
  <a for="header list">getting, decoding, and splitting</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1805,6 +1805,15 @@ initially unset.
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
 description of the attack.
 
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-timing-allow-failed-flag>timing allow failed flag</dfn>, which
+is initially unset.
+
+<p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
+allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
+the response of a redirect must be set if it was set for previous responses in the redirect chain,
+this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
+
 <p>A <a for=/>response</a> can have an associated
 <dfn export for=response id=concept-response-location-url>location URL</dfn> (null, failure, or a
 <a for=/>URL</a>). Unless specified otherwise, <a for=/>response</a> has no
@@ -3901,7 +3910,8 @@ optional <i>CORS flag</i> and <i>CORS-preflight flag</i>, run these steps:
     or <a for=/>responses</a> from a service worker for that matter, it is applied here.
 
    <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
-   then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
+   then set <var>request</var>'s <a for=request>timing allow failed flag</a> and set
+   <var>response</var>'s <a for=response>timing allow failed flag</a>.
   </ol>
 
  <li>
@@ -5089,15 +5099,15 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 <var>response</var>, run these steps:
 
 <ol>
- <li><p>If <var>response</var>'s <a for=request>timing allow failed flag</a> is set, then return
+ <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then return
  failure.
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>basic</code>" and
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>" and
  <var>response</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
  <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return success.
 
- <li><p>Let <var>serializedOrigin</var> be the result of <a>serializing a request origin</a> with
- <var>request</var>.
+ <li><p>Let <var>serializedOrigin</var> be <var>request</var>'s <a for=request>origin</a>,
+ <a lt="ASCII serialization of an origin">serialized</a> and <a>isomorphic encoded</a>.
 
  <li><p>Let <var>values</var> be the result of
  <a for="header list">getting, decoding, and splitting</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1811,7 +1811,7 @@ is initially unset.
 
 <p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
-the response of a redirect must be set if it was set for previous responses in the redirect chain,
+the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> can have an associated


### PR DESCRIPTION
This adds a Timing Allow Origin (TAO) check, trying to be as close to a CORS check as possible. The check is added very close to where the CORS check is, in the HTTP fetch algorithm. It is added so that service worker responses are also checked. When the check fails, it is stored in the request (and once it fails, future redirects cannot cause it to pass). This check is similar to https://w3c.github.io/resource-timing/#dfn-timing-allow-check but the tainted bool is replaced with the tainted origin flag to align with CORS.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/955.html" title="Last updated on Dec 3, 2019, 6:27 PM UTC (648f46e)">Preview</a> | <a href="https://whatpr.org/fetch/955/ae6435f...648f46e.html" title="Last updated on Dec 3, 2019, 6:27 PM UTC (648f46e)">Diff</a>