### PR TITLE
Partition HTTP Connections

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4837,7 +4837,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of
    <a lt="obtain a connection" for=connection>obtaining a connection</a>, <var>networkPartitionKey</var>,
-   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, and <var>credentials</var>.
+   given <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, and
+   <var>credentials</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2066,20 +2066,19 @@ for each associated <a for="fetch group">fetch record</a> whose
 
 <h3 id=connections>Connections</h3>
 
-<p>A user agent has an associated
-<dfn export id=concept-connection-pool for=connection>connection pool</dfn>. A
-<a for=connection>connection pool</a> consists of zero or more
-<dfn lt=connection export id=concept-connection>connections</dfn>. Each
-<a>connection</a> is identified by a <b>key</b> (a <a>network partition key</a>), an
-<b>origin</b> (an <a for=/>origin</a>), and <b>credentials</b> (a boolean).
+<p>A user agent has an associated <dfn export id=concept-connection-pool>connection pool</dfn>. A
+<a>connection pool</a> consists of zero or more
+<dfn lt=connection export id=concept-connection>connections</dfn>. Each <a>connection</a> is
+identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (an
+<a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
-<p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given
-<var>key</var>, <var>origin</var>, and <var>credentials</var>, run these steps:
+<p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
+<var>origin</var>, and <var>credentials</var>, run these steps:
 
 <ol>
- <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>key</b> is
- <var>key</var>, <b>origin</b> is <var>origin</var>, and <b>credentials</b> is <var>credentials</var>,
- then return that <a>connection</a>.
+ <li><p>If the user agent's <a>connection pool</a> contains a <a>connection</a> whose <b>key</b> is
+ <var>key</var>, <b>origin</b> is <var>origin</var>, and <b>credentials</b> is
+ <var>credentials</var>, then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2107,8 +2106,8 @@ for each associated <a for="fetch group">fetch record</a> whose
    <li><p>Return failure.
   </ol>
 
- <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>key</b>
- being <var>key</var>, <b>origin</b> being <var>origin</var>, and <b>credentials</b> being
+ <li><p>Add <var>connection</var> to the user agent's <a>connection pool</a> with <b>key</b> being
+ <var>key</var>, <b>origin</b> being <var>origin</var>, and <b>credentials</b> being
  <var>credentials</var>.
 
  <li><p>Return <var>connection</var>.
@@ -2130,8 +2129,8 @@ clearly stipulates that <a>connections</a> are keyed on
 an <a>implementation-defined</a> value.
 
 <p>To
-<dfn lt="determine the network partition key|determining the network partition key">
-determine the network partition key</dfn>, given <var>request</var>, run these steps:
+<dfn lt="determine the network partition key|determining the network partition key">determine the network partition key</dfn>,
+given <var>request</var>, run these steps:
 
 <ol>
  <li><p>Let <var>topLevelOrigin</var> be null.
@@ -2162,13 +2161,13 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
  <li><p>Let <var>topLevelSite</var> be the result of <a lt="obtain a site">obtaining a site</a>,
  given <var>topLevelOrigin</var>.
 
- <li><p>Let <var>secondKey</var> be null or an <a>implementation-defined</a> value.
+ <li>
+  <p>Let <var>secondKey</var> be null or an <a>implementation-defined</a> value.
 
   <p class=XXX>The second key is intentionally a little vague as the finer points are still
   evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
 
  <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>).
-
 </ol>
 
 
@@ -2179,12 +2178,12 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
 given <var>request</var>, run these steps:
 
 <ol>
- <li><p>Let <var>key</var> be the result of <a>determining the network partition key</a>.
+ <li><p>Let <var>key</var> be the result of <a>determining the network partition key</a> given
+ <var>request</var>.
 
  <li><p>If <var>key</var> is null, then return null.
 
- <li><p>Return the unique HTTP cache associated with the <var>key</var>.
- [[!HTTP-CACHING]]
+ <li><p>Return the unique HTTP cache associated with <var>key</var>. [[!HTTP-CACHING]]
 </ol>
 
 
@@ -4823,7 +4822,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
  to "<code>no-store</code>".
 
- <li><p>Let <var>networkPartitionKey</var> be the result of <a>determining the network partition key</a>.
+ <li><p>Let <var>networkPartitionKey</var> be the result of
+ <a>determining the network partition key</a> given <var>request</var>.
 
  <li>
   <p>Switch on <var>request</var>'s <a for=request>mode</a>:
@@ -4836,9 +4836,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a connection" for=connection>obtaining a connection</a>, given
-   <var>networkPartitionKey</var>, <var>request</var>'s <a for=request>current URL</a>'s
-   <a for=url>origin</a>, and <var>credentials</var>.
+   <a lt="obtain a connection">obtaining a connection</a>, given <var>networkPartitionKey</var>,
+   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, and
+   <var>credentials</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4804,7 +4804,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
  <li><p>Let <var>response</var> be null.
 
- <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP cache partition</a>, given
+ <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP state partition</a>, given
  <var>httpRequest</var>.
 
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2073,8 +2073,8 @@ for each associated <a for="fetch group">fetch record</a> whose
 <a>connection</a> is identified by a <b>key</b> (a <a>network partition key</a>), an
 <b>origin</b> (an <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
-<p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
-<var>origin</var>, <var>credentials</var>, and <var>networkPartitionKey</var>, run these steps:
+<p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given
+<var>key</var>, <var>origin</var>, and <var>credentials</var>, run these steps:
 
 <ol>
  <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>key</b> is
@@ -2179,11 +2179,11 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
 given <var>request</var>, run these steps:
 
 <ol>
- <li><p>Let <var>networkPartitionKey</var> be the result of <a>determining the network partition key</a>.
+ <li><p>Let <var>key</var> be the result of <a>determining the network partition key</a>.
 
- <li><p>If <var>networkPartitionKey</var> is null, then return null.
+ <li><p>If <var>key</var> is null, then return null.
 
- <li><p>Return the unique HTTP cache associated with the <var>networkPartitionKey</var>.
+ <li><p>Return the unique HTTP cache associated with the <var>key</var>.
  [[!HTTP-CACHING]]
 </ol>
 
@@ -4836,9 +4836,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a connection" for=connection>obtaining a connection</a>, <var>networkPartitionKey</var>,
-   given <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, and
-   <var>credentials</var>.
+   <a lt="obtain a connection" for=connection>obtaining a connection</a>, given
+   <var>networkPartitionKey</var>, <var>request</var>'s <a for=request>current URL</a>'s
+   <a for=url>origin</a>, and <var>credentials</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2155,7 +2155,7 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
  <var>topLevelOrigin</var> to <var>request</var>'s <a for=request>client</a>'s
  <a for="environment">top-level origin</a>.
 
- <li><p>Return null.
+ <li><p>Otherwise, Return null.
 
  <li><p>Assert: <var>topLevelOrigin</var> is an <a for=/>origin</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2072,15 +2072,15 @@ for each associated <a for="fetch group">fetch record</a> whose
 <dfn lt=connection export id=concept-connection>connections</dfn>. Each
 <a>connection</a> is identified by an <b>origin</b> (an
 <a for=/>origin</a>), <b>credentials</b> (a boolean), and
-<b>httpStatePartitionKey</b> (a <a for=/>site</a> list or null).
+<b>networkPartitionKey</b> (a <a for=/>site</a> list or null).
 
 <p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
-<var>origin</var>, <var>credentials</var>, and <var>httpStatePartitionKey</var>, run these steps:
+<var>origin</var>, <var>credentials</var>, and <var>networkPartitionKey</var>, run these steps:
 
 <ol>
  <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>origin</b> is
- <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>httpStatePartitionKey</b>
- is <var>httpStatePartitionKey</var>, then return that <a>connection</a>.
+ <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>networkPartitionKey</b>
+ is <var>networkPartitionKey</var>, then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2110,7 +2110,7 @@ for each associated <a for="fetch group">fetch record</a> whose
 
  <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>origin</b>
  being <var>origin</var>, <b>credentials</b> being <var>credentials</var>, and
- <b>httpStatePartitionKey</b> being <var>httpStatePartitionKey</var>.
+ <b>networkPartitionKey</b> being <var>networkPartitionKey</var>.
 
  <li><p>Return <var>connection</var>.
 </ol>
@@ -2125,11 +2125,11 @@ clearly stipulates that <a>connections</a> are keyed on
      WebSocket saner -->
 
 
-<h3 id=http-state-partition>HTTP state partition key</h3>
+<h3 id=http-state-partition>Network partition key</h3>
 
 <p>To
-<dfn lt="determine the HTTP state partition key|determining the HTTP state partition key">
-determine the HTTP state partition key</dfn>, given <var>request</var>, run these steps:
+<dfn lt="determine the network partition key|determining the network partition key">
+determine the network partition key</dfn>, given <var>request</var>, run these steps:
 
 <ol>
  <li><p>Let <var>topLevelOrigin</var> be null.
@@ -2169,6 +2169,22 @@ determine the HTTP state partition key</dfn>, given <var>request</var>, run thes
 
  <li><p>Return (<var>topLevelSite</var>)
 
+</ol>
+
+
+<h3 id=http-cache-partitions>HTTP cache partitions</h3>
+
+<p>To
+<dfn lt="determine the HTTP cache partition|determining the HTTP cache partition">determine the HTTP cache partition</dfn>,
+given <var>request</var>, run these steps:
+
+<ol>
+ <li><p>Set <var>networkPartitionKey</var> to the result of <a>determining the network partition key</a>.
+
+ <li><p>If <var>networkPartitionKey</var> is non-null, return null.
+
+ <li><p>Otherwise, Return the unique HTTP cache associated with the <var>networkPartitionKey</var>.
+ [[!HTTP-CACHING]]
 </ol>
 
 
@@ -4536,13 +4552,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <var>httpRequest</var>'s
     <a for=request>credentials mode</a>.
 
-   <li><p>Set <var>httpStatePartitionKey</var> to the result of <a>determining the HTTP state partition key</a>,
-   given <var>httpRequest</var>.
-
-   <li><p>Set <var>httpCache</var> to null.
-
-   <li><p>If <var>httpStatePartitionKey</var> is not null, then set <var>httpCache</var> to be the unique cache
-   instance associated with <var>httpStatePartitionKey</var> [[!HTTP-CACHING]].
+   <li><p>Set <var>httpCache</var> to the result of <a>determining the HTTP cache partition</a>,
+    given <var>httpRequest</var>.
 
    <li><p>If <var>httpCache</var> is null, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".
@@ -4806,8 +4817,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
  <li><p>Let <var>response</var> be null.
 
- <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP state partition key</a>,
- given <var>httpRequest</var>.
+ <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP cache partition</a>, given
+ <var>httpRequest</var>.
 
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
  to "<code>no-store</code>".
@@ -4825,7 +4836,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <dd><p>Let <var>connection</var> be the result of
    <a lt="obtain a connection" for=connection>obtaining a connection</a>, given <var>request</var>'s
    <a for=request>current URL</a>'s <a for=url>origin</a>, <var>credentials</var>, and
-   <var>httpStatePartitionKey</var>.
+   <var>networkPartitionKey</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2071,15 +2071,16 @@ for each associated <a for="fetch group">fetch record</a> whose
 <a for=connection>connection pool</a> consists of zero or more
 <dfn lt=connection export id=concept-connection>connections</dfn>. Each
 <a>connection</a> is identified by an <b>origin</b> (an
-<a for=/>origin</a>) and <b>credentials</b> (a boolean).
+<a for=/>origin</a>), <b>credentials</b> (a boolean), and
+<b>httpStatePartition</b> (a <a for=/>site</a> list).
 
 <p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
-<var>origin</var> and <var>credentials</var>, run these steps:
+<var>origin</var>, <var>credentials</var>, and <var>httpStatePartition</var>, run these steps:
 
 <ol>
  <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>origin</b> is
- <var>origin</var> and <b>credentials</b> is <var>credentials</var>, then return that
- <a>connection</a>.
+ <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>httpStatePartition</b>
+ if <var>httpStatePartition</var>, then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2108,7 +2109,8 @@ for each associated <a for="fetch group">fetch record</a> whose
   </ol>
 
  <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>origin</b>
- being <var>origin</var> and <b>credentials</b> being <var>credentials</var>.
+ being <var>origin</var>, <b>credentials</b> being <var>credentials</var>, and
+ <b>httpStatePartition</b> being <var>httpStatePartition</var>.
 
  <li><p>Return <var>connection</var>.
 </ol>
@@ -2123,10 +2125,10 @@ clearly stipulates that <a>connections</a> are keyed on
      WebSocket saner -->
 
 
-<h3 id=http-cache-partitions>HTTP cache partitions</h3>
+<h3 id=http-state-partition>HTTP state partition</h3>
 
 <p>To
-<dfn lt="determine the HTTP cache partition|determining the HTTP cache partition">determine the HTTP cache partition</dfn>,
+<dfn lt="determine the HTTP state partition|determining the HTTP state partition">determine the HTTP state partition</dfn>,
 given <var>request</var>, run these steps:
 
 <ol>
@@ -2158,12 +2160,13 @@ given <var>request</var>, run these steps:
  <li><p>Let <var>topLevelSite</var> be the result of <a lt="obtain a site">obtaining a site</a>,
  given <var>topLevelOrigin</var>.
 
- <li>
-  <p>Return the HTTP cache associated with <var>topLevelSite</var> and, possibly, a second key.
-  [[!HTTP-CACHING]]
+ <li><p>Let <var>secondKey</var> be the second key, or null.
 
   <p class=XXX>The second key is intentionally a little vague as the finer points are still
   evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
+
+ <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>)
+
 </ol>
 
 
@@ -4531,11 +4534,14 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <var>httpRequest</var>'s
     <a for=request>credentials mode</a>.
 
-   <li><p>Set <var>httpCache</var> to the result of <a>determining the HTTP cache partition</a>,
+   <li><p>Set <var>httpStatePartition</var> to the result of <a>determining the HTTP state partition</a>,
    given <var>httpRequest</var>.
 
    <li><p>If <var>httpCache</var> is null, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".
+
+   <li><p>Otherwise, let <var>httpCache</var> be the HTTP cache associated with <var>httpStatePartition</var>.
+   [[!HTTP-CACHING]]
 
    <li>
     <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is neither "<code>no-store</code>"
@@ -4814,7 +4820,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of
    <a lt="obtain a connection" for=connection>obtaining a connection</a>, given <var>request</var>'s
-   <a for=request>current URL</a>'s <a for=url>origin</a> and <var>credentials</var>.
+   <a for=request>current URL</a>'s <a for=url>origin</a>, <var>credentials</var>, and
+   <var>httpStatePartition</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2070,17 +2070,16 @@ for each associated <a for="fetch group">fetch record</a> whose
 <dfn export id=concept-connection-pool for=connection>connection pool</dfn>. A
 <a for=connection>connection pool</a> consists of zero or more
 <dfn lt=connection export id=concept-connection>connections</dfn>. Each
-<a>connection</a> is identified by an <b>origin</b> (an
-<a for=/>origin</a>), <b>credentials</b> (a boolean), and
-<b>networkPartitionKey</b> (a <a for=/>site</a> list or null).
+<a>connection</a> is identified by a <b>key</b> (a <a>network partition key</a>), an
+<b>origin</b> (an <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
 <p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
 <var>origin</var>, <var>credentials</var>, and <var>networkPartitionKey</var>, run these steps:
 
 <ol>
- <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>origin</b> is
- <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>networkPartitionKey</b>
- is <var>networkPartitionKey</var>, then return that <a>connection</a>.
+ <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>key</b> is
+ <var>key</var>, <b>origin</b> is <var>origin</var>, and <b>credentials</b> is <var>credentials</var>,
+ then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2108,9 +2107,9 @@ for each associated <a for="fetch group">fetch record</a> whose
    <li><p>Return failure.
   </ol>
 
- <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>origin</b>
- being <var>origin</var>, <b>credentials</b> being <var>credentials</var>, and
- <b>networkPartitionKey</b> being <var>networkPartitionKey</var>.
+ <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>key</b>
+ being <var>key</var>, <b>origin</b> being <var>origin</var>, and <b>credentials</b> being
+ <var>credentials</var>.
 
  <li><p>Return <var>connection</var>.
 </ol>
@@ -2125,7 +2124,10 @@ clearly stipulates that <a>connections</a> are keyed on
      WebSocket saner -->
 
 
-<h3 id=http-state-partition>Network partition key</h3>
+<h3 id=network-partition-keys>Network partition keys</h3>
+
+<p>A <dfn>network partition key</dfn> is a tuple consisting of a site and null or an
+<a>implementation-defined</a> value.
 
 <p>To
 <dfn lt="determine the network partition key|determining the network partition key">
@@ -2153,21 +2155,19 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
  <var>topLevelOrigin</var> to <var>request</var>'s <a for=request>client</a>'s
  <a for="environment">top-level origin</a>.
 
- <li><p>Otherwise, return null.
+ <li><p>Return null.
 
  <li><p>Assert: <var>topLevelOrigin</var> is an <a for=/>origin</a>.
 
  <li><p>Let <var>topLevelSite</var> be the result of <a lt="obtain a site">obtaining a site</a>,
  given <var>topLevelOrigin</var>.
 
- <li><p>Let <var>secondKey</var> be the second key, or null.
+ <li><p>Let <var>secondKey</var> be null or an <a>implementation-defined</a> value.
 
   <p class=XXX>The second key is intentionally a little vague as the finer points are still
   evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
 
- <li><p>If <var>secondKey</var> is not null, return (<var>topLevelSite</var>, <var>secondKey</var>).
-
- <li><p>Return (<var>topLevelSite</var>)
+ <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>).
 
 </ol>
 
@@ -2179,9 +2179,9 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
 given <var>request</var>, run these steps:
 
 <ol>
- <li><p>Set <var>networkPartitionKey</var> to the result of <a>determining the network partition key</a>.
+ <li><p>Let <var>networkPartitionKey</var> be the result of <a>determining the network partition key</a>.
 
- <li><p>If <var>networkPartitionKey</var> is non-null, return null.
+ <li><p>If <var>networkPartitionKey</var> is null, then return null.
 
  <li><p>Otherwise, Return the unique HTTP cache associated with the <var>networkPartitionKey</var>.
  [[!HTTP-CACHING]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -2183,7 +2183,7 @@ given <var>request</var>, run these steps:
 
  <li><p>If <var>networkPartitionKey</var> is null, then return null.
 
- <li><p>Otherwise, Return the unique HTTP cache associated with the <var>networkPartitionKey</var>.
+ <li><p>Return the unique HTTP cache associated with the <var>networkPartitionKey</var>.
  [[!HTTP-CACHING]]
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2155,7 +2155,7 @@ determine the network partition key</dfn>, given <var>request</var>, run these s
  <var>topLevelOrigin</var> to <var>request</var>'s <a for=request>client</a>'s
  <a for="environment">top-level origin</a>.
 
- <li><p>Otherwise, Return null.
+ <li><p>Otherwise, return null.
 
  <li><p>Assert: <var>topLevelOrigin</var> is an <a for=/>origin</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2126,8 +2126,8 @@ clearly stipulates that <a>connections</a> are keyed on
 
 <h3 id=network-partition-keys>Network partition keys</h3>
 
-<p>A <dfn>network partition key</dfn> is a tuple consisting of a site and null or an
-<a>implementation-defined</a> value.
+<p>A <dfn>network partition key</dfn> is a tuple consisting of a <a for=/>site</a> and null or
+an <a>implementation-defined</a> value.
 
 <p>To
 <dfn lt="determine the network partition key|determining the network partition key">
@@ -4823,6 +4823,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
  to "<code>no-store</code>".
 
+ <li><p>Let <var>networkPartitionKey</var> be the result of <a>determining the network partition key</a>.
+
  <li>
   <p>Switch on <var>request</var>'s <a for=request>mode</a>:
 
@@ -4834,9 +4836,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a connection" for=connection>obtaining a connection</a>, given <var>request</var>'s
-   <a for=request>current URL</a>'s <a for=url>origin</a>, <var>credentials</var>, and
-   <var>networkPartitionKey</var>.
+   <a lt="obtain a connection" for=connection>obtaining a connection</a>, <var>networkPartitionKey</var>,
+   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, and <var>credentials</var>.
   </dl>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4553,7 +4553,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <a for=request>credentials mode</a>.
 
    <li><p>Set <var>httpCache</var> to the result of <a>determining the HTTP cache partition</a>,
-    given <var>httpRequest</var>.
+   given <var>httpRequest</var>.
 
    <li><p>If <var>httpCache</var> is null, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".

--- a/fetch.bs
+++ b/fetch.bs
@@ -4539,11 +4539,13 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <li><p>Set <var>httpStatePartition</var> to the result of <a>determining the HTTP state partition</a>,
    given <var>httpRequest</var>.
 
+   <li><p>Set <var>httpCache</var> to null.
+
+   <li><p>If <var>httpStatePartition</var> is not null, then set <var>httpCache</var> to be the unique cache
+   instance associate with <var>httpStatePartition</var> [[!HTTP-CACHING]].
+
    <li><p>If <var>httpCache</var> is null, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".
-
-   <li><p>Otherwise, let <var>httpCache</var> be the HTTP cache associated with <var>httpStatePartition</var>.
-   [[!HTTP-CACHING]]
 
    <li>
     <p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is neither "<code>no-store</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -2080,7 +2080,7 @@ for each associated <a for="fetch group">fetch record</a> whose
 <ol>
  <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>origin</b> is
  <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>httpStatePartition</b>
- if <var>httpStatePartition</var>, then return that <a>connection</a>.
+ is <var>httpStatePartition</var>, then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2072,7 +2072,7 @@ for each associated <a for="fetch group">fetch record</a> whose
 <dfn lt=connection export id=concept-connection>connections</dfn>. Each
 <a>connection</a> is identified by an <b>origin</b> (an
 <a for=/>origin</a>), <b>credentials</b> (a boolean), and
-<b>httpStatePartition</b> (a <a for=/>site</a> list).
+<b>httpStatePartition</b> (a <a for=/>site</a> list or null).
 
 <p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
 <var>origin</var>, <var>credentials</var>, and <var>httpStatePartition</var>, run these steps:
@@ -2165,7 +2165,9 @@ given <var>request</var>, run these steps:
   <p class=XXX>The second key is intentionally a little vague as the finer points are still
   evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
 
- <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>)
+ <li><p>If <var>secondKey</var> is not null, return (<var>topLevelSite</var>, <var>secondKey</var>).
+
+ <li><p>Return (<var>topLevelSite</var>)
 
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2072,15 +2072,15 @@ for each associated <a for="fetch group">fetch record</a> whose
 <dfn lt=connection export id=concept-connection>connections</dfn>. Each
 <a>connection</a> is identified by an <b>origin</b> (an
 <a for=/>origin</a>), <b>credentials</b> (a boolean), and
-<b>httpStatePartition</b> (a <a for=/>site</a> list or null).
+<b>httpStatePartitionKey</b> (a <a for=/>site</a> list or null).
 
 <p>To <dfn export id=concept-connection-obtain for=connection>obtain a connection</dfn>, given an
-<var>origin</var>, <var>credentials</var>, and <var>httpStatePartition</var>, run these steps:
+<var>origin</var>, <var>credentials</var>, and <var>httpStatePartitionKey</var>, run these steps:
 
 <ol>
  <li><p>If <a for=connection>connection pool</a> contains a <a>connection</a> whose <b>origin</b> is
- <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>httpStatePartition</b>
- is <var>httpStatePartition</var>, then return that <a>connection</a>.
+ <var>origin</var>, <b>credentials</b> is <var>credentials</var>, and <b>httpStatePartitionKey</b>
+ is <var>httpStatePartitionKey</var>, then return that <a>connection</a>.
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2110,7 +2110,7 @@ for each associated <a for="fetch group">fetch record</a> whose
 
  <li><p>Add <var>connection</var> to the <a for=connection>connection pool</a> with <b>origin</b>
  being <var>origin</var>, <b>credentials</b> being <var>credentials</var>, and
- <b>httpStatePartition</b> being <var>httpStatePartition</var>.
+ <b>httpStatePartitionKey</b> being <var>httpStatePartitionKey</var>.
 
  <li><p>Return <var>connection</var>.
 </ol>
@@ -2125,11 +2125,11 @@ clearly stipulates that <a>connections</a> are keyed on
      WebSocket saner -->
 
 
-<h3 id=http-state-partition>HTTP state partition</h3>
+<h3 id=http-state-partition>HTTP state partition key</h3>
 
 <p>To
-<dfn lt="determine the HTTP state partition|determining the HTTP state partition">determine the HTTP state partition</dfn>,
-given <var>request</var>, run these steps:
+<dfn lt="determine the HTTP state partition key|determining the HTTP state partition key">
+determine the HTTP state partition key</dfn>, given <var>request</var>, run these steps:
 
 <ol>
  <li><p>Let <var>topLevelOrigin</var> be null.
@@ -4536,13 +4536,13 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     <var>httpRequest</var>'s
     <a for=request>credentials mode</a>.
 
-   <li><p>Set <var>httpStatePartition</var> to the result of <a>determining the HTTP state partition</a>,
+   <li><p>Set <var>httpStatePartitionKey</var> to the result of <a>determining the HTTP state partition key</a>,
    given <var>httpRequest</var>.
 
    <li><p>Set <var>httpCache</var> to null.
 
-   <li><p>If <var>httpStatePartition</var> is not null, then set <var>httpCache</var> to be the unique cache
-   instance associate with <var>httpStatePartition</var> [[!HTTP-CACHING]].
+   <li><p>If <var>httpStatePartitionKey</var> is not null, then set <var>httpCache</var> to be the unique cache
+   instance associated with <var>httpStatePartitionKey</var> [[!HTTP-CACHING]].
 
    <li><p>If <var>httpCache</var> is null, then set <var>httpRequest</var>'s
    <a for=request>cache mode</a> to "<code>no-store</code>".
@@ -4806,8 +4806,8 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
 
  <li><p>Let <var>response</var> be null.
 
- <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP state partition</a>, given
- <var>httpRequest</var>.
+ <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP state partition key</a>,
+ given <var>httpRequest</var>.
 
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
  to "<code>no-store</code>".
@@ -4825,7 +4825,7 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
    <dd><p>Let <var>connection</var> be the result of
    <a lt="obtain a connection" for=connection>obtaining a connection</a>, given <var>request</var>'s
    <a for=request>current URL</a>'s <a for=url>origin</a>, <var>credentials</var>, and
-   <var>httpStatePartition</var>.
+   <var>httpStatePartitionKey</var>.
   </dl>
 
 


### PR DESCRIPTION
Extend the HTTP cache partitioning logic to partition connections as well. This doesn't cover everything that will need to be partitioned, since much of it isn't even capturing in the fetch spec yet (browser-managed DNS caches, WebSocket connections over H2/H3 proxies, H2/H3 sessions, TLS/H3 session resumption cache, cache of metadata about H3-capable servers, HTTP auth cache, etc).

This addresses parts of issue #917.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * FireFox
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * ...
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/963480
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1572544
   * Safari: …


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1063.html" title="Last updated on Aug 6, 2020, 2:51 PM UTC (8cbe436)">Preview</a> | <a href="https://whatpr.org/fetch/1063/4ad496d...8cbe436.html" title="Last updated on Aug 6, 2020, 2:51 PM UTC (8cbe436)">Diff</a>