### PR TITLE
Add support for Content-DPR response header

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1772,6 +1772,10 @@ initially unset.
      need to mask it, whether the cache API needs to store it, etc. -->
 
 <p>A <a for=/>response</a> has an associated
+ <dfn for=response id=concept-response-image-density>image density</dfn>, which is initially set to
+ zero.
+
+<p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-https-state>HTTPS state</dfn> (an
 <a>HTTPS state value</a>). Unless stated otherwise, it is
 "<code>none</code>".
@@ -3618,6 +3622,12 @@ optionally with a <i>recursive flag</i>, run these steps:
    <a for=request>body</a>, and then
    <a>queue a fetch-request-done task</a> for <var>request</var>.
   </ol>
+
+ <li><p>If <var>request</var>'s destination is "image" and <var>response</var>'s
+  <a for=response>header list</a> <a for="header list">contains</a>
+   `<code>Content-DPR</code>`, set <var>response</var>'s <a for=response>image density</a> value to the
+  result of parsing the header value as float.
+  <!-- TODO: propoerly link parse as float -->
 
  <li><p><a>Queue a fetch task</a> on <var>request</var> to
  <a>process response</a> for <var>response</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1772,8 +1772,8 @@ initially unset.
      need to mask it, whether the cache API needs to store it, etc. -->
 
 <p>A <a for=/>response</a> has an associated
- <dfn for=response id=concept-response-image-density>image density</dfn>, which is initially set to
- zero.
+ <dfn for=response id=concept-response-image-density>image density</dfn>, which is null or a float.
+ It is initially set to null.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-https-state>HTTPS state</dfn> (an
@@ -3624,10 +3624,10 @@ optionally with a <i>recursive flag</i>, run these steps:
   </ol>
 
  <li><p>If <var>request</var>'s destination is "image" and <var>response</var>'s
-  <a for=response>header list</a> <a for="header list">contains</a>
-   `<code>Content-DPR</code>`, set <var>response</var>'s <a for=response>image density</a> value to the
-  result of parsing the header value as float.
-  <!-- TODO: propoerly link parse as float -->
+ <a for=response>header list</a> <a for="header list">contains</a> <code>Content-DPR</code>, set
+ <var>response</var>'s <a for=response>image density</a> value to the result of parsing the header
+ value as float.
+ <!-- TODO: propoerly link parse as float -->
 
  <li><p><a>Queue a fetch task</a> on <var>request</var> to
  <a>process response</a> for <var>response</var>.


### PR DESCRIPTION
This WIP PR, in conjunction with [a PR to HTML](https://github.com/whatwg/html/pull/5112), adds support for the `Content-DPR` response header on image responses ([see explainer here](https://github.com/eeeps/content-dpr-explainer)).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/971.html" title="Last updated on Nov 26, 2019, 4:41 AM UTC (dc64d8b)">Preview</a> | <a href="https://whatpr.org/fetch/971/493c021...dc64d8b.html" title="Last updated on Nov 26, 2019, 4:41 AM UTC (dc64d8b)">Diff</a>