### PR TITLE
Define "Request URL serialization for reporting"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1749,8 +1749,8 @@ source of security bugs. Please seek security review for features that deal with
 
 <hr>
 
-<p>To <dfn export for=request>serialize a request URL for reporting</dfn>, given a
-<a for=/>request</a> <var>request</var>, run these steps:
+<p>To <dfn export>serialize a request URL for reporting</dfn>, given a <a for=/>request</a>
+<var>request</var>, run these steps:
 
 <ol>
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1765,7 +1765,7 @@ source of security bugs. Please seek security review for features that deal with
 
  <li><p><a>Set the password</a> given <var>url</var> and the empty string.
 
- <li><p>Return <var>url</var> <a lt="url serializer">serialized</a>with the
+ <li><p>Return the <a lt="url serializer">serialization</a> of <var>url</var> with the
  <i>exclude fragment flag</i> set.
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1748,6 +1748,26 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 source of security bugs. Please seek security review for features that deal with partial responses.
 
 
+<p>To <dfn export for=request id=concept-request-serialize-url-for-reporting>serialize a request URL
+for reporting</dfn>, given a <a for=/>request</a> <var>request</var>, run these steps:
+
+<ol>
+ <li>
+  <p>Let <var>url</var> be a copy of <var>request</var>'s <a for=request>URL</a>.
+
+  <p class="note">This is not <var>request</var>'s <a for=request>current URL</a> in order to avoid
+  leaking information about redirect targets (see
+  <a href="https://w3c.github.io/webappsec-csp/#security-violation-reports">similar considerations
+  for CSP reporting</a> too).
+
+ <li><p><a>Set the username</a> given <var>url</var> and the empty string.
+
+ <li><p><a>Set the password</a> given <var>url</var> and the empty string.
+
+ <li><p>Return <var>url</var> <a lt="url serializer">serialized</a>with the
+ <i>exclude fragment flag</i> set.
+</ol>
+
 <h4 id=responses>Responses</h4>
 
 <p>The result of <a for=/>fetch</a> is a

--- a/fetch.bs
+++ b/fetch.bs
@@ -1747,9 +1747,10 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 <p class=note>Features that combine multiple responses into one logical resource are historically a
 source of security bugs. Please seek security review for features that deal with partial responses.
 
+<hr>
 
-<p>To <dfn export for=request id=concept-request-serialize-url-for-reporting>serialize a request URL
-for reporting</dfn>, given a <a for=/>request</a> <var>request</var>, run these steps:
+<p>To <dfn export for=request>serialize a request URL for reporting</dfn>, given a
+<a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
  <li>
@@ -1757,8 +1758,8 @@ for reporting</dfn>, given a <a for=/>request</a> <var>request</var>, run these 
 
   <p class="note">This is not <var>request</var>'s <a for=request>current URL</a> in order to avoid
   leaking information about redirect targets (see
-  <a href="https://w3c.github.io/webappsec-csp/#security-violation-reports">similar considerations
-  for CSP reporting</a> too).
+  <a href="https://w3c.github.io/webappsec-csp/#security-violation-reports">similar considerations for CSP reporting</a>
+  too). [[CSP]]
 
  <li><p><a>Set the username</a> given <var>url</var> and the empty string.
 
@@ -1767,6 +1768,7 @@ for reporting</dfn>, given a <a for=/>request</a> <var>request</var>, run these 
  <li><p>Return <var>url</var> <a lt="url serializer">serialized</a>with the
  <i>exclude fragment flag</i> set.
 </ol>
+
 
 <h4 id=responses>Responses</h4>
 


### PR DESCRIPTION
This is a preliminary change for COEP merging to the HTML and fetch specs.
We will use the serialization multiple times both in the HTML spec and
the fetch spec, so defining the operation here will be benefitial.

There's no behavior change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 2, 2020, 8:25 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Ffetch%2F1298cde97a5e66dbd2de5602afa909870c618581%2Ffetch.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201028)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/fetch%231028.)._
</details>
