### PR TITLE
Change default of request's credentials mode

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1423,7 +1423,7 @@ one or more event listeners are registered on an {{XMLHttpRequestUpload}} object
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-credentials-mode>credentials mode</dfn>,
 which is "<code>omit</code>", "<code>same-origin</code>", or
-"<code>include</code>". Unless stated otherwise, it is "<code>omit</code>".
+"<code>include</code>". Unless stated otherwise, it is "<code>same-origin</code>".
 
 <div class="note no-backref">
  <dl>
@@ -5950,8 +5950,6 @@ constructor steps are:
 
  <li><p>Let <var>fallbackMode</var> be null.
 
- <li><p>Let <var>fallbackCredentials</var> be null.
-
  <li><p>Let <var>baseURL</var> be <a>this</a>'s <a>relevant settings object</a>'s
  <a for="environment settings object">API base URL</a>.
 
@@ -5974,8 +5972,6 @@ constructor steps are:
    <a for=request>url</a> is <var>parsedURL</var>.
 
    <li><p>Set <var>fallbackMode</var> to "<code>cors</code>".
-
-   <li><p>Set <var>fallbackCredentials</var> to "<code>same-origin</code>".
   </ol>
 
  <li>
@@ -6142,12 +6138,8 @@ constructor steps are:
  <li><p>If <var>mode</var> is non-null, set <var>request</var>'s
  <a for=request>mode</a> to <var>mode</var>.
 
- <li><p>Let <var>credentials</var> be <var>init</var>["{{RequestInit/credentials}}"] if it
- <a for=map>exists</a>, and <var>fallbackCredentials</var> otherwise.
-
- <li><p>If <var>credentials</var> is non-null, set <var>request</var>'s
- <a for=request>credentials mode</a> to
- <var>credentials</var>.
+ <li><p>If <var>init</var>["{{RequestInit/credentials}}"] <a for=map>exists</a>, then set
+ <var>request</var>'s <a for=request>credentials mode</a> to it.
 
  <li><p>If <var>init</var>["{{RequestInit/cache}}"] <a for=map>exists</a>, then set
  <var>request</var>'s <a for=request>cache mode</a> to it.
@@ -7122,6 +7114,7 @@ Jeena Lee,
 Jeff Carpenter,
 Jeff Hodges,
 Jeffrey Yasskin,
+Jensen Chappell,
 Jesse M. Heines,
 Jianjun Chen,
 Jinho Bang,

--- a/fetch.bs
+++ b/fetch.bs
@@ -2475,13 +2475,10 @@ if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
   <a for=request>credentials mode</a> is
   "<code>include</code>".
 
-  <p class=note>For a <a>CORS-preflight request</a>,
-  <a for=/>request</a>'s
-  <a for=request>credentials mode</a> is always
-  "<code>omit</code>", but for any subsequent
-  <a>CORS requests</a> it might not be. Support therefore needs
-  to be indicated as part of the HTTP response to the <a>CORS-preflight request</a>
-  as well.
+  <p class=note>For a <a>CORS-preflight request</a>, <a for=/>request</a>'s
+  <a for=request>credentials mode</a> is always "<code>same-origin</code>", i.e., it excludes
+  credentials, but for any subsequent <a>CORS requests</a> it might not be. Support therefore needs
+  to be indicated as part of the HTTP response to the <a>CORS-preflight request</a> as well.
 </dl>
 
 <p>An HTTP response to a <a>CORS-preflight request</a> can include the following


### PR DESCRIPTION
This only affects specifications that do not set credentials mode and I'm not aware of any.

Closes #804.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1153.html" title="Last updated on Jan 30, 2021, 11:21 AM UTC (587b2aa)">Preview</a> | <a href="https://whatpr.org/fetch/1153/d070ea2...587b2aa.html" title="Last updated on Jan 30, 2021, 11:21 AM UTC (587b2aa)">Diff</a>