### PR TITLE
Fix typos

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5363,7 +5363,7 @@ fetch("/", {method:"HEAD"})
 </code></pre>
 
  <p>If you want to check a particular response header and then process the response of a
- cross-origin resources:
+ cross-origin resource:
 
  <pre><code class=lang-javascript>
 fetch("https://pk.example/berlin-calling.json", {mode:"cors"})
@@ -5434,7 +5434,7 @@ interface Headers {
 `<code>Set-Cookie</code>` <a for=/>header</a>. In a way this is problematic as unlike all other
 headers `<code>Set-Cookie</code>` headers cannot be combined, but since `<code>Set-Cookie</code>`
 headers are not exposed to client-side JavaScript this is deemed an acceptable compromise.
-Implementations could chose the more efficient {{Headers}} object representation even for a
+Implementations could choose the more efficient {{Headers}} object representation even for a
 <a for=/>header list</a>, as long as they also support an associated data structure for
 `<code>Set-Cookie</code>` headers.
 
@@ -7295,6 +7295,7 @@ Brad Porter,
 Bryan Smith,
 Caitlin Potter,
 Cameron McCormack,
+Chris Needham,
 Chris Rebert,
 Clement Pellerin,
 Collin Jackson,


### PR DESCRIPTION
This PR fixes a couple of typos I noticed:
* resources -> resource
* chose -> choose


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1065.html" title="Last updated on Jul 30, 2020, 4:23 PM UTC (3eb4842)">Preview</a> | <a href="https://whatpr.org/fetch/1065/4ad496d...3eb4842.html" title="Last updated on Jul 30, 2020, 4:23 PM UTC (3eb4842)">Diff</a>