### PR TITLE
Use the network partition key in the CORS-preflight cache

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2886,7 +2886,6 @@ Content-Type:
 </div>
 
 
-
 <h3 id=x-content-type-options-header>`<code>X-Content-Type-Options</code>` header</h3>
 
 <p>The
@@ -3691,7 +3690,7 @@ optionally with a <i>recursive flag</i>, run these steps:
  for <var>response</var>.
 </ol>
 
-<!-- Prior to May 2017, this algorithm was named "basic fetch." -->
+
 <h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
 <p>To perform a <dfn id=concept-scheme-fetch oldids=concept-basic-fetch>scheme fetch</dfn> using
@@ -4998,6 +4997,7 @@ run these steps:
  <li><p>Otherwise, return a <a>network error</a>.
 </ol>
 
+
 <h3 id=cors-preflight-cache>CORS-preflight cache</h3>
 
 <p>A user agent has an associated <a>CORS-preflight cache</a>. A
@@ -5006,6 +5006,7 @@ run these steps:
 <p>A <dfn>cache entry</dfn> consists of:
 
 <ul class=brief>
+ <li><dfn id=concept-cache-key for="cache entry">key</dfn> (a <a for=/>network partition key</a>)
  <li><dfn id=concept-cache-origin for="cache entry">byte-serialized origin</dfn> (a
  <a for=/>byte sequence</a>)
  <li><dfn id=concept-cache-url for="cache entry">URL</dfn> (a <a for=/>URL</a>)
@@ -5029,6 +5030,9 @@ be removed before that moment arrives.
   <p>Let <var>entry</var> be a <a>cache entry</a>, initialized as follows:
 
   <dl>
+   <dt><a for="cache entry">key</a>
+   <dd><p>The result of <a>determining the network partition key</a> given <var>request</var>
+
    <dt><a for="cache entry">byte-serialized origin</a>
    <dd><p>The result of <a>byte-serializing a request origin</a> with <var>request</var>
 
@@ -5054,12 +5058,14 @@ be removed before that moment arrives.
 
 <p>To <dfn id=concept-cache-clear>clear cache entries</dfn>, given a <var>request</var>,
 <a for=list>remove</a> any <a>cache entries</a> in the user agent's <a>CORS-preflight cache</a>
-whose <a for="cache entry">byte-serialized origin</a> is the result of
-<a>byte-serializing a request origin</a> with <var>request</var> and whose
-<a for="cache entry">URL</a> is <var>request</var>'s <a for=request>current URL</a>.
+whose <a for="cache entry">key</a> is the result of <a>determining the network partition key</a>
+given <var>request</var>, <a for="cache entry">byte-serialized origin</a> is the result of
+<a>byte-serializing a request origin</a> with <var>request</var>, and <a for="cache entry">URL</a>
+is <var>request</var>'s <a for=request>current URL</a>.
 
 <p>There is a <dfn id=concept-cache-match>cache entry match</dfn> for a <a>cache entry</a>
-<var>entry</var> with <var>request</var> if <var>entry</var>'s
+<var>entry</var> with <var>request</var> if <var>entry</var>'s <a for="cache entry">key</a> is the
+result of <a>determining the network partition key</a> given <var>request</var>, <var>entry</var>'s
 <a for="cache entry">byte-serialized origin</a> is the result of
 <a>byte-serializing a request origin</a> with <var>request</var>, <var>entry</var>'s
 <a for="cache entry">URL</a> is <var>request</var>'s <a for=request>current URL</a>, and one of


### PR DESCRIPTION
(Perhaps at some point it makes sense to determine the key once and store it on the request. For now I think this is okay, but let me know if you feel otherwise.)

cc @MattMenke2 @shivanigithub


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1101.html" title="Last updated on Oct 12, 2020, 1:18 PM UTC (3d38857)">Preview</a> | <a href="https://whatpr.org/fetch/1101/5321d4a...3d38857.html" title="Last updated on Oct 12, 2020, 1:18 PM UTC (3d38857)">Diff</a>