### PR TITLE
Clarify: credentials param affect response too

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1434,7 +1434,7 @@ which is "<code>omit</code>", "<code>same-origin</code>", or
 
   <dt>"<code>same-origin</code>"
   <dd>Include credentials with requests made to same-origin URLs, and use any credentials sent back
-  in responses from same-origin URLs
+  in responses from same-origin URLs.
 
   <dt>"<code>include</code>"
   <dd>Always includes credentials with this request, and always use any credentials sent back in the

--- a/fetch.bs
+++ b/fetch.bs
@@ -1429,13 +1429,16 @@ which is "<code>omit</code>", "<code>same-origin</code>", or
 <div class="note no-backref">
  <dl>
   <dt>"<code>omit</code>"
-  <dd>Excludes credentials from this request.
+  <dd>Excludes credentials from this request, and causes any credentials sent back in the response
+  to be ignored.
 
   <dt>"<code>same-origin</code>"
-  <dd>Include credentials with requests made to same-origin URLs.
+  <dd>Include credentials with requests made to same-origin URLs, and use any credentials sent back
+  in responses from same-origin URLs
 
   <dt>"<code>include</code>"
-  <dd>Always includes credentials with this request.
+  <dd>Always includes credentials with this request, and always use any credentials sent back in the
+  response.
  </dl>
 
  <p><a for=/>Request</a>'s <a for=request>credentials mode</a> controls the flow of


### PR DESCRIPTION
This change updates the descriptions of all “credentials mode” values, to clarify that the values affect whether browsers use credentials sent back in responses (e.g., any Set-Cookie response headers) — not just whether credentials are sent with the request. Related: https://github.com/mdn/content/pull/2468


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1174.html" title="Last updated on Feb 19, 2021, 2:58 PM UTC (8cc1ae8)">Preview</a> | <a href="https://whatpr.org/fetch/1174/c64f074...8cc1ae8.html" title="Last updated on Feb 19, 2021, 2:58 PM UTC (8cc1ae8)">Diff</a>