### PR TITLE
Editorial: align with new IDL patterns

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5901,8 +5901,8 @@ the associated steps:
 <var>object</var> and <var>type</var>, runs these steps:
 
 <ol>
- <li><p>If <var>object</var> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then return a
- <a>rejected promise</a> with a {{TypeError}}.
+ <li><p>If <var>object</var> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then return
+ <a>a promise rejected with</a> a {{TypeError}}.
 
  <li><p>Let <var>stream</var> be <var>object</var>'s <a for=Body>body</a>'s <a for=body>stream</a>
  if <var>object</var>'s <a for=Body>body</a> is non-null; otherwise an <a>empty</a>
@@ -5910,7 +5910,7 @@ the associated steps:
 
  <li><p>Let <var>reader</var> be the result of
  <a lt="get a reader" for=ReadableStream>getting a reader</a> from <var>stream</var>. If that threw
- an exception, return a <a>rejected promise</a> with that exception.
+ an exception, return <a>a promise rejected with</a> that exception.
 
  <li><p>Let <var>promise</var> be the result of
  <a lt="read all bytes" for=ReadableStream>reading all bytes</a> from <var>stream</var> with
@@ -6565,7 +6565,8 @@ set; otherwise false.
 
  <li><p>Let <var>clonedRequestObject</var> be a new {{Request}} object.
 
- <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a> <a>this</a>'s <a for=Request>request</a>.
+ <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a>
+ <a>this</a>'s <a for=Request>request</a>.
 
  <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>request</a> to <var>clonedRequest</var>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -94,12 +94,6 @@ url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;
 }
 </pre>
 
-<!-- TODO: remove ReadableStream once the linking databases have settled down -->
-<pre class=link-defaults>
-spec:infra; type:dfn; text:string
-spec:streams; type:interface; text:ReadableStream
-</pre>
-
 
 
 <h2 id=goals class="no-num short">Goals</h2>
@@ -5530,9 +5524,8 @@ objects.</span>
  <a for=Headers>remove privileged no-CORS request headers</a> from <var>headers</var>.
 </ol>
 
-<p>To <dfn export for=Headers id=concept-headers-fill>fill</dfn> a
-{{Headers}} object (<var>headers</var>) with a given object (<var>object</var>),
-run these steps:
+<p>To <dfn export for=Headers id=concept-headers-fill>fill</dfn> a {{Headers}} object
+<var>headers</var> with a given object <var>object</var>, run these steps:
 
 <ol>
  <li>
@@ -5569,76 +5562,66 @@ from a {{Headers}} object (<var>headers</var>), run these steps:
 <p class=note>This is called when headers are modified by unprivileged code.
 
 <p>The
-<dfn id=dom-headers export for=Headers constructor><code>Headers(<var>init</var>)</code></dfn>
-constructor, when invoked, must run these steps:
+<dfn id=dom-headers export for=Headers constructor lt="Headers(init)"><code>new Headers(<var>init</var>)</code></dfn>
+constructor steps are:
 
 <ol>
- <li><p>Let <var>headers</var> be a new {{Headers}} object whose
- <a for=Headers>guard</a> is "<code>none</code>".
+ <li><p>Set <a>this</a>'s <a for=Headers>guard</a> to "<code>none</code>".
 
- <li><p>If <var>init</var> is given, then <a for=Headers>fill</a> <var>headers</var> with
- <var>init</var>.
-
- <li><p>Return <var>headers</var>.
+ <li><p>If <var>init</var> is given, then <a for=Headers>fill</a> <a>this</a> with <var>init</var>.
 </ol>
 
 <p>The <dfn export for=Headers method><code>append(<var>name</var>, <var>value</var>)</code></dfn>
-method, when invoked, must <a for=Headers>append</a> <var>name</var>/<var>value</var> to the
-<a>context object</a>.
+method steps are to <a for=Headers>append</a> <var>name</var>/<var>value</var> to <a>this</a>.
 
-<p>The <dfn export for=Headers method><code>delete(<var>name</var>)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn export for=Headers method><code>delete(<var>name</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>name</var> is not a <a for=header>name</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>guard</a> is "<code>immutable</code>", then
- <a>throw</a> a {{TypeError}}.
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is "<code>immutable</code>", then <a>throw</a> a
+ {{TypeError}}.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is "<code>request</code>"
- and <var>name</var> is a <a>forbidden header name</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>request</code>" and
+ <var>name</var> is a <a>forbidden header name</a>, return.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is
- "<code>request-no-cors</code>", <var>name</var> is not a
- <a>no-CORS-safelisted request-header name</a>, and <var>name</var> is not a
- <a>privileged no-CORS request-header name</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>",
+ <var>name</var> is not a <a>no-CORS-safelisted request-header name</a>, and <var>name</var> is not
+ a <a>privileged no-CORS request-header name</a>, return.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is
- "<code>response</code>" and <var>name</var> is a <a>forbidden response-header name</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>response</code>" and
+ <var>name</var> is a <a>forbidden response-header name</a>, return.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>header list</a> does not
- <a for="header list">contain</a> <var>name</var>, then return.
+ <li><p>If <a>this</a>'s <a for=Headers>header list</a> does not <a for="header list">contain</a>
+ <var>name</var>, then return.
 
- <li><p><a for="header list">Delete</a> <var>name</var> from the <a>context object</a>'s
+ <li><p><a for="header list">Delete</a> <var>name</var> from <a>this</a>'s
  <a for=Headers>header list</a>.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>",
- then <a for=Headers>remove privileged no-CORS request headers</a> from the <a>context object</a>.
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>", then
+ <a for=Headers>remove privileged no-CORS request headers</a> from <a>this</a>.
 </ol>
 
-<p>The <dfn export for=Headers method><code>get(<var>name</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn export for=Headers method><code>get(<var>name</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>name</var> is not a <a for=header>name</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>Return the result of <a for="header list">getting</a> <var>name</var> from the
- <a>context object</a>'s <a for=Headers>header list</a>.
+ <li><p>Return the result of <a for="header list">getting</a> <var>name</var> from <a>this</a>'s
+ <a for=Headers>header list</a>.
 </ol>
 
-<p>The <dfn export for=Headers method><code>has(<var>name</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn export for=Headers method><code>has(<var>name</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>name</var> is not a <a for=header>name</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>Return true if the <a>context object</a>'s <a for=Headers>header list</a>
- <a for="header list">contains</a> <var>name</var>, and false otherwise.
+ <li><p>Return true if <a>this</a>'s <a for=Headers>header list</a>
+ <a for="header list">contains</a> <var>name</var>; otherwise false.
 </ol>
 
-<p>The
-<dfn export for=Headers method><code>set(<var>name</var>, <var>value</var>)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn export for=Headers method><code>set(<var>name</var>, <var>value</var>)</code></dfn>
+method steps are:
 
 <ol>
  <li><p><a lt=normalize for=header/value>Normalize</a> <var>value</var>.
@@ -5646,29 +5629,27 @@ method, when invoked, must run these steps:
  <li><p>If <var>name</var> is not a <a for=header>name</a> or <var>value</var> is not a
  <a for=header>value</a>, then <a>throw</a> a {{TypeError}}.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>guard</a> is "<code>immutable</code>", then
- <a>throw</a> a {{TypeError}}.
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is "<code>immutable</code>", then <a>throw</a> a
+ {{TypeError}}.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is "<code>request</code>"
- and <var>name</var> is a <a>forbidden header name</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>request</code>" and
+ <var>name</var> is a <a>forbidden header name</a>, return.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is
- "<code>request-no-cors</code>" and <var>name</var>/<var>value</var> is not a
- <a>no-CORS-safelisted request-header</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>" and
+ <var>name</var>/<var>value</var> is not a <a>no-CORS-safelisted request-header</a>, return.
 
- <li><p>Otherwise, if the <a>context object</a>'s <a for=Headers>guard</a> is
- "<code>response</code>" and <var>name</var> is a <a>forbidden response-header name</a>, return.
+ <li><p>Otherwise, if <a>this</a>'s <a for=Headers>guard</a> is "<code>response</code>" and
+ <var>name</var> is a <a>forbidden response-header name</a>, return.
 
- <li><p><a for="header list">Set</a> <var>name</var>/<var>value</var> in the <a>context object</a>'s
+ <li><p><a for="header list">Set</a> <var>name</var>/<var>value</var> in <a>this</a>'s
  <a for=Headers>header list</a>.
 
- <li><p>If the <a>context object</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>",
- then <a for=Headers>remove privileged no-CORS request headers</a> from the <a>context object</a>.
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is "<code>request-no-cors</code>", then
+ <a for=Headers>remove privileged no-CORS request headers</a> from <a>this</a>.
 </ol>
 
 <p>The <a>value pairs to iterate over</a> are the return value of running
-<a for="header list">sort and combine</a> with the <a>context object</a>'s
-<a for=Headers>header list</a>.
+<a for="header list">sort and combine</a> with <a>this</a>'s <a for=Headers>header list</a>.
 
 
 <h3 id=body-mixin>Body mixin</h3>
@@ -5822,20 +5803,20 @@ due course.
 a <dfn id=concept-body-mime-type for=Body>MIME type</dfn> (failure or a <a for=/>MIME type</a>).
 
 <p>An object implementing the {{Body}} mixin is said to be
-<dfn export id=concept-body-disturbed for=Body>disturbed</dfn> if <a for=Body>body</a> is
-non-null and its <a for=body>stream</a> is
-<a for=ReadableStream>disturbed</a>.
+<dfn export id=concept-body-disturbed for=Body>disturbed</dfn> if its <a for=Body>body</a> is
+non-null and its <a for=body>stream</a> is <a for=ReadableStream>disturbed</a>.
 
 <p>An object implementing the {{Body}} mixin is said to be
 <dfn export id=concept-body-locked for=Body>locked</dfn> if <a for=Body>body</a> is
 non-null and its <a for=body>stream</a> is
 <a for=ReadableStream>locked</a>.
 
-<p>The <dfn attribute for=Body><code>body</code></dfn> attribute's getter must return null if
-<a for=Body>body</a> is null and <a for=Body>body</a>'s <a for=body>stream</a> otherwise.
+<p>The <dfn attribute for=Body><code>body</code></dfn> getter steps are to return null if
+<a>this</a>'s <a for=Body>body</a> is null; otherwise <a>this</a>'s <a for=Body>body</a>'s
+<a for=body>stream</a>.
 
-<p>The <dfn attribute for=Body><code>bodyUsed</code></dfn> attribute's getter must
-return true if <a for=Body>disturbed</a>, and false otherwise.
+<p>The <dfn attribute for=Body><code>bodyUsed</code></dfn> getter steps are to return true if
+<a>this</a> is <a for=Body>disturbed</a>; otherwise false.
 
 <p>Objects implementing the {{Body}} mixin also have an associated
 <dfn id=concept-body-package-data for=Body>package data</dfn> algorithm, given
@@ -5946,25 +5927,20 @@ runs these steps:
           https://www.w3.org/2001/tag/doc/promises-guide -->
 </ol>
 
-<p>The <dfn method for=Body><code>arrayBuffer()</code></dfn>
-method, when invoked, must return the result of running
-<a for=Body>consume body</a> with <i>ArrayBuffer</i>.
+<p>The <dfn method for=Body><code>arrayBuffer()</code></dfn> method steps are to return the result
+of running <a for=Body>consume body</a> with <i>ArrayBuffer</i>.
 
-<p>The <dfn method for=Body><code>blob()</code></dfn> method, when
-invoked, must return the result of running
-<a for=Body>consume body</a> with <i>Blob</i>.
+<p>The <dfn method for=Body><code>blob()</code></dfn> method steps are to return the result of
+running <a for=Body>consume body</a> with <i>Blob</i>.
 
-<p>The <dfn method for=Body><code>formData()</code></dfn> method,
-when invoked, must return the result of running
-<a for=Body>consume body</a> with <i>FormData</i>.
+<p>The <dfn method for=Body><code>formData()</code></dfn> method steps are to return the result of
+running <a for=Body>consume body</a> with <i>FormData</i>.
 
-<p>The <dfn method for=Body><code>json()</code></dfn> method, when
-invoked, must return the result of running
-<a for=Body>consume body</a> with <i>JSON</i>.
+<p>The <dfn method for=Body><code>json()</code></dfn> method steps are to return the result of
+running <a for=Body>consume body</a> with <i>JSON</i>.
 
-<p>The <dfn method for=Body><code>text()</code></dfn> method, when
-invoked, must return the result of running
-<a for=Body>consume body</a> with <i>text</i>.
+<p>The <dfn method for=Body><code>text()</code></dfn> method steps are to return the result of
+running <a for=Body>consume body</a> with <i>text</i>.
 
 
 <h3 id=request-class>Request class</h3>
@@ -6169,8 +6145,8 @@ initially a new {{AbortSignal}} object.
 <hr>
 
 <p>The
-<dfn constructor for=Request id=dom-request><code>Request(<var>input</var>, <var>init</var>)</code></dfn>
-constructor must run these steps:
+<dfn constructor for=Request id=dom-request lt="Request(input, init)"><code>new Request(<var>input</var>, <var>init</var>)</code></dfn>
+constructor steps are:
 
 <ol>
  <li><p>Let <var>request</var> be null.
@@ -6179,7 +6155,7 @@ constructor must run these steps:
 
  <li><p>Let <var>fallbackCredentials</var> be null.
 
- <li><p>Let <var>baseURL</var> be <a>current settings object</a>'s
+ <li><p>Let <var>baseURL</var> be <a>this</a>'s <a>relevant settings object</a>'s
  <a for="environment settings object">API base URL</a>.
 
  <li><p>Let <var>signal</var> be null.
@@ -6206,16 +6182,18 @@ constructor must run these steps:
   </ol>
 
  <li>
-  <p>Otherwise (<var>input</var> is a {{Request}} object):
+  <p>Otherwise:
 
   <ol>
+   <li><p>Assert: <var>input</var> is a {{Request}} object.
+
    <li><p>Set <var>request</var> to <var>input</var>'s
    <a for=Request>request</a>.
 
    <li><p>Set <var>signal</var> to <var>input</var>'s <a for=Request>signal</a>.
   </ol>
 
- <li><p>Let <var>origin</var> be <a>current settings object</a>'s
+ <li><p>Let <var>origin</var> be <a>this</a>'s <a>relevant settings object</a>'s
  <a for="environment settings object">origin</a>.
 
  <li><p>Let <var>window</var> be "<code>client</code>".
@@ -6223,7 +6201,7 @@ constructor must run these steps:
  <li><p>If <var>request</var>'s <a for=request>window</a> is
  an <a>environment settings object</a> and its
  <a for="environment settings object">origin</a> is <a>same origin</a> with
- <var>origin</var>, set <var>window</var> to <var>request</var>'s
+ <var>origin</var>, then set <var>window</var> to <var>request</var>'s
  <a for=request>window</a>.
 
  <li><p>If <var>init</var>["{{RequestInit/window}}"] <a for=map>exists</a> and is non-null, then
@@ -6408,12 +6386,12 @@ constructor must run these steps:
  <li><p>If <var>init</var>["{{RequestInit/signal}}"] <a for=map>exists</a>, then set
  <var>signal</var> to it.
 
- <li><p>Let <var>r</var> be a new {{Request}} object associated with <var>request</var>.
+ <li><p>Set <a>this</a>'s <a for=Request>request</a> to <var>request</var>.
 
- <li><p>If <var>signal</var> is not null, then make <var>r</var>'s <a for=Request>signal</a>
+ <li><p>If <var>signal</var> is not null, then make <a>this</a>'s <a for=Request>signal</a>
  <a for=AbortSignal>follow</a> <var>signal</var>.
 
- <li><p>Set <var>r</var>'s <a for=Request>headers</a> to a new {{Headers}} object, whose
+ <li><p>Set <a>this</a>'s <a for=Request>headers</a> to a new {{Headers}} object, whose
  <a for=Headers>header list</a> is <var>request</var>'s <a for=request>header list</a>, and
  <a for=Headers>guard</a> is "<code>request</code>".
 
@@ -6425,23 +6403,23 @@ constructor must run these steps:
   API.
 
   <ol>
-   <li><p>Let <var>headers</var> be a copy of <var>r</var>'s <a for=Request>headers</a> and its
+   <li><p>Let <var>headers</var> be a copy of <a>this</a>'s <a for=Request>headers</a> and its
    associated <a for=Headers>header list</a>.
 
    <li><p>If <var>init</var>["{{RequestInit/headers}}"] <a for=map>exists</a>, then set
    <var>headers</var> to <var>init</var>["{{RequestInit/headers}}"].
 
-   <li><p>Empty <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
+   <li><p>Empty <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
 
    <li>
-    <p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>mode</a> is
+    <p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is
     "<code>no-cors</code>", then:
 
     <ol>
-     <li><p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
+     <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
      <a>CORS-safelisted method</a>, then <a>throw</a> a {{TypeError}}.
 
-     <li><p>Set <var>r</var>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
+     <li><p>Set <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
      "<code>request-no-cors</code>".
     </ol>
    </li>
@@ -6449,9 +6427,9 @@ constructor must run these steps:
    <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
    <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>
    <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to
-   <var>r</var>'s {{Headers}} object.
+   <a>this</a>'s <a for=Request>headers</a>.
 
-   <li><p>Otherwise, <a for=Headers>fill</a> <var>r</var>'s {{Headers}} object with
+   <li><p>Otherwise, <a for=Headers>fill</a> <a>this</a>'s <a for=Request>headers</a> with
    <var>headers</var>.
   </ol>
  </li>
@@ -6479,20 +6457,20 @@ constructor must run these steps:
    <li><p>Otherwise, set <var>body</var> and <var>Content-Type</var> to the result of
    <a for=BodyInit>extracting</a> <var>init</var>["{{RequestInit/body}}"].
 
-   <li><p>If <var>Content-Type</var> is non-null and <var>r</var>'s <a for=Request>headers</a>'s
+   <li><p>If <var>Content-Type</var> is non-null and <a>this</a>'s <a for=Request>headers</a>'s
    <a for=Headers>header list</a> <a for="header list">does not contain</a>
    `<code>Content-Type</code>`, then <a for=Headers>append</a>
-   `<code>Content-Type</code>`/<var>Content-Type</var> to <var>r</var>'s <a for=Request>headers</a>.
+   `<code>Content-Type</code>`/<var>Content-Type</var> to <a>this</a>'s <a for=Request>headers</a>.
   </ol>
 
  <li>
   <p>If <var>body</var> is non-null and <var>body</var>'s <a for=body>source</a> is null, then:
 
   <ol>
-   <li><p>If <var>r</var>'s <a for=Request>request</a>'s <a for=request>mode</a> is neither
+   <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is neither
    "<code>same-origin</code>" nor "<code>cors</code>", then throw a {{TypeError}}.
 
-   <li><p>Set <var>r</var>'s <a for=Request>request</a>'s
+   <li><p>Set <a>this</a>'s <a for=Request>request</a>'s
    <a for=request>use-CORS-preflight flag</a>.
   </ol>
 
@@ -6524,84 +6502,75 @@ constructor must run these steps:
    whose <a for=body>total bytes</a> is <var>inputBody</var>'s <a for=body>total bytes</a>.
   </ol>
 
- <li><p>Set <var>r</var>'s <a for=Request>request</a>'s <a for=request>body</a> to <var>body</var>.
+ <li><p>Set <a>this</a>'s <a for=Request>request</a>'s <a for=request>body</a> to <var>body</var>.
 
- <li><p>Set <var>r</var>'s <a for=Body>MIME type</a> to the result of
- <a for="header list">extracting a MIME type</a> from <var>r</var>'s <a for=Request>request</a>'s
+ <li><p>Set <a>this</a>'s <a for=Body>MIME type</a> to the result of
+ <a for="header list">extracting a MIME type</a> from <a>this</a>'s <a for=Request>request</a>'s
  <a for=request>header list</a>.
-
- <li><p>Return <var>r</var>.
 </ol>
 
-<p>The <dfn attribute for=Request><code>method</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>method</a>.
+<p>The <dfn attribute for=Request><code>method</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>method</a>.
 
-<p>The <dfn attribute for=Request><code>url</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>URL</a>,
+<p>The <dfn attribute for=Request><code>url</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>URL</a>, <a lt="url serializer">serialized</a>.
+
+<p>The <dfn attribute for=Request><code>headers</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Request>headers</a>.
+
+<p>The <dfn attribute for=Request><code>destination</code></dfn> getter are to return <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>destination</a>.
+
+<p>The <dfn attribute for=Request><code>referrer</code></dfn> getter steps are to return
+the empty string if <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a> is
+"<code>no-referrer</code>", "<code>about:client</code>" if <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>referrer</a> is "<code>client</code>"; otherwise
+<a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a>,
 <a lt="url serializer">serialized</a>.
 
-<p>The <dfn attribute for=Request><code>headers</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>headers</a>.
+<p>The <dfn attribute for=Request><code>referrerPolicy</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer policy</a>.
 
-<p>The <dfn attribute for=Request><code>destination</code></dfn> attribute's getter, when invoked,
-must return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>destination</a>.
+<p>The <dfn attribute for=Request><code>mode</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>mode</a>.
 
-<p>The <dfn attribute for=Request><code>referrer</code></dfn> attribute's getter, when invoked, must
-return the empty string if the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>referrer</a> is "<code>no-referrer</code>", "<code>about:client</code>" if the
-<a>context object</a>'s <a for=Request>request</a>'s <a for=request>referrer</a> is
-"<code>client</code>", and the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>referrer</a>, <a lt="url serializer">serialized</a>, otherwise.
+<p>The <dfn attribute for=Request><code>credentials</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Request>request</a>'s <a for=request>credentials mode</a>.
 
-<p>The <dfn attribute for=Request><code>referrerPolicy</code></dfn> attribute's getter, when
-invoked, must return the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>referrer policy</a>.
+<p>The <dfn attribute for=Request><code>cache</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Request>request</a>'s <a for=request>cache mode</a>.
 
-<p>The <dfn attribute for=Request><code>mode</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>mode</a>.
+<p>The <dfn attribute for=Request><code>redirect</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Request>request</a>'s <a for=request>redirect mode</a>.
 
-<p>The <dfn attribute for=Request><code>credentials</code></dfn> attribute's getter, when invoked,
-must return the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>credentials mode</a>.
+<p>The <dfn attribute for=Request><code>integrity</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Request>request</a>'s <a for=request>integrity metadata</a>.
 
-<p>The <dfn attribute for=Request><code>cache</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>cache mode</a>.
+<p>The <dfn attribute for=Request><code>keepalive</code></dfn> getter steps are to return true if
+<a>this</a>'s <a for=Request>request</a>'s <a>keepalive flag</a> is set; otherwise false.
 
-<p>The <dfn attribute for=Request><code>redirect</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Request>request</a>'s <a for=request>redirect mode</a>.
+<p>The <dfn attribute for=Request><code>isReloadNavigation</code></dfn> getter steps are to return
+true if <a>this</a>'s <a for=Request>request</a>'s <a for=request>reload-navigation flag</a> is set;
+otherwise false.
 
-<p>The <dfn attribute for=Request><code>integrity</code></dfn> attribute's getter, when invoked,
-must return the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>integrity metadata</a>.
+<p>The <dfn attribute for=Request><code>isHistoryNavigation</code></dfn> getter steps are to return
+true if <a>this</a>'s <a for=Request>request</a>'s <a for=request>history-navigation flag</a> is
+set; otherwise false.
 
-<p>The <dfn attribute for=Request><code>keepalive</code></dfn> attribute's getter, when invoked,
-must return true if the <a>context object</a>'s <a for=Request>request</a>'s <a>keepalive flag</a>
-is set, and false otherwise.
-
-<p>The <dfn attribute for=Request><code>isReloadNavigation</code></dfn> attribute's getter, when
-invoked, must return true if the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>reload-navigation flag</a> is set, and false otherwise.
-
-<p>The <dfn attribute for=Request><code>isHistoryNavigation</code></dfn> attribute's getter, when
-invoked, must return true if the <a>context object</a>'s <a for=Request>request</a>'s
-<a for=request>history-navigation flag</a> is set, and false otherwise.
-
-<p>The <dfn attribute for=Request><code>signal</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for="Request">signal</a>.
+<p>The <dfn attribute for=Request><code>signal</code></dfn> getter steps are to return <a>this</a>'s
+<a for="Request">signal</a>.
 
 <hr>
 
-<p>The <dfn method for=Request><code>clone()</code></dfn> method, when invoked, must
-run these steps:
+<p>The <dfn method for=Request><code>clone()</code></dfn> method steps are:
 
 <ol>
- <li><p>If the <a>context object</a> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then
- <a>throw</a> a {{TypeError}}.
+ <li><p>If <a>this</a> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then <a>throw</a> a
+ {{TypeError}}.
 
  <li><p>Let <var>clonedRequestObject</var> be a new {{Request}} object.
 
- <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a> the
- <a>context object</a>'s <a for=Request>request</a>.
+ <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a> <a>this</a>'s <a for=Request>request</a>.
 
  <li><p>Set <var>clonedRequestObject</var>'s <a for=Request>request</a> to <var>clonedRequest</var>.
 
@@ -6614,12 +6583,12 @@ run these steps:
    <dd><var>clonedRequest</var>'s <a for=Headers>header list</a>.
 
    <dt><a for=Headers>guard</a>
-   <dd>The <a>context object</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a>.
+   <dd><a>This</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a>.
   </dl>
  </li>
 
  <li><p>Make <var>clonedRequestObject</var>'s <a for=Request>signal</a>
- <a for=AbortSignal>follow</a> the <a>context object</a>'s <a for=Request>signal</a>.
+ <a for=AbortSignal>follow</a> <a>this</a>'s <a for=Request>signal</a>.
 
  <li><p>Return <var>clonedRequestObject</var>.
 </ol>
@@ -6667,8 +6636,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 <a for=Response>response</a>'s <a for=response>body</a>.
 
 <p>The
-<dfn constructor for=Response id=dom-response><code>Response(<var>body</var>, <var>init</var>)</code></dfn>
-constructor, when invoked, must run these steps:
+<dfn constructor for=Response id=dom-response lt="Response(body, init)"><code>new Response(<var>body</var>, <var>init</var>)</code></dfn>
+constructor steps are:
 
 <ol>
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range <code>200</code> to
@@ -6677,20 +6646,20 @@ constructor, when invoked, must run these steps:
  <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
  <a spec=http>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
 
- <li><p>Let <var>r</var> be a new {{Response}} object associated with a new <a for=/>response</a>.
+ <li><p>Set <a>this</a>'s <a for=Response>response</a> to a new <a for=/>response</a>.
 
- <li><p>Set <var>r</var>'s <a for=Response>headers</a> to a new {{Headers}} object, whose
+ <li><p>Set <a>this</a>'s <a for=Response>headers</a> to a new {{Headers}} object, whose
  <a for=Headers>header list</a> is <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>header list</a>, and <a for=Headers>guard</a> is "<code>response</code>".
 
- <li><p>Set <var>r</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
+ <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a> to
  <var>init</var>["{{ResponseInit/status}}"].
 
- <li><p>Set <var>r</var>'s <a for=Response>response</a>'s <a for=response>status message</a> to
+ <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>status message</a> to
  <var>init</var>["{{ResponseInit/statusText}}"].
 
  <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
- <a for=Headers>fill</a> <var>r</var>'s <a for=Response>headers</a> with
+ <a for=Headers>fill</a> <a>this</a>'s <a for=Response>headers</a> with
  <var>init</var>["{{ResponseInit/headers}}"].
 
  <li>
@@ -6706,30 +6675,26 @@ constructor, when invoked, must run these steps:
 
    <li><p>Let <var>Content-Type</var> be null.
 
-   <li><p>Set <var>r</var>'s <a for=Response>response</a>'s <a for=response>body</a> and
+   <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>body</a> and
    <var>Content-Type</var> to the result of <a for=BodyInit>extracting</a> <var>body</var>.
 
-   <li><p>If <var>Content-Type</var> is non-null and <var>r</var>'s <a for=Response>response</a>'s
+   <li><p>If <var>Content-Type</var> is non-null and <a>this</a>'s <a for=Response>response</a>'s
    <a for=response>header list</a> <a for="header list">does not contain</a>
    `<code>Content-Type</code>`, then <a for="header list">append</a>
-   `<code>Content-Type</code>`/<var>Content-Type</var> to <var>r</var>'s
+   `<code>Content-Type</code>`/<var>Content-Type</var> to <a>this</a>'s
    <a for=Response>response</a>'s <a for=response>header list</a>.
   </ol>
 
- <li><p>Set <var>r</var>'s <a for=Body>MIME type</a> to the result of
- <a for="header list">extracting a MIME type</a> from <var>r</var>'s <a for=Response>response</a>'s
+ <li><p>Set <a>this</a>'s <a for=Body>MIME type</a> to the result of
+ <a for="header list">extracting a MIME type</a> from <a>this</a>'s <a for=Response>response</a>'s
  <a for=response>header list</a>.
 
- <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
- <a for=response>HTTPS state</a> to
- <a>current settings object</a>'s
+ <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>HTTPS state</a> to
+ <a>this</a>'s <a>relevant settings object</a>'s
  <a for="environment settings object">HTTPS state</a>.
-
- <li><p>Return <var>r</var>.
 </ol>
 
-<p>The static <dfn method for=Response><code>error()</code></dfn> method, when invoked, must run
-these steps:
+<p>The static <dfn method for=Response><code>error()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>r</var> be a new {{Response}} object, whose <a for=Response>response</a> is a new
@@ -6742,8 +6707,8 @@ these steps:
 </ol>
 
 <p>The static
-<dfn method for=Response><code>redirect(<var>url</var>, <var>status</var>)</code></dfn>
-method, when invoked, must run these steps:
+<dfn method for=Response><code>redirect(<var>url</var>, <var>status</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>Let <var>parsedURL</var> be the result of
@@ -6772,57 +6737,54 @@ method, when invoked, must run these steps:
  <li><p>Return <var>r</var>.
 </ol>
 
-<p>The <dfn attribute for=Response><code>type</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Response>response</a>'s <a for=response>type</a>.
+<p>The <dfn attribute for=Response><code>type</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Response>response</a>'s <a for=response>type</a>.
 
-<p>The <dfn attribute for=Response><code>url</code></dfn> attribute's getter, when invoked, must
-return the empty string if the <a>context object</a>'s <a for=Response>response</a>'s
-<a for=response>URL</a> is null and the <a>context object</a>'s <a for=Response>response</a>'s
-<a for=response>URL</a>, <a lt="url serializer">serialized</a> with the <i>exclude-fragment flag</i>
-set, otherwise. [[!URL]]
+<p>The <dfn attribute for=Response><code>url</code></dfn> getter steps are to return
+the empty string if <a>this</a>'s <a for=Response>response</a>'s <a for=response>URL</a> is null;
+otherwise <a>this</a>'s <a for=Response>response</a>'s <a for=response>URL</a>,
+<a lt="url serializer">serialized</a> with the <i>exclude-fragment flag</i> set. [[!URL]]
 
-<p>The <dfn attribute for=Response><code>redirected</code></dfn> attribute's getter, when invoked,
-must return true if the <a>context object</a>'s <a for=Response>response</a>'s
-<a for=response>URL list</a> has more than one item, and false otherwise.
+<p>The <dfn attribute for=Response><code>redirected</code></dfn> getter steps are to return true if
+<a>this</a>'s <a for=Response>response</a>'s <a for=response>URL list</a> has more than one item;
+otherwise false.
 
 <p class=note>To filter out <a for=/>responses</a> that are the result of a
 redirect, do this directly through the API, e.g., <code>fetch(url, { redirect:"error" })</code>.
 This way a potentially unsafe <a for=/>response</a> cannot accidentally leak.
 
-<p>The <dfn attribute for=Response><code>status</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Response>response</a>'s <a for=response>status</a>.
+<p>The <dfn attribute for=Response><code>status</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a>.
 
-<p>The <dfn attribute for=Response><code>ok</code></dfn> attribute's getter, when invoked, must
-return true if the <a>context object</a>'s <a for=Response>response</a>'s <a for=response>status</a>
-is an <a>ok status</a>, and false otherwise.
+<p>The <dfn attribute for=Response><code>ok</code></dfn> getter steps are to return true if
+<a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a> is an <a>ok status</a>;
+otherwise false.
 
-<p>The <dfn attribute for=Response><code>statusText</code></dfn> attribute's getter, when invoked,
-must return the <a>context object</a>'s <a for=Response>response</a>'s
-<a for=response>status message</a>.
+<p>The <dfn attribute for=Response><code>statusText</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Response>response</a>'s <a for=response>status message</a>.
 
-<p>The <dfn attribute for=Response><code>headers</code></dfn> attribute's getter, when invoked, must
-return the <a>context object</a>'s <a for=Response>headers</a>.
+<p>The <dfn attribute for=Response><code>headers</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Response>headers</a>.
 
 <hr>
 
-<p>The <dfn method for=Response><code>clone()</code></dfn> method, when invoked, must
-run these steps:
+<p>The <dfn method for=Response><code>clone()</code></dfn> method steps are:
 
 <ol>
- <li><p>If the <a>context object</a> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then
- <a>throw</a> a {{TypeError}}.
+ <li><p>If <a>this</a> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then <a>throw</a> a
+ {{TypeError}}.
 
  <li><p>Let <var>clonedResponseObject</var> be a new {{Response}} object.
 
- <li><p>Let <var>clonedResponse</var> be the result of <a lt=clone for=response>cloning</a> the
- <a>context object</a>'s <a for=Response>response</a>.
+ <li><p>Let <var>clonedResponse</var> be the result of <a lt=clone for=response>cloning</a>
+ <a>this</a>'s <a for=Response>response</a>.
 
  <li><p>Set <var>clonedResponseObject</var>'s <a for=Response>response</a> to
  <var>clonedResponse</var>.
 
  <li><p>Set <var>clonedResponseObject</var>'s <a for=Request>headers</a> to a new {{Headers}} object
  whose <a for=Headers>header list</a> is set to <var>clonedResponse</var>'s
- <a for=Headers>header list</a>, and <a for=Headers>guard</a> is the <a>context object</a>'s
+ <a for=Headers>header list</a>, and <a for=Headers>guard</a> is <a>this</a>'s
  <a for=Response>headers</a>'s <a for=Headers>guard</a>.
 
  <li><p>Return <var>clonedResponseObject</var>.
@@ -6841,7 +6803,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 
 <p>The
 <dfn id=dom-global-fetch method for=WindowOrWorkerGlobalScope><code>fetch(<var>input</var>, <var>init</var>)</code></dfn>
-method, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>p</var> be a new promise.

--- a/fetch.bs
+++ b/fetch.bs
@@ -982,14 +982,11 @@ user-agent-defined <a for=header>value</a> for the
 
 <p>A <dfn export id=concept-status>status</dfn> is a code.
 
-<p>A <dfn export>null body status</dfn> is a <a for=/>status</a> that is <code>101</code>,
-<code>204</code>, <code>205</code>, or <code>304</code>.
+<p>A <dfn export>null body status</dfn> is a <a for=/>status</a> that is 101, 204, 205, or 304.
 
-<p>An <dfn export>ok status</dfn> is any <a for=/>status</a> in the range <code>200</code> to
-<code>299</code>, inclusive.
+<p>An <dfn export>ok status</dfn> is any <a for=/>status</a> in the range 200 to 299, inclusive.
 
-<p>A <dfn export>redirect status</dfn> is a <a for=/>status</a> that is <code>301</code>,
-<code>302</code>, <code>303</code>, <code>307</code>, or <code>308</code>.
+<p>A <dfn export>redirect status</dfn> is a <a for=/>status</a> that is 301, 302, 303, 307, or 308.
 
 
 <h4 id=bodies>Bodies</h4>
@@ -1822,8 +1819,8 @@ more <a>response URLs</a>). Unless stated otherwise, it is the empty list.
 <a>atomic HTTP redirect handling</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response id=concept-response-status>status</dfn>, which is a
-<a for=/>status</a>. Unless stated otherwise it is <code>200</code>.
+<dfn export for=response id=concept-response-status>status</dfn>, which is a <a for=/>status</a>.
+Unless stated otherwise it is 200.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-status-message>status message</dfn>. Unless stated
@@ -1906,9 +1903,8 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <a for=response>type</a> is "<code>error</code>" is known as a
 <dfn export id=concept-network-error>network error</dfn>.
 
-<p>A <a>network error</a> is a
-<a for=/>response</a> whose
-<a for=response>status</a> is always <code>0</code>,
+<p>A <a>network error</a> is a <a for=/>response</a> whose
+<a for=response>status</a> is always 0,
 <a for=response>status message</a> is always the empty byte sequence,
 <a for=response>header list</a> is always empty, and
 <a for=response>body</a> is always null.
@@ -1954,7 +1950,7 @@ which is only "accessible" to internal specification algorithms and is never a
 <a>filtered response</a> whose
 <a for=response>type</a> is "<code>opaque</code>",
 <a for=response>URL list</a> is the empty list,
-<a for=response>status</a> is <code>0</code>,
+<a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
 <a for=response>header list</a> is empty, and
 <a for=response>body</a> is null.
@@ -1963,7 +1959,7 @@ which is only "accessible" to internal specification algorithms and is never a
 <dfn export id=concept-filtered-response-opaque-redirect>opaque-redirect filtered response</dfn>
 is a <a>filtered response</a> whose
 <a for=response>type</a> is "<code>opaqueredirect</code>",
-<a for=response>status</a> is <code>0</code>,
+<a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
 <a for=response>header list</a> is empty, and
 <a for=response>body</a> is null.
@@ -2712,8 +2708,8 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
 
 <p>In case a server does not wish to participate in the <a>CORS protocol</a>, its HTTP response to
 the <a lt="CORS request">CORS</a> or <a>CORS-preflight request</a> must not include any of the above
-<a for=/>headers</a>. The server is encouraged to use the <code>403</code> <a for=/>status</a> in
-such HTTP responses.
+<a for=/>headers</a>. The server is encouraged to use the 403 <a for=/>status</a> in such HTTP
+responses.
 
 
 <h4 id=http-new-header-syntax>HTTP new-header syntax</h4>
@@ -3180,8 +3176,8 @@ run these steps:</p>
 
  <li><p>If <var>mimeType</var> is failure, then return <b>allowed</b>.
 
- <li><p>If <var>response</var>'s <a for=response>status</a> is <code>206</code> and
- <var>mimeType</var> is a <a>CORB-protected MIME type</a>, then return <b>blocked</b>.
+ <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is a
+ <a>CORB-protected MIME type</a>, then return <b>blocked</b>.
 
  <li>
   <p>If <a>determine nosniff</a> with <var>response</var>'s <a for=response>header list</a> is true
@@ -3190,8 +3186,8 @@ run these steps:</p>
 
   <p class="note no-backref">CORB only protects <code>text/plain</code> responses with a
   `<code>X-Content-Type-Options: nosniff</code>` header. Unfortunately, protecting such responses
-  without that header when their <a for=response>status</a> is <code>206</code> would break too many
-  existing video responses that have a <code>text/plain</code> <a for=/>MIME type</a>.
+  without that header when their <a for=response>status</a> is 206 would break too many existing
+  video responses that have a <code>text/plain</code> <a for=/>MIME type</a>.
 
  <!-- TODO: MIME type confirmation sniffing -->
  <!-- TODO: JSON security prefix sniffing -->
@@ -3779,11 +3775,10 @@ optionally with a <i>recursive flag</i>, run these steps:
 
  <li>
   <p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>",
-  <var>internalResponse</var>'s <a for=response>status</a> is <code>206</code>,
-  <var>internalResponse</var>'s <a for=response>range-requested flag</a> is set, and
-  <var>request</var>'s <a for=request>header list</a> does not <a for="header list">contain</a>
-  `<code>Range</code>`, then set <var>response</var> and <var>internalResponse</var> to a
-  <a>network error</a>.
+  <var>internalResponse</var>'s <a for=response>status</a> is 206, <var>internalResponse</var>'s
+  <a for=response>range-requested flag</a> is set, and <var>request</var>'s
+  <a for=request>header list</a> does not <a for="header list">contain</a> `<code>Range</code>`,
+  then set <var>response</var> and <var>internalResponse</var> to a <a>network error</a>.
 
   <div class=note>
    <p>Traditionally, APIs accept a ranged response even if a range was not requested. This prevents
@@ -4116,8 +4111,8 @@ optional <i>CORS-preflight flag</i>, run these steps:
     <a>network error</a>.
 
     <p class="note no-backref">As the <a>CORS check</a> is not to be applied to
-    <a for=/>responses</a> whose <a for=response>status</a> is <code>304</code> or <code>407</code>,
-    or <a for=/>responses</a> from a service worker for that matter, it is applied here.
+    <a for=/>responses</a> whose <a for=response>status</a> is 304 or 407, or <a for=/>responses</a>
+    from a service worker for that matter, it is applied here.
 
    <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
    then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
@@ -4140,11 +4135,11 @@ optional <i>CORS-preflight flag</i>, run these steps:
 
   <ol>
    <li>
-    <p>If <var>actualResponse</var>'s <a for=response>status</a> is not <code>303</code>,
-    <var>request</var>'s <a for=request>body</a> is not null, and the <a>connection</a> uses HTTP/2,
-    then user agents may, and are even encouraged to, transmit an <code>RST_STREAM</code> frame.
+    <p>If <var>actualResponse</var>'s <a for=response>status</a> is not 303, <var>request</var>'s
+    <a for=request>body</a> is not null, and the <a>connection</a> uses HTTP/2, then user agents
+    may, and are even encouraged to, transmit an <code>RST_STREAM</code> frame.
 
-    <p class=note><code>303</code> is excluded as certain communities ascribe special status to it.
+    <p class=note>303 is excluded as certain communities ascribe special status to it.
 
    <li><p>Let <var>location</var> be the result of <a>extracting header list values</a> given
    `<code>Location</code>` and <var>actualResponse</var>'s <a for=response>header list</a>.
@@ -4228,9 +4223,9 @@ optional <i>CORS-preflight flag</i>, run these steps:
 
   <p class=note>This catches a cross-origin resource redirecting to a same-origin URL.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>status</a> is not <code>303</code>,
- <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
- <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
+ <li><p>If <var>actualResponse</var>'s <a for=response>status</a> is not 303, <var>request</var>'s
+ <a for=request>body</a> is non-null, and <var>request</var>'s <a for=request>body</a>'s
+ <a for=body>source</a> is null, then return a <a>network error</a>.
 
  <li><p>If <var>actualResponse</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
  not <a>same origin</a> with <var>request</var>'s <a for=request>current URL</a>'s
@@ -4242,10 +4237,10 @@ optional <i>CORS-preflight flag</i>, run these steps:
   <p>If one of the following is true
 
   <ul class=brief>
-   <li><p><var>actualResponse</var>'s <a for=response>status</a> is <code>301</code> or
-   <code>302</code> and <var>request</var>'s <a for=request>method</a> is `<code>POST</code>`
-   <li><p><var>actualResponse</var>'s <a for=response>status</a> is <code>303</code> and
-   <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>` or `<code>HEAD</code>`
+   <li><p><var>actualResponse</var>'s <a for=response>status</a> is 301 or 302 and
+   <var>request</var>'s <a for=request>method</a> is `<code>POST</code>`
+   <li><p><var>actualResponse</var>'s <a for=response>status</a> is 303 and <var>request</var>'s
+   <a for=request>method</a> is not `<code>GET</code>` or `<code>HEAD</code>`
   </ul>
 
   <p>then:
@@ -4657,14 +4652,14 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <li><p>If <var>httpRequest</var>'s <a for=request>method</a> is
    <a href=https://tools.ietf.org/html/rfc7231#safe.methods>unsafe</a> and
-   <var>forwardResponse</var>'s <a for=response>status</a> is in the range <code>200</code> to
-   <code>399</code>, inclusive, invalidate appropriate stored responses in <var>httpCache</var>, as
-   per the "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
+   <var>forwardResponse</var>'s <a for=response>status</a> is in the range 200 to 399, inclusive,
+   invalidate appropriate stored responses in <var>httpCache</var>, as per the
+   "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
    <cite>HTTP Caching</cite>, and set <var>storedResponse</var> to null. [[!HTTP-CACHING]]
 
    <li>
     <p>If the <var>revalidatingFlag</var> is set and <var>forwardResponse</var>'s
-    <a for=response>status</a> is <code>304</code>, then:
+    <a for=response>status</a> is 304, then:
 
     <ol>
      <li>
@@ -4702,10 +4697,10 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
  `<code>Range</code>`, then set <var>response</var>'s <a for=response>range-requested flag</a>.
 
  <li>
-  <p>If <var>response</var>'s <a for=response>status</a> is <code>401</code>,
-  <var>httpRequest</var>'s <a for=request>response tainting</a> is not "<code>cors</code>", the
-  <i>credentials flag</i> is set, and <var>request</var>'s <a for=request>window</a> is an
-  <a>environment settings object</a>, then:
+  <p>If <var>response</var>'s <a for=response>status</a> is 401, <var>httpRequest</var>'s
+  <a for=request>response tainting</a> is not "<code>cors</code>", the <i>credentials flag</i> is
+  set, and <var>request</var>'s <a for=request>window</a> is an <a>environment settings object</a>,
+  then:
 
   <ol>
    <li class=XXX><p>Needs testing: multiple `<code>WWW-Authenticate</code>` headers, missing,
@@ -4756,7 +4751,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
   </ol>
 
  <li>
-  <p>If <var>response</var>'s <a for=response>status</a> is <code>407</code>, then:
+  <p>If <var>response</var>'s <a for=response>status</a> is 407, then:
 
   <ol>
    <li><p>If <var>request</var>'s <a for=request>window</a> is
@@ -4851,12 +4846,11 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
      <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
      <li>
-      <p>Any <a for=/>responses</a> whose
-      <a for=response>status</a> is in the range <code>100</code> to
-      <code>199</code>, inclusive, and is not <code>101</code>, are to be ignored.
+      <p>Any <a for=/>responses</a> whose <a for=response>status</a> is in the range 100 to 199,
+      inclusive, and is not 101, are to be ignored.
 
-      <p class="note no-backref">These kind of <a for=/>responses</a> are
-      eventually followed by a "final" <a for=/>response</a>.
+      <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by a
+      "final" <a for=/>response</a>.
     </ul>
 
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and
@@ -6222,7 +6216,7 @@ constructor steps are:
    <dd>Set.
 
    <dt><a for=request>client</a>
-   <dd><a>Current settings object</a>.
+   <dd><a>This</a>'s <a>relevant settings object</a>.
 
    <dt><a for=request>window</a>
    <dd><var>window</var>.
@@ -6516,12 +6510,18 @@ constructor steps are:
 <p>The <dfn attribute for=Request><code>destination</code></dfn> getter are to return <a>this</a>'s
 <a for=Request>request</a>'s <a for=request>destination</a>.
 
-<p>The <dfn attribute for=Request><code>referrer</code></dfn> getter steps are to return
-the empty string if <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a> is
-"<code>no-referrer</code>", "<code>about:client</code>" if <a>this</a>'s
-<a for=Request>request</a>'s <a for=request>referrer</a> is "<code>client</code>"; otherwise
-<a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a>,
-<a lt="url serializer">serialized</a>.
+<p>The <dfn attribute for=Request><code>referrer</code></dfn> getter steps are:
+
+<ol>
+ <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a> is
+ "<code>no-referrer</code>", then return the empty string.
+
+ <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a> is
+ "<code>client</code>", then return "<code>about:client</code>".
+
+ <li><p>Return <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer</a>,
+ <a lt="url serializer">serialized</a>.
+</ol>
 
 <p>The <dfn attribute for=Request><code>referrerPolicy</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Request>request</a>'s <a for=request>referrer policy</a>.
@@ -6636,8 +6636,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 constructor steps are:
 
 <ol>
- <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range <code>200</code> to
- <code>599</code>, inclusive, then <a>throw</a> a <code>RangeError</code>.
+ <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
+ then <a>throw</a> a {{RangeError}}.
 
  <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
  <a spec=http>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
@@ -6666,8 +6666,8 @@ constructor steps are:
     <p>If <var>init</var>["{{ResponseInit/status}}"] is a <a>null body status</a>, then <a>throw</a>
     a {{TypeError}}.
 
-    <p class="note no-backref"><code>101</code> is included in
-    <a>null body status</a> due to its use elsewhere. It does not affect this step.
+    <p class="note no-backref">101 is included in <a>null body status</a> due to its use elsewhere.
+    It does not affect this step.
 
    <li><p>Let <var>Content-Type</var> be null.
 
@@ -6714,8 +6714,7 @@ are:
 
  <li><p>If <var>parsedURL</var> is failure, then <a>throw</a> a {{TypeError}}.
 
- <li><p>If <var>status</var> is not a <a>redirect status</a>, then <a>throw</a> a
- <code>RangeError</code>.
+ <li><p>If <var>status</var> is not a <a>redirect status</a>, then <a>throw</a> a {{RangeError}}.
 
  <li><p>Let <var>r</var> be a new {{Response}} object, whose <a for=Response>response</a> is a new
  <a for=/>response</a>.
@@ -6726,8 +6725,10 @@ are:
  <li><p>Set <var>r</var>'s <a for=Response>response</a>'s
  <a for=response>status</a> to <var>status</var>.
 
- <li><p><a for="header list">Append</a> `<code>Location</code>` to <var>parsedURL</var>,
- <a lt="url serializer">serialized</a> and <a>isomorphic encoded</a>, in <var>r</var>'s
+ <li><p>Let <var>value</var> be <var>parsedURL</var>, <a lt="url serializer">serialized</a> and
+ <a>isomorphic encoded</a>.
+
+ <li><p><a for="header list">Append</a> `<code>Location</code>`/<var>value</var> to <var>r</var>'s
  <a for=Response>response</a>'s <a for=response>header list</a>.
 
  <li><p>Return <var>r</var>.
@@ -7070,9 +7071,8 @@ therefore not shareable, a WebSocket connection is very close to identical to an
  <li><p>Let <var>response</var> be the result of <a lt=fetch for=/>fetching</a>
  <var>request</var>.
 
- <li><p>If <var>response</var> is a <a>network error</a> or its
- <a for=response>status</a> is not <code>101</code>,
- <a>fail the WebSocket connection</a>.
+ <li><p>If <var>response</var> is a <a>network error</a> or its <a for=response>status</a> is not
+ 101, <a>fail the WebSocket connection</a>.
 
  <li>
   <p>If <var>protocols</var> is not the empty list and <a>extracting header list values</a> given

--- a/fetch.bs
+++ b/fetch.bs
@@ -2450,7 +2450,7 @@ from a {{ReadableStream}} object with <var>reader</var>, run these steps:
    <dt><a for="read request">error steps</a>, given <var>e</var>
    <dd>
     <ol>
-     <li><p><a>Reject</a> <var>promise</var> with <var>e</var>.
+     <li><p><a for=/>Reject</a> <var>promise</var> with <var>e</var>.
     </ol>
   </dl>
 
@@ -5804,12 +5804,12 @@ a <dfn id=concept-body-mime-type for=Body>MIME type</dfn> (failure or a <a for=/
 
 <p>An object implementing the {{Body}} mixin is said to be
 <dfn export id=concept-body-disturbed for=Body>disturbed</dfn> if its <a for=Body>body</a> is
-non-null and its <a for=body>stream</a> is <a for=ReadableStream>disturbed</a>.
+non-null and its <a for=Body>body</a>'s <a for=body>stream</a> is
+<a for=ReadableStream>disturbed</a>.
 
 <p>An object implementing the {{Body}} mixin is said to be
-<dfn export id=concept-body-locked for=Body>locked</dfn> if <a for=Body>body</a> is
-non-null and its <a for=body>stream</a> is
-<a for=ReadableStream>locked</a>.
+<dfn export id=concept-body-locked for=Body>locked</dfn> if its <a for=Body>body</a> is non-null and
+its <a for=Body>body</a>'s <a for=body>stream</a> is <a for=ReadableStream>locked</a>.
 
 <p>The <dfn attribute for=Body><code>body</code></dfn> getter steps are to return null if
 <a>this</a>'s <a for=Body>body</a> is null; otherwise <a>this</a>'s <a for=Body>body</a>'s
@@ -5818,10 +5818,9 @@ non-null and its <a for=body>stream</a> is
 <p>The <dfn attribute for=Body><code>bodyUsed</code></dfn> getter steps are to return true if
 <a>this</a> is <a for=Body>disturbed</a>; otherwise false.
 
-<p>Objects implementing the {{Body}} mixin also have an associated
-<dfn id=concept-body-package-data for=Body>package data</dfn> algorithm, given
-<var>bytes</var>, a <var>type</var> and a <var>mimeType</var>, switches on <var>type</var>, and
-runs the associated steps:
+<p>The <dfn id=concept-body-package-data for=Body>package data</dfn> algorithm, given
+<var>bytes</var>, <var>type</var>, and a <var>mimeType</var>, switches on <var>type</var>, and runs
+the associated steps:
 
 <dl class=switch>
  <dt><i>ArrayBuffer</i>
@@ -5898,33 +5897,29 @@ runs the associated steps:
  <var>bytes</var>.
 </dl>
 
-<p>Objects implementing the {{Body}} mixin also have an associated
-<dfn id=concept-body-consume-body for=Body>consume body</dfn> algorithm, given a <var>type</var>,
-runs these steps:
+<p>The <dfn id=concept-body-consume-body for=Body>consume body</dfn> algorithm, given an
+<var>object</var> and <var>type</var>, runs these steps:
 
 <ol>
- <li><p>If this object is <a for=Body>disturbed</a> or <a for=Body>locked</a>, return a new promise
- rejected with a {{TypeError}}.
+ <li><p>If <var>object</var> is <a for=Body>disturbed</a> or <a for=Body>locked</a>, then return a
+ <a>rejected promise</a> with a {{TypeError}}.
 
- <li><p>Let <var>stream</var> be <a for=Body>body</a>'s
- <a for=body>stream</a> if <a for=Body>body</a> is
- non-null, or an <a>empty</a>
- {{ReadableStream}} object otherwise.
+ <li><p>Let <var>stream</var> be <var>object</var>'s <a for=Body>body</a>'s <a for=body>stream</a>
+ if <var>object</var>'s <a for=Body>body</a> is non-null; otherwise an <a>empty</a>
+ {{ReadableStream}} object.
 
- <li><p>Let <var>reader</var> be the result of <a lt="get a reader" for=ReadableStream>getting
- a reader</a> from <var>stream</var>. If that threw an exception, return a new promise rejected
- with that exception.
+ <li><p>Let <var>reader</var> be the result of
+ <a lt="get a reader" for=ReadableStream>getting a reader</a> from <var>stream</var>. If that threw
+ an exception, return a <a>rejected promise</a> with that exception.
 
  <li><p>Let <var>promise</var> be the result of
- <a lt="read all bytes" for=ReadableStream>reading all bytes</a> from
- <var>stream</var> with <var>reader</var>.
+ <a lt="read all bytes" for=ReadableStream>reading all bytes</a> from <var>stream</var> with
+ <var>reader</var>.
 
- <li><p>Return the result of transforming <var>promise</var> by a fulfillment handler that
- returns the result of the <a>package data</a> algorithm
- with its first argument, <var>type</var> and this object's
- <a for=Body>MIME type</a>.
- <!-- XXX IDL really needs to define "transforming". For now it is defined in
-          https://www.w3.org/2001/tag/doc/promises-guide -->
+ <li><p>Let <var>steps</var> be to return the result of <a>package data</a> with the first argument
+ given, <var>type</var>, and <var>object</var>'s <a for=Body>MIME type</a>.
+
+ <li><p>Return the result of <a>upon fulfillment</a> of <var>promise</var> given <var>steps</var>.
 </ol>
 
 <p>The <dfn method for=Body><code>arrayBuffer()</code></dfn> method steps are to return the result
@@ -6810,7 +6805,7 @@ method steps are:
 
  <li><p>Let <var>requestObject</var> be the result of invoking the initial value of {{Request}} as
  constructor with <var>input</var> and <var>init</var> as arguments. If this throws an exception,
- reject <var>p</var> with it and return <var>p</var>.
+ <a for=/>reject</a> <var>p</var> with it and return <var>p</var>.
 
  <li><p>Let <var>request</var> be <var>requestObject</var>'s <a for=Request>request</a>.
 
@@ -6865,12 +6860,12 @@ method steps are:
    with <var>p</var>, <var>request</var>, and <var>responseObject</var>, and terminate these
    substeps.
 
-   <li><p>If <var>response</var> is a <a>network error</a>, then reject <var>p</var> with a
-   {{TypeError}} and terminate these substeps.
+   <li><p>If <var>response</var> is a <a>network error</a>, then <a for=/>reject</a> <var>p</var>
+   with a {{TypeError}} and terminate these substeps.
 
    <li><p>Associate <var>responseObject</var> with <var>response</var>.
 
-   <li><p>Resolve <var>p</var> with <var>responseObject</var>.
+   <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
   </ol>
 
  <li><p>Return <var>p</var>.
@@ -6883,7 +6878,7 @@ method steps are:
  <li><p>Let <var>error</var> be an "<code><a exception>AbortError</a></code>" {{DOMException}}.
 
  <li>
-  <p>Reject <var>promise</var> with <var>error</var>.
+  <p><a for=/>Reject</a> <var>promise</var> with <var>error</var>.
 
   <p class=note>This is a no-op if <var>promise</var> has already fulfilled.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5923,19 +5923,19 @@ the associated steps:
 </ol>
 
 <p>The <dfn method for=Body><code>arrayBuffer()</code></dfn> method steps are to return the result
-of running <a for=Body>consume body</a> with <i>ArrayBuffer</i>.
+of running <a for=Body>consume body</a> with <a>this</a> and <i>ArrayBuffer</i>.
 
 <p>The <dfn method for=Body><code>blob()</code></dfn> method steps are to return the result of
-running <a for=Body>consume body</a> with <i>Blob</i>.
+running <a for=Body>consume body</a> with <a>this</a> and <i>Blob</i>.
 
 <p>The <dfn method for=Body><code>formData()</code></dfn> method steps are to return the result of
-running <a for=Body>consume body</a> with <i>FormData</i>.
+running <a for=Body>consume body</a> with <a>this</a> and <i>FormData</i>.
 
 <p>The <dfn method for=Body><code>json()</code></dfn> method steps are to return the result of
-running <a for=Body>consume body</a> with <i>JSON</i>.
+running <a for=Body>consume body</a> with <a>this</a> and <i>JSON</i>.
 
 <p>The <dfn method for=Body><code>text()</code></dfn> method steps are to return the result of
-running <a for=Body>consume body</a> with <i>text</i>.
+running <a for=Body>consume body</a> with <a>this</a> and <i>text</i>.
 
 
 <h3 id=request-class>Request class</h3>


### PR DESCRIPTION
Use "this" and "x steps are". Also use the relevant settings object in constructors, rather than current. (They are identical there, but it's better to encourage relevant.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1054.html" title="Last updated on Jul 15, 2020, 5:51 AM UTC (0744a98)">Preview</a> | <a href="https://whatpr.org/fetch/1054/801dc8b...0744a98.html" title="Last updated on Jul 15, 2020, 5:51 AM UTC (0744a98)">Diff</a>