### PR TITLE
Editorial: use origin-based "same site" definition

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3107,9 +3107,22 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" ; case-sensit
 
  <li><p>If <var>policy</var> is `<code>same-origin</code>`, then return <b>blocked</b>.
 
- <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
- <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then return
- <b>allowed</b>.
+ <li>
+  <p>If the following are true
+
+  <ul class=brief>
+   <li><var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
+   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>
+   <li><var>request</var>'s <a for=request>origin</a>'s <a for=url>scheme</a> is
+   "<code>https</code>" or <var>response</var>'s <a for=response>HTTPS state</a> is
+   "<code>none</code>"
+  </ul>
+
+  <p>then return <b>allowed</b>.
+
+  <p class=note>This prevents HTTPS responses with
+  `<code>Cross-Origin-Resource-Policy: same-site</code>` from being accessed without secure
+  transport.
 
  <li><p>If <var>policy</var> is `<code>same-site</code>`, then return <b>blocked</b>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3111,8 +3111,8 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" ; case-sensit
   <p>If the following are true
 
   <ul class=brief>
-   <li><var>request</var>'s <a for=request>origin</a>'s <a for=url>host</a> is <a>same site</a> with
-   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a>
+   <li><var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
+   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>
    <li><var>request</var>'s <a for=request>origin</a>'s <a for=url>scheme</a> is
    "<code>https</code>" or <var>response</var>'s <a for=response>HTTPS state</a> is
    "<code>none</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -3107,22 +3107,9 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" ; case-sensit
 
  <li><p>If <var>policy</var> is `<code>same-origin</code>`, then return <b>blocked</b>.
 
- <li>
-  <p>If the following are true
-
-  <ul class=brief>
-   <li><var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
-   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>
-   <li><var>request</var>'s <a for=request>origin</a>'s <a for=url>scheme</a> is
-   "<code>https</code>" or <var>response</var>'s <a for=response>HTTPS state</a> is
-   "<code>none</code>"
-  </ul>
-
-  <p>then return <b>allowed</b>.
-
-  <p class=note>This prevents HTTPS responses with
-  `<code>Cross-Origin-Resource-Policy: same-site</code>` from being accessed without secure
-  transport.
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
+ <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then return
+ <b>allowed</b>.
 
  <li><p>If <var>policy</var> is `<code>same-site</code>`, then return <b>blocked</b>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3111,7 +3111,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" ; case-sensit
   <p>If the following are true
 
   <ul class=brief>
-   <li><var>request</var>'s <a for=request>origin</a> is <a>same site</a> with
+   <li><var>request</var>'s <a for=request>origin</a> is <a>schemelessly same site</a> with
    <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>
    <li><var>request</var>'s <a for=request>origin</a>'s <a for=url>scheme</a> is
    "<code>https</code>" or <var>response</var>'s <a for=response>HTTPS state</a> is


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/5076.

/cc @mikewest 

I'm unsure whether this should be "same site" or "schemelessly same site". I guess for parity with the previous it should be "schemelessly same site"? But that seems like a pretty bad mismatch with the web-dev-visible header name... what's going on?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/965.html" title="Last updated on Nov 19, 2019, 5:01 PM UTC (1d6002f)">Preview</a> | <a href="https://whatpr.org/fetch/965/65138f3...1d6002f.html" title="Last updated on Nov 19, 2019, 5:01 PM UTC (1d6002f)">Diff</a>