### PR TITLE
Meta: update Goals

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -117,8 +117,8 @@ everything that involves, including:
  <li>`<code>Referer</code>` [[!REFERRER]]
 </ul>
 
-<p>To do so it also supersedes the HTTP `<a http-header><code>Origin</code></a>` header semantics.
-[[ORIGIN]]
+<p>To do so it also supersedes the HTTP `<a http-header><code>Origin</code></a>` header semantics
+originally defined in The Web Origin Concept. [[ORIGIN]]
 
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -104,18 +104,8 @@ spec:streams; type:interface; text:ReadableStream
 
 <h2 id=goals class="no-num short">Goals</h2>
 
-<p>To unify fetching across the web platform this specification supplants a number of algorithms and
-specifications:
-
-<ul class="brief no-backref">
- <li>HTML Standard's fetch and potentially CORS-enabled fetch algorithms
- [[HTML]]
- <li>CORS [[CORS]]
- <li>HTTP `<a http-header><code>Origin</code></a>` header semantics
- [[ORIGIN]]
-</ul>
-
-<p>Unifying fetching provides consistent handling of:
+<p>The goal is to unify fetching across the web platform and provide consistent handling of
+everything that involves, including:
 
 <ul class=brief>
  <li>URL schemes
@@ -126,6 +116,9 @@ specifications:
  <li>Mixed Content [[!MIX]]
  <li>`<code>Referer</code>` [[!REFERRER]]
 </ul>
+
+<p>To do so it also supersedes the HTTP `<a http-header><code>Origin</code></a>` header semantics.
+[[ORIGIN]]
 
 
 


### PR DESCRIPTION
HTML now references Fetch and the old CORS specification redirects to Fetch.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1055.html" title="Last updated on Jul 14, 2020, 2:53 PM UTC (f8db93a)">Preview</a> | <a href="https://whatpr.org/fetch/1055/801dc8b...f8db93a.html" title="Last updated on Jul 14, 2020, 2:53 PM UTC (f8db93a)">Diff</a>