### PR TITLE
Set request header's guard if no-cors

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6385,6 +6385,23 @@ constructor steps are:
  <a for=Headers>guard</a> is "<code>request</code>".
 
  <li>
+  <p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is
+  "<code>no-cors</code>", then:
+
+  <ol>
+   <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
+   <a>CORS-safelisted method</a>, then <a>throw</a> a {{TypeError}}.
+   <!-- This will throw in cases where APIs have created no-cors requests with a non-safe method and
+   the developer has called new Request(fetchEvent.request) or fetch(fetchEvent.request) within a
+   service worker fetch event. This shouldn't happen, as APIs shouldn't create no-cors requests with
+   a non-safe method -->
+
+   <li><p>Set <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
+   "<code>request-no-cors</code>".
+  </ol>
+ </li>
+
+ <li>
   <p>If <var>init</var> <a for=map>is not empty</a>, then:
 
   <p class=note>The headers are sanitised as they might contain headers that are not allowed by this
@@ -6399,19 +6416,6 @@ constructor steps are:
    <var>headers</var> to <var>init</var>["{{RequestInit/headers}}"].
 
    <li><p>Empty <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
-
-   <li>
-    <p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is
-    "<code>no-cors</code>", then:
-
-    <ol>
-     <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>method</a> is not a
-     <a>CORS-safelisted method</a>, then <a>throw</a> a {{TypeError}}.
-
-     <li><p>Set <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>guard</a> to
-     "<code>request-no-cors</code>".
-    </ol>
-   </li>
 
    <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
    <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>


### PR DESCRIPTION
Fixes #1074.

I think this is all it needs, because otherwise we want the header guard to be "request".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1076.html" title="Last updated on Aug 18, 2020, 2:10 PM UTC (6fdbcde)">Preview</a> | <a href="https://whatpr.org/fetch/1076/1b1239a...6fdbcde.html" title="Last updated on Aug 18, 2020, 2:10 PM UTC (6fdbcde)">Diff</a>