### PR TITLE
Point default referrer policy to a constant defined in RP spec

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3368,11 +3368,7 @@ optionally with a <i>recursive flag</i>, run these steps:
    <li>
     <p>If <var>request</var>'s <a for=request>referrer policy</a>
     is the empty string, then set <var>request</var>'s
-    <a for=request>referrer policy</a> to
-    "<code>no-referrer-when-downgrade</code>".
-
-    <p class="note no-backref">We use "<code>no-referrer-when-downgrade</code>" because it is the
-    historical default.
+    <a for=request>referrer policy</a> to the <a for=/>default referrer policy</a>.
 
    <li>
     <p>If <var>request</var>'s <a for=request>referrer</a>


### PR DESCRIPTION
This is a re-do of #952 started by @mikewest since I am taking over the relevant spec updates.

This spec will now point to a constant defined in w3c/webappsec-referrer-policy/pull/142 as the default referrer policy.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1066.html" title="Last updated on Nov 30, 2020, 12:23 PM UTC (735829a)">Preview</a> | <a href="https://whatpr.org/fetch/1066/c5f8177...735829a.html" title="Last updated on Nov 30, 2020, 12:23 PM UTC (735829a)">Diff</a>