### PR TITLE
Remove FTP support

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -210,14 +210,11 @@ number.
 <p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is a <a for=url>scheme</a> that is
 "<code>http</code>" or "<code>https</code>".
 
-<p>A <dfn export>network scheme</dfn> is a <a for=url>scheme</a> that is "<code>ftp</code>" or an
-<a>HTTP(S) scheme</a>.
-
 <p>A <dfn export>fetch scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
-"<code>blob</code>", "<code>data</code>", "<code>file</code>", or a <a>network scheme</a>.
+"<code>blob</code>", "<code>data</code>", "<code>file</code>", or an <a>HTTP(S) scheme</a>.
 
-<p class="note no-backref"><a>HTTP(S) scheme</a>, <a>network scheme</a>, and <a>fetch scheme</a> are
-also used by <cite>HTML</cite>. [[HTML]]
+<p class="note no-backref"><a>HTTP(S) scheme</a> and <a>fetch scheme</a> are also used by
+<cite>HTML</cite>. [[HTML]]
 
 <hr>
 
@@ -2227,11 +2224,8 @@ run these steps:
  <li><p>Let <var>port</var> be <var>url</var>'s
  <a for=url>port</a>.
 
- <li><p>If <var>scheme</var> is "<code>ftp</code>" and <var>port</var> is 20 or 21, then
- return <b>allowed</b>.
-
- <li><p>Otherwise, if <var>scheme</var> is a <a>network scheme</a> and
- <var>port</var> is a <a>bad port</a>, then return <b>blocked</b>.
+ <li><p>If <var>scheme</var> is an <a>HTTP(S) scheme</a> and <var>port</var> is a <a>bad port</a>,
+ then return <b>blocked</b>.
 
  <li><p>Return <b>allowed</b>.
 </ol>
@@ -3399,14 +3393,6 @@ optionally with a <i>recursive flag</i>, run these steps:
     have it expose less sensitive information.
 
    <li>
-    <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is
-    "<code>ftp</code>", <var>request</var>'s <a for=request>client</a>'s
-    <a for=environment>creation URL</a>'s <a for=url>scheme</a> is not "<code>ftp</code>", and
-    <var>request</var>'s <a for=request>reserved client</a> is either null or an
-    <a for=/>environment</a> whose <a for=environment>target browsing context</a> is a
-    <a>nested browsing context</a>, then set <var>response</var> to a <a>network error</a>.
-
-   <li>
     <p>Set <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> to
     "<code>https</code>" if all of the following conditions are true:
 
@@ -3797,28 +3783,6 @@ optionally with a <i>recursive flag</i>, run these steps:
  <dd>
   <p>For now, unfortunate as it is, <code>file</code> <a for=/>URLs</a> are left as an exercise for
   the reader.
-
-  <p>When in doubt, return a <a>network error</a>.
-
- <dt>"<code>ftp</code>"
- <dd>
-  <p>For now, unfortunate as it is, <code>ftp</code> <a for=/>URLs</a> are mostly left as an
-  exercise for the reader.
-
-  <ol>
-   <li><p>Let <var>body</var> be the result of the user agent obtaining content from
-   <var>request</var>'s <a for=request>current URL</a> from the network via FTP. [[!RFC959]]
-
-   <li><p>Let </var>mime</var> be `<code>application/octet-stream</code>`.
-
-   <li><p>If <var>body</var> is the result of the user agent generating a directory listing page for
-   the result of FTP's LIST command, then set |mime| to `<code>text/ftp-dir</code>`.
-
-   <li><p>Return a <a for=/>response</a> whose <a for="response">status message</a> is
-   `<code>OK</code>`, <a for=response>header list</a> consists of a single <a for=/>header</a>
-   whose <a for=header>name</a> is `<code>Content-Type</code>` and whose <a for=header>value</a> is
-   <var>mime</var>, and <a for=response>body</a> is <var>body</var>.
-  </ol>
 
   <p>When in doubt, return a <a>network error</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2215,17 +2215,10 @@ through TLS using ALPN. The protocol cannot be spoofed through HTTP requests in 
 run these steps:
 
 <ol>
- <li><p>Let <var>url</var> be <var>request</var>'s
- <a for=request>current URL</a>.
+ <li><p>Let <var>url</var> be <var>request</var>'s <a for=request>current URL</a>.
 
- <li><p>Let <var>scheme</var> be <var>url</var>'s
- <a for=url>scheme</a>.
-
- <li><p>Let <var>port</var> be <var>url</var>'s
- <a for=url>port</a>.
-
- <li><p>If <var>scheme</var> is an <a>HTTP(S) scheme</a> and <var>port</var> is a <a>bad port</a>,
- then return <b>blocked</b>.
+ <li><p>If <var>url</var>'s <a for=url>scheme</a> is an <a>HTTP(S) scheme</a> and <var>url</var>'s
+ <a for=url>port</a> is a <a>bad port</a>, then return <b>blocked</b>.
 
  <li><p>Return <b>allowed</b>.
 </ol>


### PR DESCRIPTION
Any fetching of ftp: URLs will now result in a network error.

This also removes network scheme in favor of using HTTP(S) scheme exclusively.

Closes #1009.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/issues/17836 (wontfix)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=333943
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1574475
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=221675

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1166.html" title="Last updated on Feb 10, 2021, 4:04 PM UTC (3140ae4)">Preview</a> | <a href="https://whatpr.org/fetch/1166/c8c2b62...3140ae4.html" title="Last updated on Feb 10, 2021, 4:04 PM UTC (3140ae4)">Diff</a>