### PR TITLE
Meta: URL changed how it exports percent-decode

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6962,7 +6962,7 @@ that RFC's normative processing requirements to be compatible with deployed cont
 
  <li><p>Let <var>encodedBody</var> be the remainder of <var>input</var>.
 
- <li><p>Let <var>body</var> be the <a>string percent decoding</a> of <var>encodedBody</var>.
+ <li><p>Let <var>body</var> be the <a for=string>percent-decoding</a> of <var>encodedBody</var>.
 
  <li>
   <p>If <var>mimeType</var> ends with U+003B (;), followed by zero or more U+0020 SPACE, followed by


### PR DESCRIPTION
See https://github.com/whatwg/url/pull/503.

(This needs to wait for that PR to actually land + a day or so.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1026.html" title="Last updated on May 12, 2020, 7:10 AM UTC (f66370b)">Preview</a> | <a href="https://whatpr.org/fetch/1026/8d64fa2...f66370b.html" title="Last updated on May 12, 2020, 7:10 AM UTC (f66370b)">Diff</a>