### PR TITLE
Tee request body on ServiceWorker interception

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3813,7 +3813,8 @@ these steps:
     <p>If <var>response</var> is not null, then:
 
     <ol>
-     <li><p><a>Transmit request body</a> given <var>fetchParams</var>.
+     <li>If <var>request</var>'s <a for=request>body</a> is not null, then
+     <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
 
      <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a
      <a>filtered response</a>, and to <var>response</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -3805,7 +3805,6 @@ these steps:
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
 
-
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
 
@@ -3813,7 +3812,7 @@ these steps:
     <p>If <var>response</var> is not null, then:
 
     <ol>
-     <li>If <var>request</var>'s <a for=request>body</a> is not null, then
+     <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
 
      <li><p>Set <var>actualResponse</var> to <var>response</var>, if <var>response</var> is not a

--- a/fetch.bs
+++ b/fetch.bs
@@ -3806,27 +3806,26 @@ these steps:
    <a for=/>body</a>.
 
    <li>
-    <p>Let <var>copiedRequest</var> be a copy of <var>request</var>.
+    <p>Let <var>savedBody</var> be a copy of <var>request</var>'s <a for=request>body</a>.
 
     <p class="note no-backref">This step doesn't copy the contents of <a for=/>body</a>. If
-    non-null, <a lt=body for=request>bodies</a> of <var>request</var> and
-    <var>copiedRequest</var> contains references to the same <a for=body>stream</a>.
+    non-null, <var>request</var>'s <a for=request>body</a> and <var>savedBody</var>
+    contain references pointing to the same <a for=body>stream</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>copiedRequest</var>. [[!HTML]] [[!SW]]
+   <var>request</var>. [[!HTML]] [[!SW]]
 
    <li>
-    <p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is
-    non-null, and its <a for=body>stream</a> is <a for=ReadableStream>disturbed</a> or
+    <p>If <var>response</var> is null, <var>savedBody</var> is non-null, and its
+    <a for=body>stream</a> is <a for=ReadableStream>disturbed</a> or
     <a for=ReadableStream>locked</a>, then:
 
     <ol>
-     <li><p>If <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a> is null,
-     then return a <a>network error</a>.
+     <li><p>If <var>savedBody</var>'s <a for=body>source</a> is null, then return a
+     <a>network error</a>.
 
      <li><p>Otherwise, set <var>request</var>'s <a for=request>body</a> to the first return value of
-     <a for=BodyInit>safely extracting</a> <var>request</var>'s <a for=request>body</a>'s
-     <a for=body>source</a>.
+     <a for=BodyInit>safely extracting</a> <var>savedBody</var>'s <a for=body>source</a>.
     </ol>
 
    <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3802,11 +3802,18 @@ these steps:
   <p>If <var>request</var>'s <a>service-workers mode</a> is "<code>all</code>", then:
 
   <ol>
-   <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>request</var>. [[!HTML]] [[!SW]]
-
    <li><p>Assert: <var>request</var> 's <a for=request>body</a> is either null or a
    <a for=/>body</a>.
+
+   <li>
+    <p>Let <var>copiedRequest</var> be a copy of <var>request</var>.
+
+    <p class="note no-backref">This step doesn't copy the contents of <a for=request>body</a>. If it
+    is non-null, <a lt=body for=request>bodies</a> of <var>request</var> and
+    <var>copiedRequest</var> reference to the same <a for=body>stream</a>.
+
+   <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
+   <var>copiedRequest</var>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is

--- a/fetch.bs
+++ b/fetch.bs
@@ -3809,7 +3809,7 @@ these steps:
    <a for=/>body</a>.
 
    <li><p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is
-   non-null, its <a for=body>source</var> is null, and its <a for=body>stream</a> is
+   non-null, its <a for=body>source</a> is null, and its <a for=body>stream</a> is
    <a for=ReadableStream>disturbed</a> or <a for=ReadableStream>locked</a>, then return a
    <a>network error</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3802,31 +3802,12 @@ these steps:
   <p>If <var>request</var>'s <a>service-workers mode</a> is "<code>all</code>", then:
 
   <ol>
-   <li><p>Assert: <var>request</var> 's <a for=request>body</a> is either null or a
-   <a for=/>body</a>.
+   <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
+   <var>request</var>.
 
-   <li>
-    <p>Let <var>savedBody</var> be a copy of <var>request</var>'s <a for=request>body</a>.
-
-    <p class="note no-backref">This step doesn't copy the contents of <a for=/>body</a>. If
-    non-null, <var>request</var>'s <a for=request>body</a> and <var>savedBody</var>
-    contain references pointing to the same <a for=body>stream</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>request</var>. [[!HTML]] [[!SW]]
-
-   <li>
-    <p>If <var>response</var> is null, <var>savedBody</var> is non-null, and its
-    <a for=body>stream</a> is <a for=ReadableStream>disturbed</a> or
-    <a for=ReadableStream>locked</a>, then:
-
-    <ol>
-     <li><p>If <var>savedBody</var>'s <a for=body>source</a> is null, then return a
-     <a>network error</a>.
-
-     <li><p>Otherwise, set <var>request</var>'s <a for=request>body</a> to the first return value of
-     <a for=BodyInit>safely extracting</a> <var>savedBody</var>'s <a for=body>source</a>.
-    </ol>
+   <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -3805,6 +3805,14 @@ these steps:
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>request</var>. [[!HTML]] [[!SW]]
 
+   <li><p>Assert: <var>request</var> 's <a for=request>body</a> is either null or a
+   <a for=/>body</a>.
+
+   <li><p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is
+   non-null, its <a for=body>source</var> is null, and its <a for=body>stream</a> is
+   <a for=ReadableStream>disturbed</a> or <a for=ReadableStream>locked</a>, then return a
+   <a>network error</a>.
+
    <li>
     <p>If <var>response</var> is not null, then:
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3808,10 +3808,19 @@ these steps:
    <li><p>Assert: <var>request</var> 's <a for=request>body</a> is either null or a
    <a for=/>body</a>.
 
-   <li><p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is
-   non-null, its <a for=body>source</a> is null, and its <a for=body>stream</a> is
-   <a for=ReadableStream>disturbed</a> or <a for=ReadableStream>locked</a>, then return a
-   <a>network error</a>.
+   <li>
+    <p>If <var>response</var> is null, <var>request</var>'s <a for=request>body</a> is
+    non-null, and its <a for=body>stream</a> is <a for=ReadableStream>disturbed</a> or
+    <a for=ReadableStream>locked</a>, then:
+
+    <ol>
+     <li><p>If <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a> is null,
+     then return a <a>network error</a>.
+
+     <li><p>Otherwise, set <var>request</var>'s <a for=request>body</a> to the first return value of
+     <a for=BodyInit>safely extracting</a> <var>request</var>'s <a for=request>body</a>'s
+     <a for=body>source</a>.
+    </ol>
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -3808,9 +3808,9 @@ these steps:
    <li>
     <p>Let <var>copiedRequest</var> be a copy of <var>request</var>.
 
-    <p class="note no-backref">This step doesn't copy the contents of <a for=request>body</a>. If it
-    is non-null, <a lt=body for=request>bodies</a> of <var>request</var> and
-    <var>copiedRequest</var> reference to the same <a for=body>stream</a>.
+    <p class="note no-backref">This step doesn't copy the contents of <a for=/>body</a>. If
+    non-null, <a lt=body for=request>bodies</a> of <var>request</var> and
+    <var>copiedRequest</var> contains references to the same <a for=body>stream</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>copiedRequest</var>. [[!HTML]] [[!SW]]


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/27325
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1167013
   * Firefox: N/A as streaming request body has not been implemented
   * Safari: N/A as streaming request body has not been implemented

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

Fixes w3c/ServiceWorker#1560, fixes #572.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1144.html" title="Last updated on Feb 17, 2021, 12:27 PM UTC (c13ef6f)">Preview</a> | <a href="https://whatpr.org/fetch/1144/3c90676...c13ef6f.html" title="Last updated on Feb 17, 2021, 12:27 PM UTC (c13ef6f)">Diff</a>