### PR TITLE
Clarify cors requests need cors response tainting

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1390,7 +1390,8 @@ to not have to set <a for=/>request</a>'s <a for=request>referrer</a>.
   <a>network error</a> if the request is not made to a same-origin URL.
 
   <dt>"<code>cors</code>"
-  <dd>Makes the request a <a>CORS request</a>. Fetch will return a <a>network error</a> if the
+  <dd>For requests whose <a for=request>response tainting</a> is also "<code>cors</code>", makes the
+  request a <a>CORS request</a> — in which case, fetch will return a <a>network error</a> if the
   requested resource does not understand the <a>CORS protocol</a>.
 
   <dt>"<code>no-cors</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -1392,7 +1392,8 @@ to not have to set <a for=/>request</a>'s <a for=request>referrer</a>.
   <dt>"<code>cors</code>"
   <dd>For requests whose <a for=request>response tainting</a> gets set to "<code>cors</code>", makes
   the request a <a>CORS request</a> — in which case, fetch will return a <a>network error</a> if the
-  requested resource does not understand the <a>CORS protocol</a>.
+  requested resource does not understand the <a>CORS protocol</a>, or if the requested resource is
+  one that intentionally does not participate in the <a>CORS protocol</a>.
 
   <dt>"<code>no-cors</code>"
   <dd>Restricts requests to using <a>CORS-safelisted methods</a> and

--- a/fetch.bs
+++ b/fetch.bs
@@ -1390,8 +1390,8 @@ to not have to set <a for=/>request</a>'s <a for=request>referrer</a>.
   <a>network error</a> if the request is not made to a same-origin URL.
 
   <dt>"<code>cors</code>"
-  <dd>For requests whose <a for=request>response tainting</a> is also "<code>cors</code>", makes the
-  request a <a>CORS request</a> — in which case, fetch will return a <a>network error</a> if the
+  <dd>For requests whose <a for=request>response tainting</a> gets set to "<code>cors</code>", makes
+  the request a <a>CORS request</a> — in which case, fetch will return a <a>network error</a> if the
   requested resource does not understand the <a>CORS protocol</a>.
 
   <dt>"<code>no-cors</code>"


### PR DESCRIPTION
This change clarifies a (non-normative) statement that "cors" request mode is what makes a request into a cors request. In fact, for requests with "cors" request mode, "cors" response tainting is also necessary in order for the request to be considered a cors request. So this change refines the relevant statement to make that clear.

Otherwise, without this change, considering the case of a same-origin GET request whose mode is "cors", the spec is claiming that same-origin GET request is a cors request.

But because the spec defines a "cors request" as “an HTTP request that includes an `Origin` header”, a same-origin GET request cannot in fact be a cors request — because it doesn’t include an `Origin` header. (And that’s because for GET requests, the spec requires an `Origin` header to be appended only if the request’s response tainting is "cors"; but for same-origin requests, the request’s response tainting will be "basic".)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1170.html" title="Last updated on Feb 17, 2021, 10:23 AM UTC (73a43d4)">Preview</a> | <a href="https://whatpr.org/fetch/1170/3c90676...73a43d4.html" title="Last updated on Feb 17, 2021, 10:23 AM UTC (73a43d4)">Diff</a>