### PR TITLE
Remove location URL as field on responses

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1879,16 +1879,6 @@ allowed on the resource fetched by looking at the flag of the response returned.
 the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
-<p>A <a for=/>response</a> can have an associated
-<dfn export for=response id=concept-response-location-url>location URL</dfn> (null, failure, or a
-<a for=/>URL</a>). Unless specified otherwise, <a for=/>response</a> has no
-<a for=response>location URL</a>.
-
-<p class="note no-backref">This concept is used for redirect handling in Fetch and in HTML's
-navigate algorithm. It ensures `<code>Location</code>` has
-<a lt="extracting header values">its value extracted</a> consistently and only once.
-[[!HTML]]
-
 <hr>
 
 <p>A <a for=/>response</a> whose
@@ -2005,6 +1995,36 @@ is a <a>filtered response</a> whose
 
 <p>A <dfn export id=concept-stale-response>stale response</dfn> is a <a for=/>response</a> that is
 not a <a>fresh response</a> or a <a>stale-while-revalidate response</a>.
+
+<hr>
+
+<p>The <dfn export for=response id=concept-response-location-url>location URL</dfn> algorithm of
+given a <a for=/>response</a> <var>response</var> is the following steps. They return null, failure,
+or a <a for=/>URL</a>.
+
+<ol>
+ <li><p>If <var>response</var>'s <a for=response>status</a> is not a <a>redirect status</a>, then
+ return null.
+
+ <li><p>Let <var>location</var> be the result of <a>extracting header list values</a> given
+ `<code>Location</code>` and <var>response</var>'s <a for=response>header list</a>.
+ <!-- https://github.com/whatwg/fetch/issues/814#issuecomment-431366126 -->
+
+ <li>
+  <p>If <var>location</var> is a <a for=header>value</a>, then set <var>location</var> to the result
+  of <a lt="url parser">parsing</a> <var>location</var> with <var>response</var>'s
+  <a for=response>URL</a>.
+
+  <p class=note>If <var>response</var> was constructed through the {{Response}} constructor,
+  <var>response</var>'s <a for=response>URL</a> will be null, meaning that <var>location</var> will
+  only parse successfully if it is an <a>absolute-URL-with-fragment string</a>.
+
+ <li><p>Return <var>location</var>.
+</ol>
+
+<p class=note>The <a for=response>location URL</a> algorithm is exclusively used for redirect
+handling in this standard and in <cite>HTML</cite>'s navigate algorithm which handles redirects
+manually. [[!HTML]]
 
 
 <h4 id=miscellaneous>Miscellaneous</h4>
@@ -3953,16 +3973,6 @@ optional <i>CORS-preflight flag</i>, run these steps:
 
     <p class=note>303 is excluded as certain communities ascribe special status to it.
 
-   <li><p>Let <var>location</var> be the result of <a>extracting header list values</a> given
-   `<code>Location</code>` and <var>actualResponse</var>'s <a for=response>header list</a>.
-
-   <li><p>If <var>location</var> is a <a for=header>value</a>, then set <var>location</var> to the
-   result of <a lt="URL parser">parsing</a> <var>location</var> with <var>actualResponse</var>'s
-   <a for=response>URL</a>.
-
-   <li><p>Set <var>actualResponse</var>'s
-   <a for=response>location URL</a> to <var>location</var>.
-
    <li>
     <p>Switch on <var>request</var>'s
     <a for=request>redirect mode</a>:
@@ -4003,18 +4013,14 @@ optional <i>CORS-preflight flag</i>, run these steps:
  <a>filtered response</a>, and <var>response</var>'s
  <a for=internal>internal response</a> otherwise.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>location URL</a>
- is null, then return <var>response</var>.
+ <li><p>Let <var>locationURL</var> be <var>actualResponse</var>'s <a for=response>location URL</a>.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>location URL</a>
- is failure, then return a <a>network error</a>.
- <!-- only Gecko does this; and even that is currently more complicated -->
+ <li><p>If <var>locationURL</var> is null, then return <var>response</var>.
 
- <li><p>If <var>actualResponse</var>'s
- <a for=response>location URL</a>'s
- <a for=url>scheme</a> is <em>not</em> an
- <a>HTTP(S) scheme</a>, then return a
- <a>network error</a>.
+ <li><p>If <var>locationURL</var> is failure, then return a <a>network error</a>.
+
+ <li><p>If <var>locationURL</var>'s <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then
+ return a <a>network error</a>.
 
  <li><p>If <var>request</var>'s <a for=request>redirect count</a> is
  twenty, return a <a>network error</a>.
@@ -4023,15 +4029,13 @@ optional <i>CORS-preflight flag</i>, run these steps:
  <a for=request>redirect count</a> by one.
 
  <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>cors</code>",
- <var>actualResponse</var>'s <a for=response>location URL</a>
- <a lt="include credential">includes credentials</a>, and <var>request</var>'s
- <a for=request>origin</a> is not <a>same origin</a> with <var>actualResponse</var>'s
- <a for=response>location URL</a>'s <a for=url>origin</a>, then return a <a>network error</a>.
+ <var>locationURL</var> <a>includes credentials</a>, and <var>request</var>'s
+ <a for=request>origin</a> is not <a>same origin</a> with <var>locationURL</var>'s
+ <a for=url>origin</a>, then return a <a>network error</a>.
 
  <li>
   <p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and
-  <var>actualResponse</var>'s <a for=response>location URL</a>
-  <a lt="include credential">includes credentials</a>, then return a <a>network error</a>.
+  <var>locationURL</var> <a>includes credentials</a>, then return a <a>network error</a>.
 
   <p class=note>This catches a cross-origin resource redirecting to a same-origin URL.
 
@@ -4039,11 +4043,11 @@ optional <i>CORS-preflight flag</i>, run these steps:
  <a for=request>body</a> is non-null, and <var>request</var>'s <a for=request>body</a>'s
  <a for=body>source</a> is null, then return a <a>network error</a>.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>location URL</a>'s <a for=url>origin</a> is
- not <a>same origin</a> with <var>request</var>'s <a for=request>current URL</a>'s
- <a for=url>origin</a> and <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a>
- with <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, then set
- <var>request</var>'s <a for=request>tainted origin flag</a>.
+ <li><p>If <var>locationURL</var>'s <a for=url>origin</a> is not <a>same origin</a> with
+ <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> and
+ <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with <var>request</var>'s
+ <a for=request>current URL</a>'s <a for=url>origin</a>, then set <var>request</var>'s
+ <a for=request>tainted origin flag</a>.
 
  <li>
   <p>If one of the following is true
@@ -4074,7 +4078,7 @@ optional <i>CORS-preflight flag</i>, run these steps:
   <p class="note no-backref"><var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>'s
   nullity has already been checked.
 
- <li><p>Append <var>actualResponse</var>'s <a for=response>location URL</a> to <var>request</var>'s
+ <li><p><a for=list>Append</a> <var>locationURL</var> to <var>request</var>'s
  <a for=request>URL list</a>.
 
  <li><p>Invoke <a>set <var>request</var>'s referrer policy on redirect</a> on <var>request</var> and


### PR DESCRIPTION
It does not need to be stored on a response and therefore resulted in confusion.

Also clarify that synthetic responses need to have an absolute URL in the Location header field value (Response.redirect() does this automatically).

Corresponding HTML PR: TODO.

Tests: TODO.

Closes #631, closes #633, closes #958, and closes #1146. (Some of these can be closed due to #1030 making response's URL no longer null for network responses.)

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/2665871
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1170379
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1690286
   * Safari: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1149.html" title="Last updated on Feb 2, 2021, 3:27 PM UTC (e63e41a)">Preview</a> | <a href="https://whatpr.org/fetch/1149/98f23db...e63e41a.html" title="Last updated on Feb 2, 2021, 3:27 PM UTC (e63e41a)">Diff</a>