### PR TITLE
Correct location URL algorithm fragment handling

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2044,8 +2044,8 @@ or a <a for=/>URL</a>.
   only parse successfully if it is an <a>absolute-URL-with-fragment string</a>.
 
  <li>
-  <p>If <var>locationURL</var>'s <a for=url>fragment</a> is null, then set <var>locationURL</var>'s
-  <a for=url>fragment</a> to <var>requestFragment</var>.
+  <p>If <var>location</var> is a <a for=/>URL</a> whose <a for=url>fragment</a> is null, then set
+  <var>location</var>'s <a for=url>fragment</a> to <var>requestFragment</var>.
 
   <p class=note>This ensures that synthetic (indeed, all) responses follow the processing model for
   redirects defined by HTTP. [[HTTP-SEMANTICS]]
@@ -7358,6 +7358,7 @@ Tiancheng "Timothy" Gu,
 Tobie Langel,
 Tom Schuster,
 Tomás Aparicio,
+triple-underscore<!-- GitHub -->,
 保呂毅 (Tsuyoshi Horo),
 Tyler Close,
 Ujjwal Sharma,

--- a/fetch.bs
+++ b/fetch.bs
@@ -4821,9 +4821,6 @@ these steps:
         <ol>
          <li><p>Let <var>bytes</var> be the transmitted bytes.
 
-         <li><p>Increase <var>response</var>'s <a for=response>body</a>'s <a for=body>transmitted
-         bytes</a> with <var>bytes</var>' length.
-
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
          `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 


### PR DESCRIPTION
a876e5dc87f5e18732aada8a12f6b8cd6eb39340 made a typo and did not account for it potentially not being a URL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1180.html" title="Last updated on Feb 26, 2021, 4:54 PM UTC (30a78d4)">Preview</a> | <a href="https://whatpr.org/fetch/1180/a876e5d...30a78d4.html" title="Last updated on Feb 26, 2021, 4:54 PM UTC (30a78d4)">Diff</a>