### PR TITLE
Editorial: align bad port service names with IANA

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2286,7 +2286,8 @@ run these steps:
  <tr><td>6669<td>ircu
  <tr><td>6697<td>ircs-u
 </table>
-<!-- https://www-archive.mozilla.org/projects/netlib/PortBanning.html -->
+<!-- Service names per
+     https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt -->
 
 
 <h3 dfn export lt="should response to request be blocked due to mime type" id=should-response-to-request-be-blocked-due-to-mime-type?>Should

--- a/fetch.bs
+++ b/fetch.bs
@@ -2235,11 +2235,11 @@ run these steps:
  <tr><td>42<td>name
  <tr><td>43<td>nicname
  <tr><td>53<td>domain
- <tr><td>77<td>priv-rjs
+ <tr><td>77<td>—
  <tr><td>79<td>finger
- <tr><td>87<td>ttylink
+ <tr><td>87<td>—
  <tr><td>95<td>supdup
- <tr><td>101<td>hostriame
+ <tr><td>101<td>hostname
  <tr><td>102<td>iso-tsap
  <tr><td>103<td>gppitnp
  <tr><td>104<td>acr-nema
@@ -2251,14 +2251,14 @@ run these steps:
  <tr><td>117<td>uucp-path
  <tr><td>119<td>nntp
  <tr><td>123<td>ntp
- <tr><td>135<td>loc-srv / epmap
- <tr><td>139<td>netbios
- <tr><td>143<td>imap2
+ <tr><td>135<td>epmap
+ <tr><td>139<td>netbios-ssn
+ <tr><td>143<td>imap
  <tr><td>179<td>bgp
  <tr><td>389<td>ldap
- <tr><td>427<td>afp (alternate)
- <tr><td>465<td>smtp (alternate)
- <tr><td>512<td>print / exec
+ <tr><td>427<td>svrloc
+ <tr><td>465<td>submissions
+ <tr><td>512<td>exec
  <tr><td>513<td>login
  <tr><td>514<td>shell
  <tr><td>515<td>printer
@@ -2269,22 +2269,22 @@ run these steps:
  <tr><td>540<td>uucp
  <tr><td>548<td>afp
  <tr><td>556<td>remotefs
- <tr><td>563<td>nntp+ssl
- <tr><td>587<td>smtp (outgoing)
+ <tr><td>563<td>nntps
+ <tr><td>587<td>submission
  <tr><td>601<td>syslog-conn
- <tr><td>636<td>ldap+ssl
- <tr><td>993<td>ldap+ssl
- <tr><td>995<td>pop3+ssl
+ <tr><td>636<td>ldaps
+ <tr><td>993<td>imaps
+ <tr><td>995<td>pop3s
  <tr><td>2049<td>nfs
  <tr><td>3659<td>apple-sasl
- <tr><td>4045<td>lockd
+ <tr><td>4045<td>npp
  <tr><td>6000<td>x11
- <tr><td>6665<td>irc (alternate)
- <tr><td>6666<td>irc (alternate)
- <tr><td>6667<td>irc (default)
- <tr><td>6668<td>irc (alternate)
- <tr><td>6669<td>irc (alternate)
- <tr><td>6697<td>irc+tls
+ <tr><td>6665<td>ircu
+ <tr><td>6666<td>ircu
+ <tr><td>6667<td>ircu
+ <tr><td>6668<td>ircu
+ <tr><td>6669<td>ircu
+ <tr><td>6697<td>ircs-u
 </table>
 <!-- https://www-archive.mozilla.org/projects/netlib/PortBanning.html -->
 


### PR DESCRIPTION
Closes #750.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1107.html" title="Last updated on Nov 2, 2020, 2:08 PM UTC (6c00440)">Preview</a> | <a href="https://whatpr.org/fetch/1107/515e6bb...6c00440.html" title="Last updated on Nov 2, 2020, 2:08 PM UTC (6c00440)">Diff</a>