### PR TITLE
Clarify RequestInit/credentials affects response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5889,8 +5889,9 @@ object), initially null.
    <dd>A string indicating whether credentials will be sent with the request always, never, or only
    when sent to a same-origin URL — as well as whether any credentials sent back in the response
    will be used always, never, or only when received from a same-origin URL. Sets
-   <var>request</var>'s {{Request/credentials}}. If {{RequestInit/credentials}} is unspecified, the
-   <a>credentials mode</a> for <var>request</var> defaults to "<code>same-origin</code>".
+   <var>request</var>'s {{Request/credentials}}. If <var>input</var> is a string and
+   {{RequestInit/credentials}} is unspecified, the <a>credentials mode</a> for <var>request</var>
+   defaults to "<code>same-origin</code>".
 
    <dt>{{RequestInit/cache}}
    <dd>A string indicating how the request will interact with the browser's cache to set

--- a/fetch.bs
+++ b/fetch.bs
@@ -5883,15 +5883,15 @@ object), initially null.
 
    <dt>{{RequestInit/mode}}
    <dd>A string to indicate whether the request will use CORS, or will be restricted to same-origin
-   URLs. Sets <var>request</var>'s {{Request/mode}}.
+   URLs. Sets <var>request</var>'s {{Request/mode}}. If <var>input</var> is a string, it defaults to
+   "<code>cors</code>".
 
    <dt>{{RequestInit/credentials}}
    <dd>A string indicating whether credentials will be sent with the request always, never, or only
    when sent to a same-origin URL — as well as whether any credentials sent back in the response
    will be used always, never, or only when received from a same-origin URL. Sets
-   <var>request</var>'s {{Request/credentials}}. If <var>input</var> is a string and
-   {{RequestInit/credentials}} is unspecified, the <a>credentials mode</a> for <var>request</var>
-   defaults to "<code>same-origin</code>".
+   <var>request</var>'s {{Request/credentials}}. If <var>input</var> is a string, it defaults to
+   "<code>same-origin</code>".
 
    <dt>{{RequestInit/cache}}
    <dd>A string indicating how the request will interact with the browser's cache to set

--- a/fetch.bs
+++ b/fetch.bs
@@ -5887,7 +5887,10 @@ object), initially null.
 
    <dt>{{RequestInit/credentials}}
    <dd>A string indicating whether credentials will be sent with the request always, never, or only
-   when sent to a same-origin URL. Sets <var>request</var>'s {{Request/credentials}}.
+   when sent to a same-origin URL — as well as whether any credentials sent back in the response
+   will be used always, never, or only when received from a same-origin URL. Sets
+   <var>request</var>'s {{Request/credentials}}. If {{RequestInit/credentials}} is unspecified, the
+   <a>credentials mode</a> for <var>request</var> defaults to "<code>same-origin</code>".
 
    <dt>{{RequestInit/cache}}
    <dd>A string indicating how the request will interact with the browser's cache to set


### PR DESCRIPTION
This change is a follow-up to the previous change at https://github.com/whatwg/fetch/commit/00344d2 which clarified the effects of the “credentials mode” value. This change similarly refines the description of the RequestInit/credentials member — while adding a statement that the behavior defaults to "same-origin" if RequestInit/credentials is not specified in the Request instance.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1178.html" title="Last updated on Mar 1, 2021, 6:48 AM UTC (38d218d)">Preview</a> | <a href="https://whatpr.org/fetch/1178/00344d2...38d218d.html" title="Last updated on Mar 1, 2021, 6:48 AM UTC (38d218d)">Diff</a>