### PR TITLE
Add port blocking for tftp, netbios-ns, snmp, rtsp, h323gatestat, h32…

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2238,6 +2238,7 @@ run these steps:
  <tr><td>42<td>name
  <tr><td>43<td>nicname
  <tr><td>53<td>domain
+ <tr><td>69<td>tftp
  <tr><td>77<td>—
  <tr><td>79<td>finger
  <tr><td>87<td>—
@@ -2255,8 +2256,10 @@ run these steps:
  <tr><td>119<td>nntp
  <tr><td>123<td>ntp
  <tr><td>135<td>epmap
+ <tr><td>137<td>netbios-ns
  <tr><td>139<td>netbios-ssn
  <tr><td>143<td>imap
+ <tr><td>161<td>snmp
  <tr><td>179<td>bgp
  <tr><td>389<td>ldap
  <tr><td>427<td>svrloc
@@ -2271,6 +2274,7 @@ run these steps:
  <tr><td>532<td>netnews
  <tr><td>540<td>uucp
  <tr><td>548<td>afp
+ <tr><td>554<td>rtsp
  <tr><td>556<td>remotefs
  <tr><td>563<td>nntps
  <tr><td>587<td>submission
@@ -2278,12 +2282,16 @@ run these steps:
  <tr><td>636<td>ldaps
  <tr><td>993<td>imaps
  <tr><td>995<td>pop3s
+ <tr><td>1719<td>h323gatestat
+ <tr><td>1720<td>h323hostcall
+ <tr><td>1723<td>pptp
  <tr><td>2049<td>nfs
  <tr><td>3659<td>apple-sasl
  <tr><td>4045<td>npp
  <tr><td>5060<td>sip
  <tr><td>5061<td>sips
  <tr><td>6000<td>x11
+ <tr><td>6566<td>sane-port
  <tr><td>6665<td>ircu
  <tr><td>6666<td>ircu
  <tr><td>6667<td>ircu


### PR DESCRIPTION
…3hostcall, pptp, sane-port

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * [blink intent to ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/4Btz5xQ-gXc/m/iPDxYSEgAgAJ)
   * [Firefox](https://www.mozilla.org/en-US/security/advisories/mfsa2021-03/#CVE-2021-23961)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/27990
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: See discussion.
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1677940
   * Safari: See discussion.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1148.html" title="Last updated on Mar 10, 2021, 2:49 PM UTC (6601ba8)">Preview</a> | <a href="https://whatpr.org/fetch/1148/d070ea2...6601ba8.html" title="Last updated on Mar 10, 2021, 2:49 PM UTC (6601ba8)">Diff</a>