### PR TITLE
Change the Access-Control-Max-Age default to 5

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2601,7 +2601,7 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
  <a for=response>URL</a> for the purposes of the <a>CORS protocol</a>.
 
  <dt>`<dfn export http-header id=http-access-control-max-age><code>Access-Control-Max-Age</code></dfn>`
- <dd><p>Indicates how long the information provided by the
+ <dd><p>Indicates the number of seconds (5 by default) the information provided by the
  `<a http-header><code>Access-Control-Allow-Methods</code></a>` and
  `<a http-header><code>Access-Control-Allow-Headers</code></a>` <a for=/>headers</a> can be cached.
 </dl>
@@ -4955,7 +4955,7 @@ run these steps:
    `<a http-header><code>Access-Control-Max-Age</code></a>` and <var>response</var>'s
    <a for=response>header list</a>.
 
-   <li><p>If <var>max-age</var> is failure or null, then set <var>max-age</var> to zero.
+   <li><p>If <var>max-age</var> is failure or null, then set <var>max-age</var> to 5.
 
    <li><p>If <var>max-age</var> is greater than an imposed limit on
    <a for="cache entry">max-age</a>, then set <var>max-age</var> to the imposed limit.


### PR DESCRIPTION
Already covered by web-platform-tests.

Fixes #990.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/992.html" title="Last updated on Jan 9, 2020, 10:36 AM UTC (14f2982)">Preview</a> | <a href="https://whatpr.org/fetch/992/8ca6148...14f2982.html" title="Last updated on Jan 9, 2020, 10:36 AM UTC (14f2982)">Diff</a>