### PR TITLE
fetch() does not need in parallel as fetch already does so

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6733,8 +6733,6 @@ method steps are:
   </ol>
 
  <li>
-  <p>Run the following <a>in parallel</a>:
-
   <p><a for=/>Fetch</a> <var>request</var>.
 
   <p>To <a>process response</a> for <var>response</var>, run these substeps:


### PR DESCRIPTION
There is no need for the fetch() method to go in parallel to run fetch as the main fetch algorithm already does that itself. This also prevents the issue of the main fetch algorithm grabbing global state at the wrong time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1163.html" title="Last updated on Feb 8, 2021, 1:44 PM UTC (f4bcad7)">Preview</a> | <a href="https://whatpr.org/fetch/1163/e5500e5...f4bcad7.html" title="Last updated on Feb 8, 2021, 1:44 PM UTC (f4bcad7)">Diff</a>