### PR TITLE
Make Cors requests not take Referrer-Policy into account

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2436,7 +2436,7 @@ request <a for=/>header</a> indicates where a
 <p class="note no-backref">The `<a http-header><code>Origin</code></a>` header is a version of the
 `<code>Referer</code>` [sic] header that does not reveal a <a for=url>path</a>. It is used for all
 <a lt="HTTP fetch">HTTP fetches</a> whose <a for=/>request</a>'s
-<a for=request>response tainting</a> is "<code>cors</code>", as well as those where
+<a for=request>mode</a> is "<code>cors</code>", as well as those where
 <a for=/>request</a>'s <a for=request>method</a> is neither `<code>GET</code>` nor
 `<code>HEAD</code>`. Due to compatibility constraints it is not included in all
 <a lt=fetch for=/>fetches</a>.
@@ -2464,7 +2464,7 @@ given a <a for=/>request</a> <var>request</var>, run these steps:
  <li><p>Let <var>serializedOrigin</var> be the result of <a>byte-serializing a request origin</a>
  with <var>request</var>.
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" or
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>cors</code>" or
  <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>", then
  <a for="header list">append</a> `<code>Origin</code>`/<var>serializedOrigin</var> to
  <var>request</var>'s <a for=request>header list</a>.


### PR DESCRIPTION
The test fetch/origin/assorted.window.js indicates that CORS (mode
is Cors) requests should not take Referrer-Policy into account, however
basing this on the tainting value seems to invalidate that, as same-origin
Cors fetches set tainting to Basic, not Cors, and would take
Referrer-Policy into account, so instead of tainting base Step 2
on mode.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1013.html" title="Last updated on Mar 31, 2020, 12:53 PM UTC (208d6c6)">Preview</a> | <a href="https://whatpr.org/fetch/1013/00239c1...208d6c6.html" title="Last updated on Mar 31, 2020, 12:53 PM UTC (208d6c6)">Diff</a>