### PR TITLE
Add more parameters to "obtain a connection"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2140,9 +2140,11 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
 
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
 <var>origin</var>, <var>credentials</var>, an optional boolean
-<dfn export for=obtain-a-connection><var>http3Only</var></dfn> (default: false), and an optional
-boolean <dfn export for=obtain-a-connection><var>dedicated</var></dfn> (default: false), run these
+<dfn export for="obtain a connection"><var>http3Only</var></dfn> (default: false), and an optional
+boolean <dfn export for="obtain a connection"><var>dedicated</var></dfn> (default: false), run these
 steps:
+<!-- http3Only and dedicated have been added for WebTransport -->
+
 <ol>
  <li>
   <p>If <var>dedicated</var> is false, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -89,6 +89,24 @@ url:https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-4.2;
         "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
         "publisher": "IETF",
         "title": "Structured Field Values for HTTP"
+    },
+    "HTTP3": {
+        "authors": ["M. Bishop, Ed."],
+        "href": "https://tools.ietf.org/html/draft-ietf-quic-http",
+        "publisher": "IETF",
+        "title": "Hypertext Transfer Protocol Version 3 (HTTP/3)"
+    },
+    "WEBTRANSPORT-HTTP3": {
+        "authors": ["V. Vasiliev"],
+        "href": "https://tools.ietf.org/html/draft-ietf-webtrans-http3",
+        "publisher": "IETF",
+        "title": "WebTransport over HTTP/3"
+    },
+    "HTTP3-DATAGRAM": {
+        "authors": ["David Schinazi", "Lucas Pardue"],
+        "href": "https://tools.ietf.org/html/draft-ietf-masque-h3-datagram",
+        "publisher": "IETF",
+        "title": "Using QUIC Datagrams with HTTP/3"
     }
 }
 </pre>
@@ -2121,12 +2139,25 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
 <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
-<var>origin</var>, and <var>credentials</var>, run these steps:
-
+<var>origin</var>, <var>credentials</var>, an optional boolean
+<dfn export for=obtain-a-connection><var>http3Only</var></dfn> (default: false), and an optional
+boolean <dfn export for=obtain-a-connection><var>dedicated</var></dfn> (default: false), run these
+steps:
 <ol>
- <li><p>If the user agent's <a>connection pool</a> contains a <a>connection</a> whose <b>key</b> is
- <var>key</var>, <b>origin</b> is <var>origin</var>, and <b>credentials</b> is
- <var>credentials</var>, then return that <a>connection</a>.
+ <li>
+  <p>If <var>dedicated</var> is false, then:
+
+  <ol>
+   <li><p>Let <var>connections</var> be a set of <a>connections</a> in the user agent's
+   <a>connection pool</a> each of whose <b>key</b> is <var>key</var>, <b>origin</b> is
+   <var>origin</var>, and <b>credentials</b> is <var>credentials</var>.
+
+   <li><p>If <var>connections</var> is not empty and <var>http3Only</var> is false, then return
+   one of <var>connections</var>.
+
+   <li><p>If there is an HTTP/3 <a>connection</a> in <var>connections</var>, then return that
+   <a>connection</a>.
+  </ol>
 
  <li><p>Let <var>connection</var> be null.
 
@@ -2138,6 +2169,12 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
     <p>Set <var>connection</var> to the result of establishing an HTTP connection to
     <var>origin</var>. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
     [[!TLS]]
+
+    <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]
+
+    <p>When establishing an HTTP/3 connection, include SETTINGS_ENABLE_WEBTRANSPORT with a value of
+    1 and H3_DATAGRAM with a value of 1 in the initial SETTINGS frame. [[!WEBTRANSPORT-HTTP3]]
+    [[!HTTP3-DATAGRAM]]
 
     <p>If <var>credentials</var> is false, then do <em>not</em> send a TLS client certificate.
 
@@ -2154,9 +2191,9 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
    <li><p>Return failure.
   </ol>
 
- <li><p>Add <var>connection</var> to the user agent's <a>connection pool</a> with <b>key</b> being
- <var>key</var>, <b>origin</b> being <var>origin</var>, and <b>credentials</b> being
- <var>credentials</var>.
+ <li><p>If <var>dedicated</var> is false, then add <var>connection</var> to the user agent's
+ <a>connection pool</a> with <b>key</b> being <var>key</var>, <b>origin</b> being <var>origin</var>,
+ and <b>credentials</b> being <var>credentials</var>.
 
  <li><p>Return <var>connection</var>.
 </ol>


### PR DESCRIPTION
Add more parameters to the "obtain a connection" operation, as we want to create a WebTransport over HTTP/3 connection for WebTransport.

This is for w3c/webtransport#128.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * We'll test this as part of WebTransport
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A: This is an infrastructure change needed by WebTransport

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1171.html" title="Last updated on Mar 3, 2021, 2:39 PM UTC (5ba523f)">Preview</a> | <a href="https://whatpr.org/fetch/1171/24a8670...5ba523f.html" title="Last updated on Mar 3, 2021, 2:39 PM UTC (5ba523f)">Diff</a>