### PR TITLE
Meta: disambiguate fetch() from the CSS function with the same name

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6405,7 +6405,7 @@ constructor steps are:
 
    <li><p>Empty <a>this</a>'s <a for=Request>headers</a>'s <a for=Headers>header list</a>.
 
-   <li><p>If <var>headers</var> is a <code>Headers</code> object, then <a for=list>for each</a>
+   <li><p>If <var>headers</var> is a {{Headers}} object, then <a for=list>for each</a>
    <var>header</var> in its <a for=Headers>header list</a>, <a for=Headers>append</a>
    <var>header</var>'s <a for=header>name</a>/<var>header</var>'s <a for=header>value</a> to
    <a>this</a>'s <a for=Request>headers</a>.
@@ -7177,7 +7177,7 @@ service worker layer, and network &amp; cache layer.
 `<code>Accept-Encoding</code>`,
 `<code>Host</code>`, and `<code>Referer</code>`, are
 set in the network &amp; cache layer. Developers can set headers either at the API layer
-or in the service worker layer (typically through a <a for=/><code>Request</code></a> object).
+or in the service worker layer (typically through a {{Request}} object).
 Developers have almost no control over
 <a lt="forbidden header name">forbidden headers</a>, but can control
 `<code>Accept</code>` and have the means to constrain and omit

--- a/fetch.bs
+++ b/fetch.bs
@@ -128,9 +128,8 @@ APIs. The Fetch Standard provides a unified architecture for these features so t
 all consistent when it comes to various aspects of fetching, such as redirects and the
 CORS protocol.
 
-<p>The Fetch Standard also defines the <a><code>fetch()</code></a>
-JavaScript API, which exposes most of the networking functionality at a fairly low level
-of abstraction.
+<p>The Fetch Standard also defines the <a method><code>fetch()</code></a> JavaScript API, which
+exposes most of the networking functionality at a fairly low level of abstraction.
 
 
 
@@ -1081,13 +1080,9 @@ unset.
 is unset.
 
 <p class="note no-backref">The <a>unsafe-request flag</a> is set by APIs such as
-<a><code>fetch()</code></a>  and
-{{XMLHttpRequest}} to ensure a
-<a>CORS-preflight fetch</a> is done based on the supplied
-<a for=request>method</a> and
-<a for=request>header list</a>. It does not free an API from
-outlawing <a>forbidden methods</a> and
-<a>forbidden header names</a>.
+<a method><code>fetch()</code></a>  and {{XMLHttpRequest}} to ensure a <a>CORS-preflight fetch</a>
+is done based on the supplied <a for=request>method</a> and <a for=request>header list</a>. It does
+not free an API from outlawing <a>forbidden methods</a> and <a>forbidden header names</a>.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-body>body</dfn> (null, a <a for=/>byte sequence</a>, or a
@@ -1247,9 +1242,9 @@ not always relevant and might require different behavior.
   <tr>
    <td>""
    <td><code>connect-src</code>
-   <td><code>navigator.sendBeacon()</code>, <code>EventSource</code>,
+   <td><code>navigator.sendBeacon()</code>, {{EventSource}},
    HTML's <code>&lt;a ping=""></code> and <code>&lt;area ping=""></code>,
-   <a><code>fetch()</code></a>, <code>XMLHttpRequest</code>, <code>WebSocket</code>, Cache API
+   <a method><code>fetch()</code></a>, {{XMLHttpRequest}}, {{WebSocket}}, Cache API
   <tr>
    <td>"<code>object</code>"
    <td><code>object-src</code>
@@ -4491,10 +4486,9 @@ Range Requests</cite>. [[HTTP-RANGE]] However, this is not widely supported by b
     `<code>Accept-Charset</code>`, and
     `<code>Accept-Language</code>` must not be included at this point.
 
-    <p class="note no-backref">`<code>Accept</code>` and
-    `<code>Accept-Language</code>` are already included (unless
-    <a><code>fetch()</code></a> is used, which does not include the latter by
-    default), and `<code>Accept-Charset</code>` is a waste of bytes. See
+    <p class="note no-backref">`<code>Accept</code>` and `<code>Accept-Language</code>` are already
+    included (unless <a method><code>fetch()</code></a> is used, which does not include the latter
+    by default), and `<code>Accept-Charset</code>` is a waste of bytes. See
     <a>HTTP header layer division</a> for more details.
 
    <li>
@@ -5348,15 +5342,13 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 
 <h2 id=fetch-api>Fetch API</h2>
 
-<p class=no-backref>The <a><code>fetch()</code></a> method is relatively
-low-level API for <a lt=fetch for=/>fetching</a> resources. It covers slightly
-more ground than {{XMLHttpRequest}}, although it is
-currently lacking when it comes to request progression (not response progression).
+<p class=no-backref>The <a method><code>fetch()</code></a> method is relatively low-level API for
+<a lt=fetch for=/>fetching</a> resources. It covers slightly more ground than {{XMLHttpRequest}},
+although it is currently lacking when it comes to request progression (not response progression).
 
 <div id=fetch-blob-example class="example no-backref">
- <p>The <a><code>fetch()</code></a> method makes it quite straightforward
- to <a for=/>fetch</a> a resource and extract its contents as a
- {{Blob}}:
+ <p>The <a method><code>fetch()</code></a> method makes it quite straightforward to
+ <a for=/>fetch</a> a resource and extract its contents as a {{Blob}}:
 
  <pre><code class=lang-javascript>
 fetch("/music/pk/altes-kamuffel.flac")
@@ -6900,7 +6892,7 @@ method steps are:
 is not observable through script.
 
 <p class="note no-backref">"Observable through script" means observable through
-<a><code>fetch()</code></a>'s arguments and return value. Other ways, such as
+<a method><code>fetch()</code></a>'s arguments and return value. Other ways, such as
 communicating with the server through a side-channel are not included.
 
 <p class="note no-backref">The server being able to observe garbage collection has precedent, e.g.,


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1084.html" title="Last updated on Aug 27, 2020, 7:18 AM UTC (de1d0fc)">Preview</a> | <a href="https://whatpr.org/fetch/1084/99db8c2...de1d0fc.html" title="Last updated on Aug 27, 2020, 7:18 AM UTC (de1d0fc)">Diff</a>