### PR TITLE
Add `cross-origin` to allowed CORP header values.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3122,7 +3122,7 @@ response <a for=/>header</a> can be used to require checking a <a for=/>request<
 <p>Its <a for=header>value</a> <a>ABNF</a>:
 
 <pre><code class=lang-abnf>
-Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" ; case-sensitive
+Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-site" ; case-sensitive
 </code></pre>
 
 <p>To perform a <dfn>cross-origin resource policy check</dfn>, given a <var>request</var> and

--- a/fetch.bs
+++ b/fetch.bs
@@ -3122,7 +3122,7 @@ response <a for=/>header</a> can be used to require checking a <a for=/>request<
 <p>Its <a for=header>value</a> <a>ABNF</a>:
 
 <pre><code class=lang-abnf>
-Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-site" ; case-sensitive
+Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
 </code></pre>
 
 <p>To perform a <dfn>cross-origin resource policy check</dfn>, given a <var>request</var> and


### PR DESCRIPTION
This patch adds `cross-site` to the list of allowed CORP header values. It's a no-op
at this point, but I've started asking folks to set this header in preparation for COEP
rollout, and one has pointed me to the spec, noting that the value I'm suggesting they
add isn't technically legal.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1016.html" title="Last updated on Apr 1, 2020, 2:32 PM UTC (1665249)">Preview</a> | <a href="https://whatpr.org/fetch/1016/00239c1...1665249.html" title="Last updated on Apr 1, 2020, 2:32 PM UTC (1665249)">Diff</a>