### PR TITLE
Editorial: remove a reference to "responsible document"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1449,8 +1449,8 @@ not always relevant and might require different behavior.
  submission algorithm.
 
  <p>CSP will also need to check <a for=/>request</a>'s <a for=request>client</a>'s
- <a for="environment settings object">responsible document</a>'s
- <a for=Document>browsing context</a>'s <a>ancestor browsing contexts</a> for various CSP
+ <a for="environment settings object">global object</a>'s
+ <a for=Window>browsing context</a>'s <a>ancestor browsing contexts</a> for various CSP
  directives.
 </div>
 


### PR DESCRIPTION
Part of https://github.com/whatwg/html/issues/4335.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1179.html" title="Last updated on Feb 24, 2021, 5:27 PM UTC (e7d765b)">Preview</a> | <a href="https://whatpr.org/fetch/1179/6ad9998...e7d765b.html" title="Last updated on Feb 24, 2021, 5:27 PM UTC (e7d765b)">Diff</a>