### PR TITLE
Use ReadableStreamPipeTo in Request constructor

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6224,17 +6224,19 @@ constructor must run these steps:
   <p>If <var>inputBody</var> is <var>body</var> and <var>inputBody</var> is non-null, then:
 
   <ol>
-   <li>
-    <p>Let <var>rs</var> bs a {{ReadableStream}} object from which one can read the exactly
-    same data as one could read from <var>inputBody</var>'s <a for=body>stream</a>.
+   <li><p>Let <var>ws</var> and <var>rs</var> be the <a>writable side</a> and <a>readable side</a>
+   of an <a>identity transform stream</a>, respectively.</li>
 
-    <p class=XXX>This will be specified more precisely once
-    <a href=https://streams.spec.whatwg.org/#ts-model>transform stream</a> and
-    <a href=https://streams.spec.whatwg.org/#pipe-chains>piping</a> are precisely defined.
-    See <a href=https://github.com/whatwg/fetch/issues/463>issue #463</a>.
+   <li>
+    <p>Let <var>promise</var> be the result of calling
+    <a abstract-op>ReadableStreamPipeTo</a>(<var>inputBody</var>, <var>ws</var></var>, false,
+    false, false, undefined).
 
     <p class="note no-backref">This makes <var>inputBody</var>'s <a for=body>stream</a>
     <a for=ReadableStream>locked</a> and <a for=ReadableStream>disturbed</a> immediately.
+   </li>
+
+   <li><p>Set <var>promise</var>.\[[PromiseIsHandled]]</var> to true.
 
    <li><p>Set <var>body</var> to a new <a for=/>body</a> whose <a for=body>stream</a> is
    <var>rs</var>, whose <a for=body>source</a> is <var>inputBody</var>'s <a for=body>source</a>, and


### PR DESCRIPTION
We have used an imprecise sentence for creating a ReadableStream "from which
one can read the exactly same data as one could read" from the original
ReadableStream, because transform streams and piping were not defined. Now they
are available, so let's use them.

Fixes #463.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/959.html" title="Last updated on Dec 13, 2019, 9:03 AM UTC (81c5b23)">Preview</a> | <a href="https://whatpr.org/fetch/959/7db8ac5...81c5b23.html" title="Last updated on Dec 13, 2019, 9:03 AM UTC (81c5b23)">Diff</a>