### PR TITLE
Return null if parsing a structured field value fails

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -75,9 +75,7 @@ url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;
         "title": "HTTP proxy default configurations allow arbitrary TCP connections."
     },
     "EXPECT-CT": {
-        "authors": [
-            "Emily Stark"
-        ],
+        "authors": ["Emily Stark"],
         "href": "https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-02",
         "publisher": "IETF",
         "title": "Expect-CT Extension for HTTP"
@@ -86,7 +84,7 @@ url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;
         "aliasOf": "RFC2560"
     },
     "HEADER-STRUCTURE": {
-        "authors": ["Mark Nottingham","Paul-Henning Kamp"],
+        "authors": ["Mark Nottingham", "Poul-Henning Kamp"],
         "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
         "publisher": "IETF",
         "title": "Structured Field Values for HTTP"

--- a/fetch.bs
+++ b/fetch.bs
@@ -16,9 +16,9 @@ url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content;type:dfn;
 url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
-url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-2;text:structured header value;type:dfn;spec:header-structure
-url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.1;text:serializing structured headers;type:dfn;spec:header-structure
-url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;text:parsing structured headers;type:dfn;spec:header-structure
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-2;text:structured field value;type:dfn;spec:header-structure
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.1;text:serializing structured fields;type:dfn;spec:header-structure
+url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;text:parsing structured fields;type:dfn;spec:header-structure
 </pre>
 
 <pre class=biblio>
@@ -89,7 +89,7 @@ url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;
         "authors": ["Mark Nottingham","Paul-Henning Kamp"],
         "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
         "publisher": "IETF",
-        "title": "Structured Headers for HTTP"
+        "title": "Structured Field Values for HTTP"
     }
 }
 </pre>
@@ -384,7 +384,7 @@ for consistency.
 specialized multimap. An ordered list of key-value pairs with potentially duplicate keys.
 
 <p>To
-<dfn export for="header list" id=concept-header-list-get-structured-header>get a structured header</dfn>
+<dfn export for="header list" id=concept-header-list-get-structured-header>get a structured field value</dfn>
 given a <var>name</var> and a <var>type</var> from a <a for=/>header list</a> <var>list</var>, run
 these steps:
 
@@ -397,28 +397,28 @@ these steps:
 
  <li><p>If <var>value</var> is null, then return null.
 
- <li><p>Let <var>result</var> be the result of executing the <a>parsing structured headers</a>
- algorithm with <var ignore>input_string</var> set to <var>value</var>, and
- <var ignore>header_type</var> set to <var>type</var>.
+ <li><p>Let <var>result</var> be the result of <a>parsing structured fields</a> with
+ <var ignore>input_string</var> set to <var>value</var> and <var ignore>header_type</var> set to
+ <var>type</var>.
 
- <li><p>If parsing failed, then return failure.
+ <li><p>If parsing failed, then return null.
 
  <li><p>Return <var>result</var>.
 </ol>
 
 <p>To
-<dfn export for="header list" id=concept-header-list-set-structured-header>set a structured header</dfn>
-<a for=header>name</a>/<a>structured header value</a> <var>name</var>/<var>structuredValue</var>
+<dfn export for="header list" id=concept-header-list-set-structured-header>set a structured field value</dfn>
+<a for=header>name</a>/<a>structured field value</a> <var>name</var>/<var>structuredValue</var>
 pair in a <a for=/>header list</a> <var>list</var>, run these steps:
 
 <ol>
  <li><p>Let <var>serializedValue</var> be the result of executing the
- <a>serializing structured headers</a> algorithm on <var>structuredValue</var>.
+ <a>serializing structured fields</a> algorithm on <var>structuredValue</var>.
 
  <li><p><a for="header list">Set</a> <var>name</var>/<var>serializedValue</var> in <var>list</var>.
 </ol>
 
-<p class=note><a>Structured header values</a> are defined as objects which HTTP can (eventually)
+<p class=note><a>Structured field values</a> are defined as objects which HTTP can (eventually)
 serialize in interesting and efficient ways. For the moment, Fetch only supports <a for=/>header</a>
 <a for=header>values</a> as <a for=/>byte sequences</a>, which means that these objects can be set
 in <a for=/>header lists</a> only via serialization, and they can be obtained from

--- a/fetch.bs
+++ b/fetch.bs
@@ -404,6 +404,10 @@ these steps:
  <li><p>Return <var>result</var>.
 </ol>
 
+<p class="note"><a>Get a structured field value</a> intentionally does not distinguish between a
+<a for=/>header</a> not being present and its <a for=header>value</a> failing to parse as a
+<a>structured field value</a>. This ensures uniform processing across the web platform.
+
 <p>To
 <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured field value</dfn>
 <a for=header>name</a>/<a>structured field value</a> <var>name</var>/<var>structuredValue</var>


### PR DESCRIPTION
All usage of structured fields in the web platform should not distinguish between the header not being there and failing to parse per the structured field parsing algorithm.

This also aligns Fetch slightly with terminology changes in HTTP that more clearly separate headers and trailers.

A future change might rename other concepts to also align with that (e.g., header list to field list).

Fixes #1053.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1056.html" title="Last updated on Jul 15, 2020, 4:41 AM UTC (b15a670)">Preview</a> | <a href="https://whatpr.org/fetch/1056/801dc8b...b15a670.html" title="Last updated on Jul 15, 2020, 4:41 AM UTC (b15a670)">Diff</a>