### PR TITLE
Initial resource timing integration.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4283,16 +4283,6 @@ these steps:
  <a for=body>stream</a> is still being enqueued to after returning.</span>
 </ol>
 
- <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
- Resource Timing entry later. This step is done here, as resource-timing entries
- are available only for HTTP fetchesm, including ones that are handled by service-workers or HTTP
- cache, and not for data/blob/file fetches, and are only available after all the CORS checks have
- passed for the request.
- <li><p>Return <var>response</var>. <span class="note no-backref">Typically
- <var>actualResponse</var>'s <a for=response>body</a>'s
- <a for=body>stream</a> is still being enqueued to after returning.</span>
-</ol>
-
 
 <h3 id=http-redirect-fetch>HTTP-redirect fetch</h3>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -187,28 +187,33 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
+
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
+
  <dt><dfn for="fetch params">redirect timing info list</dfn> (default « »)
- <dd>A <a for=/>list</a> of <a for=/>fetch timing info</a>.
+ <dd>A <a for=/>list</a> of 0 or more <a for=/>fetch timing info</a>.
 </dl>
 
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
 information required by the resource timing and navigation timing specs. It has the following
 <a for=struct>items</a>:
+
 <dl>
- <dt><dfn export for="fetch timing info">start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">fetch start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">worker start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">request start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">response start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">response end time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">redirect start time</dfn> (default zero)
- <dt><dfn export for="fetch timing info">redirect end time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">fetch start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">worker start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">request start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">response start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">response end time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">redirect start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">redirect end time</dfn> (default 0)
  <dd>A <a typedef for=/>DOMHighResTimeStamp</a>.
- <dt><dfn export for="fetch timing info">encoded body size</dfn> (default zero)
- <dt><dfn export for="fetch timing info">decoded body size</dfn> (default zero)
+
+ <dt><dfn export for="fetch timing info">encoded body size</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">decoded body size</dfn> (default 0)
  <dd>A number.
+
  <dt><dfn export for="fetch timing info">connection timing info</dfn> (default null)
  <dd>Null or a <a for=/>connection timing info</a>.
 </dl>
@@ -216,13 +221,15 @@ information required by the resource timing and navigation timing specs. It has 
 <p>A <dfn export>connection timing info</dfn> is a <a for=/>struct</a> used to maintain timing
 information pertaining to the process of obtaining a connection. It has the following
 <a for=struct>items</a>:
+
 <dl>
-  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default zero)
-  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default zero)
-  <dt><dfn export for="connection timing info">connection start time</dfn> (default zero)
-  <dt><dfn export for="connection timing info">connection end time</dfn> (default zero)
-  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default zero)
+  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
   <dd>A <a typedef for=/>DOMHighResTimeStamp</a>
+
   <dt><dfn export for="connection timing info">alpn negotiated protocol</dfn> (default empty string)
   <dd>A string.
 </dl>
@@ -230,9 +237,10 @@ information pertaining to the process of obtaining a connection. It has the foll
 <p class=note>Note that timestamps in this spec are usually unsafe, and are meant to be coarsened
 and normalized to a <a for=/>global object</a> prior to being exposed.
 
-<p>To <dfn>clamp connection timing to fetch timing</dfn>, given <a for=/>connection timing info</a>
-<var>timingInfo</var> and <a typedef for=/>DOMHighResTimeStamp</a> <var>defaultStartTime</var>, run these
-steps:
+<p>To <dfn>clamp connection timing to fetch timing</dfn>, given a
+<a for=/>connection timing info</a> <var>timingInfo</var> and a
+<a typedef for=/>DOMHighResTimeStamp</a> <var>defaultStartTime</var>, run these steps:
+
 <ol>
  <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
  greater than <var>defaultStartTime</var>, then return <var>timingInfo</var>.
@@ -247,8 +255,10 @@ steps:
  set to <var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>.
 </ol>
 
-<p>To <dfn>update timing info from stored response</dfn>, given <a for=/>connection timing info</a>
-<var>timingInfo</var> and <a for=/>response</a> <var>response</var>, perform the following steps:
+<p>To <dfn>update timing info from stored response</dfn>, given a
+<a for=/>connection timing info</a> <var>timingInfo</var> and a <a for=/>response</a>
+<var>response</var>, perform the following steps:
+
 <ol>
  <li><p>Let <var>storedTimingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
@@ -1996,7 +2006,7 @@ the response of a redirect has to be set if it was set for previous responses in
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-info>timing info</dfn> (Null or a
+<dfn for=response id=concept-response-timing-info>timing info</dfn> (null or a
 <a for=/>fetch timing info</a>), which is initially null.
 
 <hr>
@@ -2249,9 +2259,9 @@ false), and an optional boolean <dfn export for="obtain a connection"><var>dedic
 
   <ol>
    <li>
-    <p>Set <var>connection</var> to the result of establishing an HTTP connection to
-    <var>origin</var>, following the requirements for
-    <a>recording connection timing info</a> given <var>connection</var>.
+    <p>Set <var>connection</var> to a new <a for=/>connection</a>.
+    <a for=/>Record connection timing info</a> given <var>connection</var> and use
+    <var>connection</var> to establish an HTTP connection to <var>origin</var>.
     [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]] [[!TLS]]
 
     <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]
@@ -2291,9 +2301,10 @@ clearly stipulates that <a>connections</a> are keyed on
 <!-- See https://github.com/whatwg/fetch/issues/114#issuecomment-143500095 for when we make
      WebSocket saner -->
 
-<p>The requirements for <dfn>recording connection timing info</dfn> given a <a for=/>connection</a>
-<var>connection</var> and its <a for=/>connection timing info</a> <var>timingInfo</var>, are as
-follows:
+<p>To <dfn>record connection timing info</dfn> given a <a for=/>connection</a>
+<var>connection</var>, let <var>timingInfo</var> be <var>connection</var>'s
+<a for=connection>connection timing info</a> and observe these requirements:
+
 <ul>
  <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>
  should be the <a for=/>unsafe shared current time</a> immediately before starting the domain
@@ -2307,76 +2318,77 @@ follows:
  be the <a for=/>unsafe shared current time</a> immediately before establishing the connection to
  the server or proxy.
 
- <li><p><var>timingInfo</var>'s <a for="connection timing info">connection end time</a> should be
- the <a for=/>unsafe shared current time</a> immediately after establishing the connection to the
- server or proxy, as follows:
- <ul>
-  <li><p>The returned time must include the time interval to establish the transport
-  connection, as well as other time intervals such as SOCKS authentication. It
-  must include the time interval to complete enough of the TLS handshake to
-  request the resource.
+ <li>
+  <p><var>timingInfo</var>'s <a for="connection timing info">connection end time</a> should be the
+  <a for=/>unsafe shared current time</a> immediately after establishing the connection to the
+  server or proxy, as follows:
 
-  <li><p>If the user agent used TLS False Start [[RFC7918]] for this connection,
-  this interval must not include the time needed to receive the server's
-  Finished message.
+  <ul>
+   <li><p>The returned time must include the time interval to establish the transport connection, as
+   well as other time intervals such as SOCKS authentication. It must include the time interval to
+   complete enough of the TLS handshake to request the resource.
 
-  <li><p>If the user agent sends the request with early data [[RFC8470]] without
-  waiting for the full handshare to complete, this interval must not include
-  the time needed to receive the server's ServerHello message.
+   <li><p>If the user agent used TLS False Start for this connection, this interval must not include
+   the time needed to receive the server's Finished message. [[RFC7918]]
 
-  <li><p>If the user agent waits for full handshake completion to send the
-  request, this interval includes the full TLS handshake even if other
-  requests were sent using early data on <var>connection</var>.
- </ul>
+   <li><p>If the user agent sends the request with early data without waiting for the full handshare
+   to complete, this interval must not include the time needed to receive the server's ServerHello
+   message. [[RFC8470]]
 
- <p class=note>Example: Suppose the user agent establishes an HTTP/2 connection
- over TLS 1.3 to send a GET request and a POST request. It sends the ClientHello
- at time <code>t1</code> and then sends the GET request with early data. The
- POST request is not safe [[HTTP-SEMANTICS]] (section 4.2.1), so the user agent waits
- to complete the handshake at time <code>t2</code> before sending it.  Although
- both requests used the same connection, the GET request reports a connectEnd
- value of <code>t1</code>, while the POST request reports a connectEnd value for
- <code>t2</code>.
+   <li><p>If the user agent waits for full handshake completion to send the request, this interval
+   includes the full TLS handshake even if other requests were sent using early data on
+   <var>connection</var>.
+  </ul>
+
+  <p class=example>Suppose the user agent establishes an HTTP/2 connection over TLS 1.3 to send a
+  <code>GET</code> request and a <code>POST</code> request. It sends the ClientHello at time
+  <var>t1</var> and then sends the <code>GET</code> request with early data. The <code>POST</code>
+  request is not safe ([[HTTP-SEMANTICS]], section 4.2.1), so the user agent waits to complete the
+  handshake at time <var>t2</var> before sending it. Although both requests used the same
+  connection, the <code>GET</code> request reports a connection end time of <var>t1</var>, while the
+  <code>POST</code> request reports <var>t2</var>.
 
  <li><p>If a secure transport is used, <var>timingInfo</var>'s
  <a for="connection timing info">secure connection start time</a> should be the result of calling
  <a for=/>unsafe shared current time</a> immmediately before starting the handshake process to
  secure <var>connection</var>. [[!TLS]]
 
- <li><p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>
- should be the <var>connection</var>'s ALPN Protocol ID as specified in [[RFC7301]], with the
- following caveats:
- <ul>
-  <li><p>When a proxy is configured, if a tunnel connection is established then this attribute
-  must return the ALPN Protocol ID of the tunneled protocol, otherwise it must return the ALPN
-  Protocol ID of the first hop to the proxy.
+ <li>
+  <p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a> should be
+  the <var>connection</var>'s ALPN Protocol ID, with the following caveats: [[RFC7301]]
+  <!-- TODO Since it's in octets, I guess we have to isomorphic decode it? -->
 
-  <li><p>Octets in the ALPN protocol must not be percent-encoded if they are valid token
-  characters except "%", and when using percent-encoding, uppercase hex digits must be used.
+  <ul>
+   <li><p>When a proxy is configured, if a tunnel connection is established then this must be the
+   ALPN Protocol ID of the tunneled protocol, otherwise it must be the ALPN Protocol ID of the first
+   hop to the proxy.
 
-  <li><p>Formally registered ALPN protocol IDs are documented by <a href=
-  "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">
-  IANA</a>.
+   <li><p>Octets in the ALPN Protocol ID must not be percent-encoded if they are valid token
+   characters except "%", and when using percent-encoding, uppercase hex digits must be used.
+   <!-- TODO I don't think we have to state this as the network does this. -->
 
-  <li><p>In case the user agent is using an experimental, non-registered protocol, the user
-  agent must use the ALPN negotiated value if any. If ALPN was not used for protocol
-  negotiations, the user agent MAY use another descriptive string.
+   <li><p>Formally registered ALPN Protocol IDs are documented by
+   <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">IANA</a>.
+   <!-- TODO I'm not sure we need to reference this? -->
 
-  <p class="note">The "h3" ALPN ID is defined for the final version
-  of the HTTP/3 protocol in the
-  <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3
-  Internet Draft</a>.
+   <li>
+    <p>In case the user agent is using an experimental, non-registered protocol, the user agent must
+    use the used ALPN Protocol ID, if any. If ALPN was not used for protocol negotiations, the user
+    agent may use another descriptive string.
 
-  <p class="note">Note that <a for="connection timing info">alpn negotiated protocol</a> is
-  intended to identify the network protocol in use for the fetch regardless of how it was
-  actually negotiated; that is, even if ALPN is not used to negotiate the network protocol,
-  this attribute still uses the ALPN Protocol IDs to indicate the protocol in use.
- </ul>
+    <p class=note>The "<code>h3</code>" ALPN Protocol ID is defined for the final version of the
+    HTTP/3 protocol in the
+    <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3 Internet Draft</a>.
 
- <p class="note">The <a for="connection">timingInfo</a> for the connection might be saved in the
- <a>connection pool</a>, and later retrieved alongside the connection if the connection is reused.
- The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that details of reused
- connections are not exposed.
+    <p class=note><var>connection</var>'s
+    <a for="connection timing info">alpn negotiated protocol</a> is intended to identify the network
+    protocol in use regardless of how it was actually negotiated; that is, even if ALPN is not used
+    to negotiate the network protocol, this is the ALPN Protocol IDs that indicates the protocol in
+    use.
+  </ul>
+
+  <p class=note>The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that
+  details of reused connections are not exposed.
 </ol>
 
 <h3 id=network-partition-keys>Network partition keys</h3>
@@ -3483,11 +3495,12 @@ an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseEndOfBody</var></dfn>,
 an optional algorithm <dfn export for=fetch><var>processResponseDone</var></dfn>, and an optional
 boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run the steps
-below. If given, <var>processRequestBody</var> must be an algorithm accepting an integer representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be
+below. If given, <var>processRequestBody</var> must be an algorithm accepting an integer
+representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be
 an algorithm accepting no arguments. If given, <var>processResponse</var> must be an algorithm
 accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be an
-algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>.
-If given, <var>processResponseDone</var> must be an algorithm accepting no arguments.
+algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>. If
+given, <var>processResponseDone</var> must be an algorithm accepting no arguments.
 
 <p>An ongoing <a for=/>fetch</a> can be
 <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> with flag <var>aborted</var>,
@@ -3612,9 +3625,8 @@ steps:
 
  <li><p>Let <var>response</var> be null.
 
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a> be a new
- <a for=/>fetch timing info</a> with its <a for="fetch timing info">fetch start time</a> set to the
- <a for=/>unsafe shared current time</a>.
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+ <a for="fetch timing info">fetch start time</a> to the <a for=/>unsafe shared current time</a>.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
@@ -3940,15 +3952,17 @@ steps:
   </ol>
 </ol>
 
-<p>To <dfn>finalize response</dfn> given <a for=/>response</a> <var>response</var> and
-<a for=/>fetch params</a> <var>fetchParams</var>, perform the following steps:
+<p>To <dfn>finalize response</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var> and a
+<a for=/>response</a> <var>response</var>, run these steps:
+
 <ol>
- <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>
+ <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
  <li><p>If <var>timingInfo</var> is not null, then set <var>timingInfo</var>'s
  <a for="fetch timing info">response end time</a> to the <a for=/>unsafe shared current time</a>.
 
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>done flag</a>.
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+ <a for=request>done flag</a>.
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
  then <a>queue a fetch task</a> given <var>fetchParams</var>'s
@@ -3956,14 +3970,15 @@ steps:
  <a for="fetch params">task destination</a>.
 </ol>
 
-<p>To <dfn export>finalize and report timing</dfn> given <a for=/>response</a>
-<var>response</var>, a <a for=/>global object</a> <var>global</var> and a DOMString
-<var>initiatorType</var> (default "<code>other</code>"), perform the following steps:
-<ol>
- <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or empty, then return.
+<p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
+<var>response</var>, a <a for=/>global object</a> <var>global</var>, and a <a for=/>string</a>
+<var>initiatorType</var> (default "<code>other</code>"), run these steps:
 
- <li><p>Let <var>originalURL</var> be <var>response</var>'s <a for=response>URL list</a>'s
- first item.
+<ol>
+ <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or
+ <a for=list lt="is empty">empty</a>, then return.
+
+ <li><p>Let <var>originalURL</var> be <var>response</var>'s <a for=response>URL list</a>[0].
 
  <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
@@ -3972,12 +3987,12 @@ steps:
  <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
  <a for="fetch timing info">fetch start time</a>.
 
- <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not zero,
- then set <var>startTime</var> to <var>timingInfo</var>'s
+ <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not 0, then
+ set <var>startTime</var> to <var>timingInfo</var>'s
  <a for="fetch timing info">redirect start time</a>.
 
- <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
- set <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
+ <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then set
+ <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
  <a for="fetch timing info">start time</a> and <a for="fetch timing info">fetch start time</a> set
  to <var>startTime</var>.
 
@@ -3988,7 +4003,9 @@ steps:
 
  <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
  <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
+ <!-- TODO -->
 </ol>
+
 
 <h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
@@ -4112,8 +4129,7 @@ these steps:
 
  <li><p>Let <var>actualResponse</var> be null.
 
- <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing
- info</a>.
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
  <li>
   <p>If <var>request</var>'s <a>service-workers mode</a> is "<code>all</code>", then:
@@ -4123,6 +4139,7 @@ these steps:
    <var>request</var>.
 
    <li><p>Let <var>workerStartTime</var> be the <a for=/>unsafe shared current time</a>.
+   <!-- TODO: can we rename this to service worker start time? -->
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
@@ -4134,7 +4151,7 @@ these steps:
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
      <a for="fetch timing info">worker start time</a> to <var>workerStartTime</var>.
 
-     <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
+     <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.
 
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
@@ -4272,19 +4289,20 @@ these steps:
  <li><p>Let <var>redirectTimingList</var> be <var>fetchParams</var>'s
  <a for="fetch params">redirect timing info list</a>.
 
- <li><p>If <var>redirectTimingList</var> is not empty, set <var>timingInfo</var>'s
- <a for="fetch timing info">redirect start time</a> to <var>redirectTimingList</var>'s first item's
- <a for="fetch timing info">fetch start time</a> and
+ <li><p>If <var>redirectTimingList</var> <a for=list>is not empty</a>, then set
+ <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> to
+ <var>redirectTimingList</var>[0]'s <a for="fetch timing info">fetch start time</a> and
  <a for="fetch timing info">redirect end time</a> to <var>redirectTimingList</var>'s last item's
  <a for="fetch timing info">fetch start time</a>.
 
- <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.
+ <li>
+  <p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.
 
- <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
- Resource Timing entry later. This step is done here, as resource-timing entries
- are available only for HTTP fetches, including ones that are handled by service-workers or HTTP
- cache, and not for data/blob/file fetches, and are only available after all the CORS checks have
- passed for the request.
+  <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
+  Resource Timing entry later. This step is done here, as resource-timing entries are available only
+  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for,
+  e.g., <code>data:</code>, <code>blob:</code> URL fetches, and are only available after all the
+  relevant security checks have succeeded.
 
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s
@@ -4803,7 +4821,7 @@ steps. They return a <a for=/>response</a>.
 
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
-     <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
+     <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.
     </ol>
 
@@ -5025,14 +5043,15 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
      <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to
      the <a for=/>unsafe shared current time</a> immediately after the user agent's HTTP parser
-     receives the first byte of the response (e.g. frame header bytes for HTTP/2, or response
-     status line for HTTP/1.x), regardless of the response's status code.
+     receives the first byte of the response (e.g., frame header bytes for HTTP/2, or response
+     status line for HTTP/1.x).
 
      <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
      <li>
       <p>Any <a for=/>responses</a> whose <a for=response>status</a> is in the range 100 to 199,
-      inclusive, and is not 101, are to be ignored.
+      inclusive, and is not 101, are to be ignored, except for the purposes of setting
+      <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> above.
 
       <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by a
       "final" <a for=/>response</a>.
@@ -5235,7 +5254,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
        normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
        <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>finalize response</a> for
-       <var>response</var> and <var>fetchParams</var>, and abort these in-parallel steps.
+       <var>fetchParams</var> and <var>response</var>, and abort these in-parallel steps.
       </ol>
     </ol>
 
@@ -5243,7 +5262,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li><a for=/>Finalize response</a> for <var>response</var> and <var>fetchParams</var>.
+     <li><a for=/>Finalize response</a> for <var>fetchParams</var> and <var>response</var>.
 
      <li><p>Let <var>aborted</var> be the termination's aborted flag.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3936,7 +3936,9 @@ steps:
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a ofr=request>done flag</a>.
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
- call <var>fetchParams</var>'s <a for="fetch params">process response done</a>.
+ then <a>queue a fetch task</a> given <var>fetchParams</var>'s
+ <a for="fetch params">process response done</a> and <var>fetchParams</var>'s
+ <a for="fetch params">task destination</a>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -188,6 +188,9 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
+ <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
+ <dd>A boolean.
+
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
 
@@ -208,7 +211,7 @@ information required by the resource timing and navigation timing specs. It has 
  <dt><dfn export for="fetch timing info">response end time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">redirect start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">redirect end time</dfn> (default 0)
- <dd>A <a typedef for=/>DOMHighResTimeStamp</a>.
+ <dd>A {{DOMHighResTimeStamp}}.
 
  <dt><dfn export for="fetch timing info">encoded body size</dfn> (default 0)
  <dt><dfn export for="fetch timing info">decoded body size</dfn> (default 0)
@@ -228,32 +231,48 @@ information pertaining to the process of obtaining a connection. It has the foll
   <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
   <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
   <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
-  <dd>A <a typedef for=/>DOMHighResTimeStamp</a>
+  <dd>A {{DOMHighResTimeStamp}}.
 
   <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
   <a for=/>byte sequence</a>)
   <dd>A <a for=/>byte sequence</a>.
 </dl>
 
-<p class=note>Note that timestamps in this spec are usually unsafe, and are meant to be coarsened
-and normalized to a <a for=/>global object</a> prior to being exposed.
-
-<p>To <dfn>clamp connection timing to fetch timing</dfn>, given a
-<a for=/>connection timing info</a> <var>timingInfo</var> and a
-<a typedef for=/>DOMHighResTimeStamp</a> <var>defaultStartTime</var>, run these steps:
+<p>To <dfn>clamp and coarsen connection timing info</dfn>, given a
+<a for=/>connection timing info</a> <var>timingInfo</var>, a {{DOMHighResTimeStamp}}
+<var>defaultStartTime</var>, and a boolean <var>crossOriginIsolatedCapability</var>, run these
+steps:
 
 <ol>
  <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
- greater than <var>defaultStartTime</var>, then return <var>timingInfo</var>.
+ less than <var>defaultStartTime</var>, then return a new <a for=/>connection timing info</a> whose
+ <a for="connection timing info">domain lookup start time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">domain lookup end time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">connection start time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">connection end time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">secure connection start time</a> is <var>defaultStartTime</var>,
+ and <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
+ <a for="connection timing info">ALPN negotiated protocol</a>.
 
- <li><p>Return a new <a for=/>connection timing info</a>, with
- <a for="connection timing info">domain lookup start time</a> set to <var>defaultStartTime</var>,
- <a for="connection timing info">domain lookup end time</a> set to <var>defaultStartTime</var>,
- <a for="connection timing info">connection start time</a> set to <var>defaultStartTime</var>,
- <a for="connection timing info">connection end time</a> set to <var>defaultStartTime</var>,
- <a for="connection timing info">secure connection start time</a> set to
- <var>defaultStartTime</var>, and <a for="connection timing info">ALPN negotiated protocol</a>
- set to <var>timingInfo</var>'s <a for="connection timing info">ALPN negotiated protocol</a>.
+ <li><p>Return a new <a for=/>connection timing info</a> whose
+ <a for="connection timing info">domain lookup start time</a> is the result of <a>coarsen time</a>
+ given <var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a> and
+ <var>crossOriginIsolatedCapability</var>,
+ <a for="connection timing info">domain lookup end time</a> is the result of <a>coarsen time</a>
+ given <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> and
+ <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection start time</a>
+ is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection start time</a> and
+ <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection end time</a>
+ is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection end time</a> and
+ <var>crossOriginIsolatedCapability</var>,
+ <a for="connection timing info">secure connection start time</a> is the result of
+ <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection end time</a> and
+ <var>crossOriginIsolatedCapability</var>, and
+ <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
+ <a for="connection timing info">ALPN negotiated protocol</a>.
 </ol>
 
 <p>To <dfn>update timing info from stored response</dfn>, given a
@@ -2230,6 +2249,8 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
 <p>Each <a>connection</a> has an associated <a for=/>connection timing info</a>
 <dfn for=connection id=concept-connection-timing-info>timing info</dfn>.
 
+<hr>
+
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
 <var>origin</var>, <var>credentials</var>, an optional boolean <var>forceNew</var> (default false),
 an optional boolean <dfn export for="obtain a connection"><var>http3Only</var></dfn> (default
@@ -2379,8 +2400,8 @@ clearly stipulates that <a>connections</a> are keyed on
   <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">list of ALPN Protocol IDs</a>.
 </ol>
 
-<p class=note>The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that
-details of reused connections are not exposed.
+<p class=note>The <a for=/>clamp and coarsen connection timing info</a> algorithm ensures that
+details of reused connections are not exposed and time values are coarsened.
 
 
 <h3 id=network-partition-keys>Network partition keys</h3>
@@ -3513,12 +3534,22 @@ the request.
 <ol>
  <li><p>Let <var>taskDestination</var> be null.
 
+ <li><p>Let <var>crossOriginIsolatedCapability</var> be false.
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>client</a> is non-null, then:
+
+  <ol>
+   <li><p>Set <var>taskDestination</var> to <var>request</var>'s <a for=request>client</a>'s
+   <a for="environment settings object">global object</a>.
+
+   <li><p>Set <var>crossOriginIsolatedCapability</var> to <var>request</var>'s
+   <a for=request>client</a>'s
+   <a for="environment settings object">cross-origin isolated capability</a>.
+  </ol>
+
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
-
- <li><p>Otherwise, if <var>request</var>'s <a for=request>client</a> is non-null, set
- <var>taskDestination</var> to <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a>.
 
  <!-- It would be nice to assert that taskDestination is non-null here, but it's not clear if this
       works for all callers. Fetch itself calls main fetch while taskDestination is null. Anyone
@@ -3532,8 +3563,10 @@ the request.
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
  <a for="fetch params">process response end-of-body</a> is <var>processResponseEndOfBody</var>,
- <a for="fetch params">process response done</a> is <var>processResponseDone</var>, and
- <a for="fetch params">task destination</a> is <var>taskDestination</var>.
+ <a for="fetch params">process response done</a> is <var>processResponseDone</var>,
+ <a for="fetch params">task destination</a> is <var>taskDestination</var>, and
+ <a for="fetch params">cross-origin isolated capability</a> is
+ <var>crossOriginIsolatedCapability</var>.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
@@ -3618,7 +3651,8 @@ steps:
  <li><p>Let <var>response</var> be null.
 
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
- <a for="fetch timing info">fetch start time</a> to the <a for=/>unsafe shared current time</a>.
+ <a for="fetch timing info">fetch start time</a> to the <a for=/>coarsened shared current time</a>
+ given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
@@ -3951,7 +3985,8 @@ steps:
  <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
  <li><p>If <var>timingInfo</var> is not null, then set <var>timingInfo</var>'s
- <a for="fetch timing info">response end time</a> to the <a for=/>unsafe shared current time</a>.
+ <a for="fetch timing info">response end time</a> to the <a for=/>coarsened shared current time</a>
+ given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
@@ -3989,7 +4024,9 @@ steps:
  to <var>startTime</var>.
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to the
- <a href=/>unsafe shared current time</a>.
+ <a for=/>coarsened shared current time</a> given <var>global</var>'s
+ <a>relevant settings object</a>'s
+ <a for="environment settings object">cross-origin isolated capability</a>.
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
@@ -4130,7 +4167,8 @@ these steps:
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
 
-   <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>unsafe shared current time</a>.
+   <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>coarsened shared current time</a>
+   given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
@@ -5005,9 +5043,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   </dl>
 
  <li>Set <var>timingInfo</var>'s <a for="fetch timing info">connection timing info</a> to the
- result of calling <a>clamp connection timing to fetch timing</a> with <var>connection</var>'s
- <a for=connection>timing info</a> and <var>timingInfo</var>'s
- <a for="fetch timing info">fetch start time</a>.
+ result of calling <a>clamp and coarsen connection timing info</a> with <var>connection</var>'s
+ <a for=connection>timing info</a>, <var>timingInfo</var>'s
+ <a for="fetch timing info">fetch start time</a>, and <var>fetchParams</var>'s
+ <a for="fetch params">cross-origin isolated capability</a>.
 
  <li>
   <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
@@ -5023,7 +5062,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for=request>header list</a>.
 
    <li>Set <var>timingInfo</var>'s <a for="fetch timing info">request start time</a> to the
-   <a for=/>unsafe shared current time</a>.
+   <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+   <a for="fetch params">cross-origin isolated capability</a>.
 
    <li>
     <p>Set <var>response</var> to the result of making an HTTP request over <var>connection</var>
@@ -5032,10 +5072,11 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
-     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to
-     the <a for=/>unsafe shared current time</a> immediately after the user agent's HTTP parser
-     receives the first byte of the response (e.g., frame header bytes for HTTP/2, or response
-     status line for HTTP/1.x).
+     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to the
+     <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+     <a for="fetch params">cross-origin isolated capability</a>, immediately after the user agent's
+     HTTP parser receives the first byte of the response (e.g., frame header bytes for HTTP/2 or
+     response status line for HTTP/1.x).
 
      <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -221,60 +221,6 @@ information required by the resource timing and navigation timing specs. It has 
  <dd>Null or a <a for=/>connection timing info</a>.
 </dl>
 
-<p>A <dfn export>connection timing info</dfn> is a <a for=/>struct</a> used to maintain timing
-information pertaining to the process of obtaining a connection. It has the following
-<a for=struct>items</a>:
-
-<dl>
-  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
-  <dd>A {{DOMHighResTimeStamp}}.
-
-  <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
-  <a for=/>byte sequence</a>)
-  <dd>A <a for=/>byte sequence</a>.
-</dl>
-
-<p>To <dfn>clamp and coarsen connection timing info</dfn>, given a
-<a for=/>connection timing info</a> <var>timingInfo</var>, a {{DOMHighResTimeStamp}}
-<var>defaultStartTime</var>, and a boolean <var>crossOriginIsolatedCapability</var>, run these
-steps:
-
-<ol>
- <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
- less than <var>defaultStartTime</var>, then return a new <a for=/>connection timing info</a> whose
- <a for="connection timing info">domain lookup start time</a> is <var>defaultStartTime</var>,
- <a for="connection timing info">domain lookup end time</a> is <var>defaultStartTime</var>,
- <a for="connection timing info">connection start time</a> is <var>defaultStartTime</var>,
- <a for="connection timing info">connection end time</a> is <var>defaultStartTime</var>,
- <a for="connection timing info">secure connection start time</a> is <var>defaultStartTime</var>,
- and <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
- <a for="connection timing info">ALPN negotiated protocol</a>.
-
- <li><p>Return a new <a for=/>connection timing info</a> whose
- <a for="connection timing info">domain lookup start time</a> is the result of <a>coarsen time</a>
- given <var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a> and
- <var>crossOriginIsolatedCapability</var>,
- <a for="connection timing info">domain lookup end time</a> is the result of <a>coarsen time</a>
- given <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> and
- <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection start time</a>
- is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
- <a for="connection timing info">connection start time</a> and
- <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection end time</a>
- is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
- <a for="connection timing info">connection end time</a> and
- <var>crossOriginIsolatedCapability</var>,
- <a for="connection timing info">secure connection start time</a> is the result of
- <a>coarsen time</a> given <var>timingInfo</var>'s
- <a for="connection timing info">connection end time</a> and
- <var>crossOriginIsolatedCapability</var>, and
- <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
- <a for="connection timing info">ALPN negotiated protocol</a>.
-</ol>
-
 <p>To <dfn>update timing info from stored response</dfn>, given a
 <a for=/>connection timing info</a> <var>timingInfo</var> and a <a for=/>response</a>
 <var>response</var>, perform the following steps:
@@ -2249,6 +2195,60 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
 <p>Each <a>connection</a> has an associated <a for=/>connection timing info</a>
 <dfn for=connection id=concept-connection-timing-info>timing info</dfn>.
 
+<p>A <dfn export>connection timing info</dfn> is a <a for=/>struct</a> used to maintain timing
+information pertaining to the process of obtaining a connection. It has the following
+<a for=struct>items</a>:
+
+<dl>
+  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
+  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
+  <dd>A {{DOMHighResTimeStamp}}.
+
+  <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
+  <a for=/>byte sequence</a>)
+  <dd>A <a for=/>byte sequence</a>.
+</dl>
+
+<p>To <dfn>clamp and coarsen connection timing info</dfn>, given a
+<a for=/>connection timing info</a> <var>timingInfo</var>, a {{DOMHighResTimeStamp}}
+<var>defaultStartTime</var>, and a boolean <var>crossOriginIsolatedCapability</var>, run these
+steps:
+
+<ol>
+ <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
+ less than <var>defaultStartTime</var>, then return a new <a for=/>connection timing info</a> whose
+ <a for="connection timing info">domain lookup start time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">domain lookup end time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">connection start time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">connection end time</a> is <var>defaultStartTime</var>,
+ <a for="connection timing info">secure connection start time</a> is <var>defaultStartTime</var>,
+ and <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
+ <a for="connection timing info">ALPN negotiated protocol</a>.
+
+ <li><p>Return a new <a for=/>connection timing info</a> whose
+ <a for="connection timing info">domain lookup start time</a> is the result of <a>coarsen time</a>
+ given <var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a> and
+ <var>crossOriginIsolatedCapability</var>,
+ <a for="connection timing info">domain lookup end time</a> is the result of <a>coarsen time</a>
+ given <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> and
+ <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection start time</a>
+ is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection start time</a> and
+ <var>crossOriginIsolatedCapability</var>, <a for="connection timing info">connection end time</a>
+ is the result of <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection end time</a> and
+ <var>crossOriginIsolatedCapability</var>,
+ <a for="connection timing info">secure connection start time</a> is the result of
+ <a>coarsen time</a> given <var>timingInfo</var>'s
+ <a for="connection timing info">connection end time</a> and
+ <var>crossOriginIsolatedCapability</var>, and
+ <a for="connection timing info">ALPN negotiated protocol</a> is <var>timingInfo</var>'s
+ <a for="connection timing info">ALPN negotiated protocol</a>.
+</ol>
+
 <hr>
 
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
@@ -2322,6 +2322,8 @@ clearly stipulates that <a>connections</a> are keyed on
 <a>connections</a> whose <b>credentials</b> are true.
 <!-- See https://github.com/whatwg/fetch/issues/114#issuecomment-143500095 for when we make
      WebSocket saner -->
+
+<hr>
 
 <p>To <dfn>record connection timing info</dfn> given a <a for=/>connection</a>
 <var>connection</var>, let <var>timingInfo</var> be <var>connection</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -5026,7 +5026,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to
      the <a for=/>unsafe shared current time</a> immediately after the user agent's HTTP parser
      receives the first byte of the response (e.g. frame header bytes for HTTP/2, or response
-     status line for HTTP/1.x).
+     status line for HTTP/1.x), regardless of the response's status code.
 
      <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4108,8 +4108,7 @@ these steps:
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
 
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-   <a for="fetch timing info">worker start time</a> to the <a for=/>unsafe shared current time</a>.
+   <li><p>Let <var>workerStartTime</var> be the <a for=/>unsafe shared current time</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
@@ -4119,13 +4118,13 @@ these steps:
 
     <ol>
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-     <a for="fetch timing info">response start time</a> to the
-     <a for=/>unsafe shared current time</a>.
+     <a for="fetch timing info">worker start time</a> to <var>workerStartTime</var>.
 
-     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> and
-     <a for="fetch timing info">decoded body size</a> to the result of calling
-     <a for="header list">extract a length</a> from <var>response</var>'s
-     <a for=response>header list</a>.
+     <p class=note>If the response is cached, the current <a for="fetch params">timing info</a>'s
+     <a for="fetch timing info">encoded body size</a>,
+     <a for="fetch timing info">decoded body size</a>,
+     <a for="fetch timing info">request start time</a>,
+     and <a for="fetch timing info">response start time</a> will remain zero.
 
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
@@ -4156,9 +4155,6 @@ these steps:
       <p>then return a <a>network error</a>.
     </ol>
   </ol>
-
-  <p>Otheriwse, set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-  <a for="fetch timing info">worker start time</a> to zero.
 
  <li>
   <p>If <var>response</var> is null, then:
@@ -4672,9 +4668,6 @@ steps. They return a <a for=/>response</a>.
      <li>
       <p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
-      <p>Set <var>timingInfo</var>'s <a for="fetch timing info">request start time</a> to the
-      <a for=/>unsafe shared current time</a>.
-
       <p>Set <var>storedResponse</var> to the result of selecting a response from the
       <var>httpCache</var>, possibly needing validation, as per the
       "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
@@ -4688,14 +4681,6 @@ steps. They return a <a for=/>response</a>.
 
       <!-- cache hit -->
       <ol>
-       <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to the
-       <a for=/>unsafe shared current time</a>.
-
-       <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> and
-       <a for="fetch timing info">decoded body size</a> to the result of calling
-       <a for="header list">extract a length</a> from <var>storedResponse</var>'s
-       <a for=response>header list</a>.
-
        <li>
         <p>If <a for=request>cache mode</a> is "<code>default</code>", <var>storedResponse</var>
         is a <a>stale-while-revalidate response</a>, and <var>httpRequest</var>'s
@@ -5023,7 +5008,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
      <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to
-     the <a for=/>unsafe shared current time</a>immediately after the user agent's HTTP parser
+     the <a for=/>unsafe shared current time</a> immediately after the user agent's HTTP parser
      receives the first byte of the response (e.g. frame header bytes for HTTP/2, or response
      status line for HTTP/1.x).
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -196,8 +196,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 </dl>
 
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
-information required by the resource timing and navigation timing specs. It has the following
-<a for=struct>items</a>:
+information needed by <cite>Resource Timing</cite> and <cite>Navigation Timing</cite>. It has the
+following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
 <dl>
  <dt><dfn export for="fetch timing info">start time</dfn> (default 0)
@@ -2198,16 +2198,16 @@ information pertaining to the process of obtaining a connection. It has the foll
 <a for=struct>items</a>:
 
 <dl>
-  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
-  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
-  <dd>A {{DOMHighResTimeStamp}}.
+ <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default 0)
+ <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default 0)
+ <dt><dfn export for="connection timing info">connection start time</dfn> (default 0)
+ <dt><dfn export for="connection timing info">connection end time</dfn> (default 0)
+ <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
+ <dd>A {{DOMHighResTimeStamp}}.
 
-  <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
-  <a for=/>byte sequence</a>)
-  <dd>A <a for=/>byte sequence</a>.
+ <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
+ <a for=/>byte sequence</a>)
+ <dd>A <a for=/>byte sequence</a>.
 </dl>
 
 <p>To <dfn>clamp and coarsen connection timing info</dfn>, given a

--- a/fetch.bs
+++ b/fetch.bs
@@ -182,6 +182,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">process request end-of-body</dfn> (default null)
  <dt><dfn for="fetch params">process response</dfn> (default null)
  <dt><dfn for="fetch params">process response end-of-body</dfn> (default null)
+ <dt><dfn for="fetch params">process response done</dfn> (default null)
  <dd>Null or an algorithm.
 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
@@ -239,7 +240,7 @@ steps:
  <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
  greater than <var>defaultStartTime</var>, then return <var>timingInfo</var>.
 
- <li><p>Otherwise, return a new <a for=/>connection timing info</a>, with
+ <li><p>Return a new <a for=/>connection timing info</a>, with
  <a for="connection timing info">domain lookup start time</a> set to <var>defaultStartTime</var>,
  <a for="connection timing info">domain lookup end time</a> set to <var>defaultStartTime</var>,
  <a for="connection timing info">connection start time</a> set to <var>defaultStartTime</var>,
@@ -247,6 +248,7 @@ steps:
  <a for="connection timing info">secure connection start time</a> set to
  <var>defaultStartTime</var>, and <a for="connection timing info">alpn negotiated protocol</a>
  set to <var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>.
+</ol>
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2278,9 +2280,8 @@ clearly stipulates that <a>connections</a> are keyed on
 <!-- See https://github.com/whatwg/fetch/issues/114#issuecomment-143500095 for when we make
      WebSocket saner -->
 
-<p>The requirements for <dfn export id="concept-record-connection-timing-info">recording connection
-timing info</dfn> given a <a for=/>connection</a> <var>connection</var> and its
-<a for=/>connection timing info</a> <var>timingInfo</var>, are as
+<p>The requirements for <dfn>recording connection timing info</dfn> given a <a for=/>connection</a>
+<var>connection</var> and its <a for=/>connection timing info</a> <var>timingInfo</var>, are as
 follows:
 <ul>
  <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>
@@ -3462,15 +3463,16 @@ optional algorithm
 <dfn export for=fetch id=process-request-body><var>processRequestBody</var></dfn>, an optional
 algorithm
 <dfn export for=fetch id=process-request-end-of-body oldids=process-request-end-of-file><var>processRequestEndOfBody</var></dfn>,
-an optional algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an
-optional algorithm
+an optional algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>,
+an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseEndOfBody</var></dfn>,
-and an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run
-the steps below. If given, <var>processRequestBody</var> must be an algorithm accepting an integer
-representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be
+an optional algorithm <dfn export for=fetch><var>processResponseDone</var></dfn>, and an optional
+boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run the steps
+below. If given, <var>processRequestBody</var> must be an algorithm accepting an integer representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be
 an algorithm accepting no arguments. If given, <var>processResponse</var> must be an algorithm
 accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be an
 algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>.
+If given, <var>processResponseDone</var> must be an algorithm accepting no arguments.
 
 <p>An ongoing <a for=/>fetch</a> can be
 <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> with flag <var>aborted</var>,
@@ -3509,7 +3511,8 @@ the request.
  <a for="fetch params">process request body</a> is <var>processRequestBody</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
- <a for="fetch params">process response end-of-body</a> is <var>processResponseEndOfBody</var>, and
+ <a for="fetch params">process response end-of-body</a> is <var>processResponseEndOfBody</var>,
+ <a for="fetch params">process response done</a> is <var>processResponseDone</var>, and
  <a for="fetch params">task destination</a> is <var>taskDestination</var>.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
@@ -3920,33 +3923,20 @@ steps:
    <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
-
- <li><p>Wait for either <var>response</var>'s <a for=response>body</a> to be null, or
- <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> to be
- <a for=ReadableStream>closed</a> or <a for=ReadableStream>errored</a>, and then set
- <var>request</var>'s <a>done flag</a>.
- <!-- This is really bad and needs to be handled differently at some point. -->
 </ol>
 
-<p>To <dfn for=response>Attach timing info</dfn>, given <a for=/>response</a>
-<var>response</var> and <a for=/>fetch params</a> <var>fetchParams</var>, perform the following
-steps:
+<p>To <dfn>finalize response</dfn> given <a for=/>response</a> <var>response</var> and
+<a for=/>fetch params</a> <var>fetchParams</var>, perform the following steps:
 <ol>
- <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+ <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>
 
- <li><p>Let <var>redirectTimingList</var> be <var>fetchParams</var>'s
- <a for="fetch params">redirect timing info list</a>.
+ <li><p>If <var>timingInfo</var> is not null, then set <var>timingInfo</var>'s
+ <a for="fetch timing info">response end time</a> to the <a for=/>unsafe shared current time</a>.
 
- <li><p>Let <var>body</var> be <var>response</var>'s <a for=response>body</a>.
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a ofr=request>done flag</a>.
 
- <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>fetchParams</var>'s
- <a for="fetch params">timing info</a>.
-
- <li><p>If <var>redirectTimingList</var> is not empty, set <var>timingInfo</var>'s
- <a for="fetch timing info">redirect start time</a> to <var>redirectTimingList</var>'s first item's
- <a for="fetch timing info">fetch start time</a> and
- <a for="fetch timing info">redirect end time</a> to <var>redirectTimingList</var>'s last item's
- <a for="fetch timing info">fetch start time</a>.
+ <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
+ call <var>fetchParams</var>'s <a for="fetch params">process response done</a>.
 </ol>
 
 <p>To <dfn export for=response>retrieve timing info</dfn>, given <a for=/>response</a> <var>response</var>,
@@ -3975,7 +3965,7 @@ perform the following steps:
  <li><p>Return <var>timingInfo</var>.
 </ol>
 
-<p>To <dfn export for=response>finalize and report timing</dfn> given <a for=/>response</a>
+<p>To <dfn export>finalize and report timing</dfn> given <a for=/>response</a>
 <var>response</var>, a <a for=/>global object</a> <var>global</var> and a DOMString
 <var>initiatorType</var> (default "<code>other</code>"), perform the following steps:
 <ol>
@@ -4134,7 +4124,8 @@ these steps:
    <a for="fetch timing info">worker start time</a> to the <a for=/>unsafe shared current time</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
+   <var>requestForServiceWorker</var> and <var>fetchParams</var>
+   <a for="fetch params">process response done</a>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:
@@ -4284,8 +4275,27 @@ these steps:
     <!-- not resetting actualResponse since it's no longer used anyway -->
   </ol>
 
- <li><p><a for=response>Attach timing info</a> for <var>response</var> and
- <var>fetchParams</var>.
+ <li><p>Let <var>redirectTimingList</var> be <var>fetchParams</var>'s
+ <a for="fetch params">redirect timing info list</a>.
+
+ <li><p>If <var>redirectTimingList</var> is not empty, set <var>timingInfo</var>'s
+ <a for="fetch timing info">redirect start time</a> to <var>redirectTimingList</var>'s first item's
+ <a for="fetch timing info">fetch start time</a> and
+ <a for="fetch timing info">redirect end time</a> to <var>redirectTimingList</var>'s last item's
+ <a for="fetch timing info">fetch start time</a>.
+
+ <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.
+
+ <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
+ Resource Timing entry later. This step is done here, as resource-timing entries
+ are available only for HTTP fetches, including ones that are handled by service-workers or HTTP
+ cache, and not for data/blob/file fetches, and are only available after all the CORS checks have
+ passed for the request.
+
+ <li><p>Return <var>response</var>. <span class="note no-backref">Typically
+ <var>actualResponse</var>'s <a for=response>body</a>'s
+ <a for=body>stream</a> is still being enqueued to after returning.</span>
+</ol>
 
  <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
  Resource Timing entry later. This step is done here, as resource-timing entries
@@ -5254,6 +5264,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
+     <li><a for=/>Finalize response</a> for <var>response</var> and <var>fetchParams</var>.
+
      <li><p>Let <var>aborted</var> be the termination's aborted flag.
 
      <li>
@@ -6074,10 +6086,6 @@ due course.
 returns failure or a <a for=/>MIME type</a>.
 
 <p>Objects including the {{Body}} interface mixin have an associated
-<dfn id=concept-body-on-fully-read for=Body>on body consumed</dfn> (an algorithm which takes no
-arguments), initially set to do nothing.
-
-<p>Objects including the {{Body}} interface mixin have an associated
 <dfn id=concept-body-body for=Body>body</dfn> (null or a <a for=/>body</a>).
 
 <p>An object including the {{Body}} interface mixin is said to be
@@ -6204,7 +6212,7 @@ the associated steps:
 
 <ol>
  <li><p>If <var>object</var> is <a for=Body>unusable</a>, then return <a>a promise rejected with</a>
- a {{TypeError}} and call <var>object</var>'s <a for=Body>on body consumed</a>.
+ a {{TypeError}}.
 
  <li><p>Let <var>promise</var> be <a>a promise resolved with</a> an empty
  <a for=/>byte sequence</a>.
@@ -6214,9 +6222,6 @@ the associated steps:
 
  <li><p>Let <var>steps</var> be to return the result of <a>package data</a> with the first argument
  given, <var>type</var>, and <var>object</var>'s <a for=Body>MIME type</a>.
-
- <li><p><a>Upon fulfillment</a> of <var>promise</var>, call <var>object</var>'s
- <a for=Body>on body consumed</a>.
 
  <li><p>Return the result of <a>upon fulfillment</a> of <var>promise</var> given <var>steps</var>.
 </ol>
@@ -7192,9 +7197,13 @@ method steps are:
    <li><p><a lt=terminated for=fetch>Terminate</a> the ongoing fetch with the aborted flag set.
   </ol>
 
+ <li><p>Let <var>handleFetchDone</var> be to <a>finalize and report timing</a> with
+ <var>response</var>, <var>globalObject</var>, and "<code>fetch</code>".
+
  <li>
-  <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponse</i></a> given
-  <var>response</var> being these substeps:
+  <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponseDone</a> set to
+  <var>handleFetchDone</var>, and <a for=fetch><i>processResponse</i></a> given <var>response</var>
+  being these substeps:
 
   <ol>
    <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
@@ -7209,14 +7218,10 @@ method steps are:
    <li><p>Set <var>responseObject</var> to the result of <a for=Response>creating</a> a {{Response}}
    object, given <var>response</var>, "<code>immutable</code>", and <var>relevantRealm</var>.
 
-   <li><p>Set <var>responseObject</var>'s <a for=Body>on body consumed</a> to calling
-   <a for=response>finalize and report timing</a> for <var>response</var>,
-   <var>globalObject</var> and "<code>fetch</code>".
-
    <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
   </ol>
 
-  <p><a>If aborted</a>, then <a for=response>finalize and report timing</a> for <var>response</var>,
+  <p><a>If aborted</a>, then <a for=/>finalize and report timing</a> for <var>response</var>,
    <var>globalObject</var> and "<code>fetch</code>".
 
  <li><p>Return <var>p</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -7147,7 +7147,7 @@ method steps are:
   </ol>
 
  <li>Let <var>globalObject</var> be  <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a>
+ <a for="environment settings object">global object</a>.
 
  <li>If <var>globalObject</var> is a {{ServiceWorkerGlobalScope}} object,
  then set <var>request</var>'s <a>service-workers mode</a> to "<code>none</code>".
@@ -7178,7 +7178,7 @@ method steps are:
  <var>response</var>, <var>globalObject</var>, and "<code>fetch</code>".
 
  <li>
-  <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponseDone</a> set to
+  <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponseDone</i></a> set to
   <var>handleFetchDone</var>, and <a for=fetch><i>processResponse</i></a> given <var>response</var>
   being these substeps:
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2227,7 +2227,7 @@ identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (a
 <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
 <p>Each <a>connection</a> has an associated <a for=/>connection timing info</a>
-<dfn for=connection>timingInfo</dfn>.
+<dfn for=connection id=concept-connection-timing-info>timing info</dfn>.
 
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
 <var>origin</var>, <var>credentials</var>, an optional boolean <var>forceNew</var> (default false),
@@ -2303,7 +2303,7 @@ clearly stipulates that <a>connections</a> are keyed on
 
 <p>To <dfn>record connection timing info</dfn> given a <a for=/>connection</a>
 <var>connection</var>, let <var>timingInfo</var> be <var>connection</var>'s
-<a for=connection>connection timing info</a> and observe these requirements:
+<a for=connection>timing info</a> and observe these requirements:
 
 <ul>
  <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>
@@ -2340,13 +2340,13 @@ clearly stipulates that <a>connections</a> are keyed on
    <var>connection</var>.
   </ul>
 
-  <p class=example>Suppose the user agent establishes an HTTP/2 connection over TLS 1.3 to send a
-  <code>GET</code> request and a <code>POST</code> request. It sends the ClientHello at time
-  <var>t1</var> and then sends the <code>GET</code> request with early data. The <code>POST</code>
-  request is not safe ([[HTTP-SEMANTICS]], section 4.2.1), so the user agent waits to complete the
-  handshake at time <var>t2</var> before sending it. Although both requests used the same
-  connection, the <code>GET</code> request reports a connection end time of <var>t1</var>, while the
-  <code>POST</code> request reports <var>t2</var>.
+  <p class=example id=example-connection-end-time>Suppose the user agent establishes an HTTP/2
+  connection over TLS 1.3 to send a <code>GET</code> request and a <code>POST</code> request. It
+  sends the ClientHello at time <var>t1</var> and then sends the <code>GET</code> request with early
+  data. The <code>POST</code> request is not safe ([[HTTP-SEMANTICS]], section 4.2.1), so the user
+  agent waits to complete the handshake at time <var>t2</var> before sending it. Although both
+  requests used the same connection, the <code>GET</code> request reports a connection end time of
+  <var>t1</var>, while the <code>POST</code> request reports <var>t2</var>.
 
  <li><p>If a secure transport is used, <var>timingInfo</var>'s
  <a for="connection timing info">secure connection start time</a> should be the result of calling
@@ -2380,7 +2380,7 @@ clearly stipulates that <a>connections</a> are keyed on
     HTTP/3 protocol in the
     <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3 Internet Draft</a>.
 
-    <p class=note><var>connection</var>'s
+    <p class=note><var>timingInfo</var>'s
     <a for="connection timing info">alpn negotiated protocol</a> is intended to identify the network
     protocol in use regardless of how it was actually negotiated; that is, even if ALPN is not used
     to negotiate the network protocol, this is the ALPN Protocol IDs that indicates the protocol in
@@ -5015,7 +5015,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li>Set <var>timingInfo</var>'s <a for="fetch timing info">connection timing info</a> to the
  result of calling <a>clamp connection timing to fetch timing</a> with <var>connection</var>'s
- <a for=connection>timingInfo</a> and <var>timingInfo</var>'s
+ <a for=connection>timing info</a> and <var>timingInfo</var>'s
  <a for="fetch timing info">fetch start time</a>.
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -201,20 +201,20 @@ information required by the resource timing and navigation timing specs. It has 
 
 <dl>
  <dt><dfn export for="fetch timing info">start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">fetch start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">service worker start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">request start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">response start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">response end time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">redirect start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">redirect end time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">post-redirect start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">final service worker start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">final network-request start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">final network-response start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">end time</dfn> (default 0)
  <dd>A {{DOMHighResTimeStamp}}.
 
  <dt><dfn export for="fetch timing info">encoded body size</dfn> (default 0)
  <dt><dfn export for="fetch timing info">decoded body size</dfn> (default 0)
  <dd>A number.
 
- <dt><dfn export for="fetch timing info">connection timing info</dfn> (default null)
+ <dt><dfn export for="fetch timing info">final connection timing info</dfn> (default null)
  <dd>Null or a <a for=/>connection timing info</a>.
 </dl>
 
@@ -2189,8 +2189,9 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (an
 <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
-<p>Each <a>connection</a> has an associated <a for=/>connection timing info</a>
-<dfn for=connection id=concept-connection-timing-info>timing info</dfn>.
+<p>Each <a>connection</a> has an associated
+<dfn for=connection id=concept-connection-timing-info>timing info</dfn> (a
+<a for=/>connection timing info</a>).
 
 <p>A <dfn export>connection timing info</dfn> is a <a for=/>struct</a> used to maintain timing
 information pertaining to the process of obtaining a connection. It has the following
@@ -3555,9 +3556,14 @@ the request.
       wanting to do a ping without request body might do so as well, but if you do have a request
       body you definitely need this as otherwise transmit-request-body loop breaks down. -->
 
+ <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
+ <a for="fetch timing info">start time</a> and
+ <a for="fetch timing info">post-redirect start time</a> are the
+ <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>.
+
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
  <a for="fetch params">request</a> is <var>request</var>,
- <a for="fetch params">timing info</a> is a new <a for=/>fetch timing info</a>,
+ <a for="fetch params">timing info</a> is <var>timingInfo</var>,
  <a for="fetch params">process request body</a> is <var>processRequestBody</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
@@ -3648,10 +3654,6 @@ steps:
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
  <li><p>Let <var>response</var> be null.
-
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
- <a for="fetch timing info">fetch start time</a> to the <a for=/>coarsened shared current time</a>
- given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
@@ -3981,12 +3983,6 @@ steps:
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
- <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
-
- <li><p>If <var>timingInfo</var> is not null, then set <var>timingInfo</var>'s
- <a for="fetch timing info">response end time</a> to the <a for=/>coarsened shared current time</a>
- given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
-
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 
@@ -4010,19 +4006,13 @@ steps:
 
  <li><p>If <var>timingInfo</var> is null, then return.
 
- <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
- <a for="fetch timing info">fetch start time</a>.
-
- <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not 0, then
- set <var>startTime</var> to <var>timingInfo</var>'s
- <a for="fetch timing info">redirect start time</a>.
-
  <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then set
- <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
- <a for="fetch timing info">start time</a> and <a for="fetch timing info">fetch start time</a> set
- to <var>startTime</var>.
+ <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
+ <a for="fetch timing info">start time</a> and
+ <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+ <a for="fetch timing info">start time</a>.
 
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to the
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
  <a for=/>coarsened shared current time</a> given <var>global</var>'s
  <a>relevant settings object</a>'s
  <a for="environment settings object">cross-origin isolated capability</a>.
@@ -4177,7 +4167,8 @@ these steps:
 
     <ol>
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-     <a for="fetch timing info">service worker start time</a> to <var>serviceWorkerStartTime</var>.
+     <a for="fetch timing info">final service worker start time</a> to
+     <var>serviceWorkerStartTime</var>.
 
      <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.
@@ -4410,13 +4401,14 @@ run these steps:
 
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">redirect end time</a> to the
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">redirect end time</a> and
+ <a for="fetch timing info">post-redirect start time</a> to the
  <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
  <a for="fetch params">cross-origin isolated capability</a>.
 
  <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is 0, then set
  <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> to
- <var>timingInfo</var>'s <a for="fetch timing info">fetch start time</a>.
+ <var>timingInfo</var>'s <a for="fetch timing info">start time</a>.
 
  <li><p><a for=list>Append</a> <var>locationURL</var> to <var>request</var>'s
  <a for=request>URL list</a>.
@@ -5039,10 +5031,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <var>includeCredentials</var>, and <var>forceNewConnection</var>.
   </dl>
 
- <li>Set <var>timingInfo</var>'s <a for="fetch timing info">connection timing info</a> to the
+ <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final connection timing info</a> to the
  result of calling <a>clamp and coarsen connection timing info</a> with <var>connection</var>'s
  <a for=connection>timing info</a>, <var>timingInfo</var>'s
- <a for="fetch timing info">fetch start time</a>, and <var>fetchParams</var>'s
+ <a for="fetch timing info">post-redirect start time</a>, and <var>fetchParams</var>'s
  <a for="fetch params">cross-origin isolated capability</a>.
 
  <li>
@@ -5058,8 +5050,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    `<code>Transfer-Encoding</code>`/`<code>chunked</code>` to <var>request</var>'s
    <a for=request>header list</a>.
 
-   <li>Set <var>timingInfo</var>'s <a for="fetch timing info">request start time</a> to the
-   <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+   <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final network-request start time</a>
+   to the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
    <a for="fetch params">cross-origin isolated capability</a>.
 
    <li>
@@ -5069,7 +5061,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
-     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to the
+     <li><p>Set <var>timingInfo</var>'s
+     <a for="fetch timing info">final network-response start time</a> to the
      <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
      <a for="fetch params">cross-origin isolated capability</a>, immediately after the user agent's
      HTTP parser receives the first byte of the response (e.g., frame header bytes for HTTP/2 or
@@ -5080,7 +5073,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li>
       <p>Any <a for=/>responses</a> whose <a for=response>status</a> is in the range 100 to 199,
       inclusive, and is not 101, are to be ignored, except for the purposes of setting
-      <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> above.
+      <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> above.
 
       <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by a
       "final" <a for=/>response</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -186,7 +186,67 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
+ <dt><dfn for="fetch params">timing info</dfn>
+ <dd>A <a for=/>fetch timing info</a>.
+ <dt><dfn for="fetch params">redirect timing info list</dfn> (default « »)
+ <dd>A <a for=/>list</a> of <a for=/>fetch timing info</a>.
 </dl>
+
+<p><dfn>Unsafe shared current time</dfn> is defined in [[HR-TIME]].
+<p class=XXX>Remove this once HR-TIME-3 refs are available.
+
+<p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
+information later required by the resource timing and navigation timing specs. It has the following
+<a for=struct>items</a>:
+<dl>
+ <dt><dfn export for="fetch timing info">start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">fetch start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">worker start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">request start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">response start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">response end time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">redirect start time</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">redirect end time</dfn> (default zero)
+ <dd>A <a typedef for=/>DOMHighResTimeStamp</a>.
+ <dt><dfn export for="fetch timing info">encoded body size</dfn> (default zero)
+ <dt><dfn export for="fetch timing info">decoded body size</dfn> (default zero)
+ <dd>A number.
+ <dt><dfn export for="fetch timing info">connection timing info</dfn> (default null)
+ <dd>Null or a <a for=/>connection timing info</a>.
+</dl>
+
+<p>A <dfn export>connection timing info</dfn> is a <a for=/>struct</a> used to maintain timing
+information pertaining to the process of obtaining a connection. It has the following
+<a for=struct>items</a>:
+<dl>
+  <dt><dfn export for="connection timing info">domain lookup start time</dfn> (default zero)
+  <dt><dfn export for="connection timing info">domain lookup end time</dfn> (default zero)
+  <dt><dfn export for="connection timing info">connection start time</dfn> (default zero)
+  <dt><dfn export for="connection timing info">connection end time</dfn> (default zero)
+  <dt><dfn export for="connection timing info">secure connection start time</dfn> (default zero)
+  <dd>A <a typedef for=/>DOMHighResTimeStamp</a>
+  <dt><dfn export for="connection timing info">alpn negotiated protocol</dfn> (default empty string)
+  <dd>A string.
+</dl>
+
+<p class=note>Note that timestamps in this spec are usually unsafe, and are meant to be coarsened
+and normalized to a <a for=/>global object</a> prior to being exposed.
+
+<p>To <dfn>clamp connection timing to fetch timing</dfn>, given <a for=/>connection timing info</a>
+<var>timingInfo</var> and <a typedef for=/>DOMHighResTimeStamp</a> <var>defaultStartTime</var>, run these
+steps:
+<ol>
+ <li><p>If <var>timingInfo</var>'s <a for="connection timing info">connection start time</a> is
+ greater than <var>defaultStartTime</var>, then return <var>timingInfo</var>.
+
+ <li><p>Otherwise, return a new <a for=/>connection timing info</a>, with
+ <a for="connection timing info">domain lookup start time</a> set to <var>defaultStartTime</var>,
+ <a for="connection timing info">domain lookup end time</a> set to <var>defaultStartTime</var>,
+ <a for="connection timing info">connection start time</a> set to <var>defaultStartTime</var>,
+ <a for="connection timing info">connection end time</a> set to <var>defaultStartTime</var>,
+ <a for="connection timing info">secure connection start time</a> set to
+ <var>defaultStartTime</var>, and <a for="connection timing info">alpn negotiated protocol</a>
+ set to <var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>.
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -1922,6 +1982,10 @@ allowed on the resource fetched by looking at the flag of the response returned.
 the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-timing-info>timing info</dfn> (Null or a
+<a for=/>fetch timing info</a>), which is initially null.
+
 <hr>
 
 <p>A <a for=/>response</a> whose
@@ -2139,6 +2203,9 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 identified by a <b>key</b> (a <a>network partition key</a>), an <b>origin</b> (an
 <a for=/>origin</a>), and <b>credentials</b> (a boolean).
 
+<p>Each <a>connection</a> has an associated <a for=/>connection timing info</a>
+<dfn for=connection>timingInfo</dfn>.
+
 <p>To <dfn export id=concept-connection-obtain>obtain a connection</dfn>, given a <var>key</var>,
 <var>origin</var>, <var>credentials</var>, an optional boolean <var>forceNew</var> (default false),
 an optional boolean <dfn export for="obtain a connection"><var>http3Only</var></dfn> (default
@@ -2170,8 +2237,9 @@ false), and an optional boolean <dfn export for="obtain a connection"><var>dedic
   <ol>
    <li>
     <p>Set <var>connection</var> to the result of establishing an HTTP connection to
-    <var>origin</var>. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
-    [[!TLS]]
+    <var>origin</var>, following the requirements for
+    <a>recording <var>connection</var> timing info</a>.
+    [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]] [[!TLS]]
 
     <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]
 
@@ -2210,6 +2278,89 @@ clearly stipulates that <a>connections</a> are keyed on
 <!-- See https://github.com/whatwg/fetch/issues/114#issuecomment-143500095 for when we make
      WebSocket saner -->
 
+<p>The requirements for <dfn>recording connection timing info</dfn> given a <a for=/>connection</a>
+<var>connection</var> and its <a for=/>connection timing info</a> <var>timingInfo</var>, are as
+follows:
+<ul>
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>
+ should be the <a for=/>unsafe shared current time</a> immediately before starting the domain
+ lookup, or beginning retrieval of the information from cache.
+
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> should
+ be the <a for=/>unsafe shared current time</a> immediately after finishing the domain lookup, or
+ retrieving the information from cache.
+
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">connection start time</a> should
+ be the <a for=/>unsafe shared current time</a> immediately before establishing the connection to
+ the server or proxy.
+
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">connection end time</a> should be
+ the <a for=/>unsafe shared current time</a> immediately after establishing the connection to the
+ server or proxy, as follows:
+ <ul>
+  <li><p>The returned time must include the time interval to establish the transport
+  connection, as well as other time intervals such as SOCKS authentication. It
+  must include the time interval to complete enough of the TLS handshake to
+  request the resource.
+
+  <li><p>If the user agent used TLS False Start [[RFC7918]] for this connection,
+  this interval must not include the time needed to receive the server's
+  Finished message.
+
+  <li><p>If the user agent sends the request with early data [[RFC8470]] without
+  waiting for the full handshare to complete, this interval must not include
+  the time needed to receive the server's ServerHello message.
+
+  <li><p>If the user agent waits for full handshake completion to send the
+  request, this interval includes the full TLS handshake even if other
+  requests were sent using early data on <var>connection</var>.
+ </ul>
+
+ <p class=note>Example: Suppose the user agent establishes an HTTP/2 connection
+ over TLS 1.3 to send a GET request and a POST request. It sends the ClientHello
+ at time <code>t1</code> and then sends the GET request with early data. The
+ POST request is not safe [[HTTP-SEMANTICS]] (section 4.2.1), so the user agent waits
+ to complete the handshake at time <code>t2</code> before sending it.  Although
+ both requests used the same connection, the GET request reports a connectEnd
+ value of <code>t1</code>, while the POST request reports a connectEnd value for
+ <code>t2</code>.
+
+  <li><p>If a secure transport is used, <var>timingInfo</var>'s
+  <a for="connection timing info">secure connection start time</a> should be the result of calling
+  <a for=/>unsafe shared current time</a> immmediately before starting the handshake process to
+  secure <var>connection</var>. [[!TLS]]
+
+  <li><p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>
+  should be the <var>connection</var>'s ALPN Protocol ID as specified in [[RFC7301]], with the
+  following caveats:
+  <ul>
+   <li><p>When a proxy is configured, if a tunnel connection is established then this attribute
+   must return the ALPN Protocol ID of the tunneled protocol, otherwise it must return the ALPN
+   Protocol ID of the first hop to the proxy.
+
+   <li><p>Octets in the ALPN protocol must not be percent-encoded if they are valid token
+   characters except "%", and when using percent-encoding, uppercase hex digits must be used.
+
+   <li><p>Formally registered ALPN protocol IDs are documented by <a href=
+   "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">
+   IANA</a>.
+
+   <li><p>In case the user agent is using an experimental, non-registered protocol, the user
+   agent must use the ALPN negotiated value if any. If ALPN was not used for protocol
+   negotiations, the user agent MAY use another descriptive string.
+
+   <p class="note">The "h3" ALPN ID is defined for the final version
+   of the HTTP/3 protocol in the
+   <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3
+   Internet Draft</a>.
+
+   <p class="note">Note that <a for="connection timing info">alpn negotiated protocol</a> is
+   intended to identify the network protocol in use for the fetch regardless of how it was
+   actually negotiated; that is, even if ALPN is not used to negotiate the network protocol,
+   this attribute still uses the ALPN Protocol IDs to indicate the protocol in use.
+  </ul>
+ </ul>
+</ol>
 
 <h3 id=network-partition-keys>Network partition keys</h3>
 
@@ -3353,6 +3504,7 @@ the request.
 
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
  <a for="fetch params">request</a> is <var>request</var>,
+ <a for="fetch params">timing info</a> is a new <a for=/>fetch timing info</a>,
  <a for="fetch params">process request body</a> is <var>processRequestBody</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
@@ -3440,6 +3592,10 @@ steps:
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
  <li><p>Let <var>response</var> be null.
+
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a> be a new
+ <a for=/>fetch timing info</a> with its <a for="fetch timing info">fetch start time</a> set to the
+ <a for=/>unsafe shared current time</a>.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
@@ -3771,6 +3927,75 @@ steps:
  <!-- This is really bad and needs to be handled differently at some point. -->
 </ol>
 
+<p>To <dfn for=response>Attach timing info</dfn>, given <a for=/>response</a>
+<var>response</var> and <a for=/>fetch params</a> <var>fetchParams</var>, perform the following
+steps:
+<ol>
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
+ <li><p>Let <var>redirectTimingList</var> be <var>fetchParams</var>'s
+ <a for="fetch params">redirect timing info list</a>.
+
+ <li><p>Let <var>body</var> be <var>response</var>'s <a for=response>body</a>.
+
+ <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>fetchParams</var>'s
+ <a for="fetch params">timing info</a>.
+
+ <li><p>If <var>redirectTimingList</var> is not empty, set <var>timingInfo</var>'s
+ <a for="fetch timing info">redirect start time</a> to <var>redirectTimingList</var>'s first item's
+ <a for="fetch timing info">fetch start time</a> and
+ <a for="fetch timing info">redirect end time</a> to <var>redirectTimingList</var>'s last item's
+ <a for="fetch timing info">fetch start time</a>.
+</ol>
+
+<p>To <dfn export for=response>retrieve timing info</dfn>, given <a for=/>response</a> <var>response</var>,
+perform the following steps:
+
+<ol>
+ <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
+
+ <li><p>If <var>timingInfo</var> is null, return null.
+
+ <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
+ <a for="fetch timing info">fetch start time</a>.
+
+ <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not zero,
+ then set <var>startTime</var> to <var>timingInfo</var>'s
+ <a for="fetch timing info">redirect start time</a>.
+
+ <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
+ set <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
+ <a for="fetch timing info">start time</a>
+ <a for="fetch timing info">fetch start time</a> set to <var>startTime</var>.
+
+ <li><p>Otherwise, <var>timingInfo</var>'s <a for="fetch timing info">start time</a> to
+ <var>startTime</var>.
+
+ <li><p>Return <var>timingInfo</var>.
+</ol>
+
+<p>To <dfn export for=response>finalize and report timing</dfn> given <a for=/>response</a>
+<var>response</var>, a <a for=/>global object</a> <var>global</var> and a DOMString
+<var>initiatorType</var> (default "<code>other</code>"), perform the following steps:
+<ol>
+ <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or empty, then return.
+
+ <li><p>Let <var>originalURL</var> be <var>response</var>'s <a for=response>URL list</a>'s
+ first item.
+
+ <li><p>Let <var>timingInfo</var> be the result of calling <a for=response>retrieve timing info</a>
+ for <var>response</var>.
+
+ <li><p>If <var>timingInfo</var> is null, then return.
+
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to the
+ <a href=/>unsafe shared current time</a>.
+
+ <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
+
+ <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
+ <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
+</ol>
 
 <h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
@@ -3894,12 +4119,18 @@ these steps:
 
  <li><p>Let <var>actualResponse</var> be null.
 
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s<a for="fetch params">timing
+ info</a>.
+
  <li>
   <p>If <var>request</var>'s <a>service-workers mode</a> is "<code>all</code>", then:
 
   <ol>
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
+
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+   <a for="fetch timing info">worker start time</a> to the <a for=/>unsafe shared current time</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
@@ -3908,6 +4139,15 @@ these steps:
     <p>If <var>response</var> is not null, then:
 
     <ol>
+     <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+     <a for="fetch timing info">response start time</a> to the
+     <a for=/>unsafe shared current time</a>.
+
+     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> and
+     <a for="fetch timing info">decoded body size</a> to the result of calling
+     <a for="header list">extract a length</a> from <var>response</var>'s
+     <a for=response>header list</a>.
+
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
 
@@ -3937,6 +4177,9 @@ these steps:
       <p>then return a <a>network error</a>.
     </ol>
   </ol>
+
+  <p>Otheriwse, set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+  <a for="fetch timing info">worker start time</a> to zero.
 
  <li>
   <p>If <var>response</var> is null, then:
@@ -4040,6 +4283,14 @@ these steps:
     <!-- not resetting actualResponse since it's no longer used anyway -->
   </ol>
 
+ <li><p><a for=response>Attach timing info</a> for <var>response</var> and
+ <var>fetchParams</var>.
+
+ <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
+ Resource Timing entry later. This step is done here, as resource-timing entries
+ are available only for HTTP fetchesm, including ones that are handled by service-workers or HTTP
+ cache, and not for data/blob/file fetches, and are only available after all the CORS checks have
+ passed for the request.
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s
  <a for=body>stream</a> is still being enqueued to after returning.</span>
@@ -4124,6 +4375,9 @@ run these steps:
 
   <p class="note no-backref"><var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>'s
   nullity has already been checked.
+
+ <li><p>Append <var>fetchParams</var>'s <a for="fetch params">timing info</a> to
+ <var>fetchParams</var>'s <a for="fetch params">redirect timing info list</a>.
 
  <li><p><a for=list>Append</a> <var>locationURL</var> to <var>request</var>'s
  <a for=request>URL list</a>.
@@ -4428,6 +4682,11 @@ steps. They return a <a for=/>response</a>.
 
     <ol>
      <li>
+      <p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
+      <p>Set <var>timingInfo</var>'s <a for="fetch timing info">request start time</a> to the
+      <a for=/>unsafe shared current time</a>.
+
       <p>Set <var>storedResponse</var> to the result of selecting a response from the
       <var>httpCache</var>, possibly needing validation, as per the
       "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
@@ -4441,6 +4700,14 @@ steps. They return a <a for=/>response</a>.
 
       <!-- cache hit -->
       <ol>
+       <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to the
+       <a for=/>unsafe shared current time</a>.
+
+       <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> and
+       <a for="fetch timing info">decoded body size</a> to the result of calling
+       <a for="header list">extract a length</a> from <var>storedResponse</var>'s
+       <a for=response>header list</a>.
+
        <li>
         <p>If <a for=request>cache mode</a> is "<code>default</code>", <var>storedResponse</var>
         is a <a>stale-while-revalidate response</a>, and <var>httpRequest</var>'s
@@ -4712,6 +4979,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p>Let <var>response</var> be null.
 
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
  <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP cache partition</a>, given
  <var>httpRequest</var>.
 
@@ -4737,6 +5006,11 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <var>includeCredentials</var>, and <var>forceNewConnection</var>.
   </dl>
 
+ <li>Set <var>timingInfo</var>'s <a for="fetch timing info">connection timing info</a> to the
+ result of calling <a>clamp connection timing to fetch timing</a> with <var>connection</var>'s
+ <a for=connection>timingInfo</a> and <var>timingInfo</var>'s
+ <a for="fetch timing info">fetch start time</a>.
+
  <li>
   <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
 
@@ -4750,12 +5024,20 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    `<code>Transfer-Encoding</code>`/`<code>chunked</code>` to <var>request</var>'s
    <a for=request>header list</a>.
 
+   <li>Set <var>timingInfo</var>'s <a for="fetch timing info">request start time</a> to the
+   <a for=/>unsafe shared current time</a>.
+
    <li>
     <p>Set <var>response</var> to the result of making an HTTP request over <var>connection</var>
     using <var>request</var> with the following caveats:
 
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
+
+     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response start time</a> to
+     the <a for=/>unsafe shared current time</a>immediately after the user agent's HTTP parser
+     receives the first byte of the response (e.g. frame header bytes for HTTP/2, or response
+     status line for HTTP/1.x).
 
      <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
@@ -4935,12 +5217,18 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
          `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
+         <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a>
+         by <var>bytes</var>'s <a for="byte sequence">length</a>.
+
          <li>
           <p>Set <var>bytes</var> to the result of <a lt="handle content codings">handling content
           codings</a> given <var>codings</var> and <var>bytes</var>.
 
           <p class="note no-backref">This makes the `<code>Content-Length</code>` <a for=/>header</a>
           unreliable to the extent that it was reliable to begin with.
+
+         <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> by
+         <var>bytes</var>'s <a for="byte sequence">length</a>.
 
          <li><p>If <var>bytes</var> is failure, then <a lt=terminated for=fetch>terminate</a> the
          ongoing fetch.
@@ -5785,6 +6073,10 @@ due course.
 returns failure or a <a for=/>MIME type</a>.
 
 <p>Objects including the {{Body}} interface mixin have an associated
+<dfn id=concept-body-on-fully-read for=Body>on body consumed</dfn> (an algorithm which takes no
+arguments), initially set to do nothing.
+
+<p>Objects including the {{Body}} interface mixin have an associated
 <dfn id=concept-body-body for=Body>body</dfn> (null or a <a for=/>body</a>).
 
 <p>An object including the {{Body}} interface mixin is said to be
@@ -5911,7 +6203,7 @@ the associated steps:
 
 <ol>
  <li><p>If <var>object</var> is <a for=Body>unusable</a>, then return <a>a promise rejected with</a>
- a {{TypeError}}.
+ a {{TypeError}} and call <var>object</var>'s <a for=Body>on body consumed</a>.
 
  <li><p>Let <var>promise</var> be <a>a promise resolved with</a> an empty
  <a for=/>byte sequence</a>.
@@ -5921,6 +6213,9 @@ the associated steps:
 
  <li><p>Let <var>steps</var> be to return the result of <a>package data</a> with the first argument
  given, <var>type</var>, and <var>object</var>'s <a for=Body>MIME type</a>.
+
+ <li><p><a>Upon fulfillment</a> of <var>promise</var>, call <var>object</var>'s
+ <a for=Body>on body consumed</a>.
 
  <li><p>Return the result of <a>upon fulfillment</a> of <var>promise</var> given <var>steps</var>.
 </ol>
@@ -6868,8 +7163,10 @@ method steps are:
    <li><p>Return <var>p</var>.
   </ol>
 
- <li>If <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a> is a {{ServiceWorkerGlobalScope}} object,
+ <li>Let <var>globalObject</var> be  <var>request</var>'s <a for=request>client</a>'s
+ <a for="environment settings object">global object</a>
+
+ <li>If <var>globalObject</var> is a {{ServiceWorkerGlobalScope}} object,
  then set <var>request</var>'s <a>service-workers mode</a> to "<code>none</code>".
 
  <li><p>Let <var>responseObject</var> be null.
@@ -6911,8 +7208,15 @@ method steps are:
    <li><p>Set <var>responseObject</var> to the result of <a for=Response>creating</a> a {{Response}}
    object, given <var>response</var>, "<code>immutable</code>", and <var>relevantRealm</var>.
 
+   <li><p>Set <var>responseObject</var>'s <a for=Body>on body consumed</a> to calling
+   <a for=response>finalize and report timing</a> for <var>response</var>,
+   <var>globalObject</var> and "<code>fetch</code>".
+
    <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
   </ol>
+
+  <p><a>If aborted</a>, then <a for=response>finalize and report timing</a> for <var>response</var>,
+   <var>globalObject</var> and "<code>fetch</code>".
 
  <li><p>Return <var>p</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2324,41 +2324,45 @@ follows:
  value of <code>t1</code>, while the POST request reports a connectEnd value for
  <code>t2</code>.
 
-  <li><p>If a secure transport is used, <var>timingInfo</var>'s
-  <a for="connection timing info">secure connection start time</a> should be the result of calling
-  <a for=/>unsafe shared current time</a> immmediately before starting the handshake process to
-  secure <var>connection</var>. [[!TLS]]
+ <li><p>If a secure transport is used, <var>timingInfo</var>'s
+ <a for="connection timing info">secure connection start time</a> should be the result of calling
+ <a for=/>unsafe shared current time</a> immmediately before starting the handshake process to
+ secure <var>connection</var>. [[!TLS]]
 
-  <li><p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>
-  should be the <var>connection</var>'s ALPN Protocol ID as specified in [[RFC7301]], with the
-  following caveats:
-  <ul>
-   <li><p>When a proxy is configured, if a tunnel connection is established then this attribute
-   must return the ALPN Protocol ID of the tunneled protocol, otherwise it must return the ALPN
-   Protocol ID of the first hop to the proxy.
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>
+ should be the <var>connection</var>'s ALPN Protocol ID as specified in [[RFC7301]], with the
+ following caveats:
+ <ul>
+  <li><p>When a proxy is configured, if a tunnel connection is established then this attribute
+  must return the ALPN Protocol ID of the tunneled protocol, otherwise it must return the ALPN
+  Protocol ID of the first hop to the proxy.
 
-   <li><p>Octets in the ALPN protocol must not be percent-encoded if they are valid token
-   characters except "%", and when using percent-encoding, uppercase hex digits must be used.
+  <li><p>Octets in the ALPN protocol must not be percent-encoded if they are valid token
+  characters except "%", and when using percent-encoding, uppercase hex digits must be used.
 
-   <li><p>Formally registered ALPN protocol IDs are documented by <a href=
-   "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">
-   IANA</a>.
+  <li><p>Formally registered ALPN protocol IDs are documented by <a href=
+  "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">
+  IANA</a>.
 
-   <li><p>In case the user agent is using an experimental, non-registered protocol, the user
-   agent must use the ALPN negotiated value if any. If ALPN was not used for protocol
-   negotiations, the user agent MAY use another descriptive string.
+  <li><p>In case the user agent is using an experimental, non-registered protocol, the user
+  agent must use the ALPN negotiated value if any. If ALPN was not used for protocol
+  negotiations, the user agent MAY use another descriptive string.
 
-   <p class="note">The "h3" ALPN ID is defined for the final version
-   of the HTTP/3 protocol in the
-   <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3
-   Internet Draft</a>.
+  <p class="note">The "h3" ALPN ID is defined for the final version
+  of the HTTP/3 protocol in the
+  <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3
+  Internet Draft</a>.
 
-   <p class="note">Note that <a for="connection timing info">alpn negotiated protocol</a> is
-   intended to identify the network protocol in use for the fetch regardless of how it was
-   actually negotiated; that is, even if ALPN is not used to negotiate the network protocol,
-   this attribute still uses the ALPN Protocol IDs to indicate the protocol in use.
-  </ul>
+  <p class="note">Note that <a for="connection timing info">alpn negotiated protocol</a> is
+  intended to identify the network protocol in use for the fetch regardless of how it was
+  actually negotiated; that is, even if ALPN is not used to negotiate the network protocol,
+  this attribute still uses the ALPN Protocol IDs to indicate the protocol in use.
  </ul>
+
+ <p class="note">The <a for="connection">timingInfo</a> for the connection might be saved in the
+ <a>connection pool</a>, and later retrieved alongside the connection if the connection is reused.
+ The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that details of reused
+ connections are not exposed.
 </ol>
 
 <h3 id=network-partition-keys>Network partition keys</h3>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5240,7 +5240,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
        normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
-       <a for=ReadableStream>close</a> <var>stream</var> and abort these in-parallel steps.
+       <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>Finalize response</a> for
+       <var>response</var> and <var>fetchParams</var>, and abort these in-parallel steps.
       </ol>
     </ol>
 
@@ -7204,9 +7205,6 @@ method steps are:
 
    <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
   </ol>
-
-  <p><a>If aborted</a>, then <a for=/>finalize and report timing</a> for <var>response</var>,
-   <var>globalObject</var> and "<code>fetch</code>".
 
  <li><p>Return <var>p</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3939,32 +3939,6 @@ steps:
  call <var>fetchParams</var>'s <a for="fetch params">process response done</a>.
 </ol>
 
-<p>To <dfn export for=response>retrieve timing info</dfn>, given <a for=/>response</a> <var>response</var>,
-perform the following steps:
-
-<ol>
- <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
-
- <li><p>If <var>timingInfo</var> is null, return null.
-
- <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
- <a for="fetch timing info">fetch start time</a>.
-
- <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not zero,
- then set <var>startTime</var> to <var>timingInfo</var>'s
- <a for="fetch timing info">redirect start time</a>.
-
- <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
- set <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
- <a for="fetch timing info">start time</a>
- <a for="fetch timing info">fetch start time</a> set to <var>startTime</var>.
-
- <li><p>Otherwise, <var>timingInfo</var>'s <a for="fetch timing info">start time</a> to
- <var>startTime</var>.
-
- <li><p>Return <var>timingInfo</var>.
-</ol>
-
 <p>To <dfn export>finalize and report timing</dfn> given <a for=/>response</a>
 <var>response</var>, a <a for=/>global object</a> <var>global</var> and a DOMString
 <var>initiatorType</var> (default "<code>other</code>"), perform the following steps:
@@ -3974,10 +3948,28 @@ perform the following steps:
  <li><p>Let <var>originalURL</var> be <var>response</var>'s <a for=response>URL list</a>'s
  first item.
 
- <li><p>Let <var>timingInfo</var> be the result of calling <a for=response>retrieve timing info</a>
- for <var>response</var>.
+ <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
+
+ <ol>
+  <li><p>Otherwise, <var>timingInfo</var>'s <a for="fetch timing info">start time</a> to
+  <var>startTime</var>.
+
+  <li><p>Return <var>timingInfo</var>.
+ </ol>
 
  <li><p>If <var>timingInfo</var> is null, then return.
+ 
+ <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
+ <a for="fetch timing info">fetch start time</a>.
+
+ <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is not zero,
+ then set <var>startTime</var> to <var>timingInfo</var>'s
+ <a for="fetch timing info">redirect start time</a>.
+
+ <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
+ set <var>timingInfo</var> to a new <a for=/>fetch timing info</a>, with its
+ <a for="fetch timing info">start time</a> and <a for="fetch timing info">fetch start time</a> set
+ to <var>startTime</var>.
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to the
  <a href=/>unsafe shared current time</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -202,7 +202,7 @@ information required by the resource timing and navigation timing specs. It has 
 <dl>
  <dt><dfn export for="fetch timing info">start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">fetch start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">worker start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">service worker start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">request start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">response start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">response end time</dfn> (default 0)
@@ -230,8 +230,9 @@ information pertaining to the process of obtaining a connection. It has the foll
   <dt><dfn export for="connection timing info">secure connection start time</dfn> (default 0)
   <dd>A <a typedef for=/>DOMHighResTimeStamp</a>
 
-  <dt><dfn export for="connection timing info">alpn negotiated protocol</dfn> (default empty string)
-  <dd>A string.
+  <dt><dfn export for="connection timing info">ALPN negotiated protocol</dfn> (default the empty
+  <a for=/>byte sequence</a>)
+  <dd>A <a for=/>byte sequence</a>.
 </dl>
 
 <p class=note>Note that timestamps in this spec are usually unsafe, and are meant to be coarsened
@@ -251,8 +252,8 @@ and normalized to a <a for=/>global object</a> prior to being exposed.
  <a for="connection timing info">connection start time</a> set to <var>defaultStartTime</var>,
  <a for="connection timing info">connection end time</a> set to <var>defaultStartTime</var>,
  <a for="connection timing info">secure connection start time</a> set to
- <var>defaultStartTime</var>, and <a for="connection timing info">alpn negotiated protocol</a>
- set to <var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>.
+ <var>defaultStartTime</var>, and <a for="connection timing info">ALPN negotiated protocol</a>
+ set to <var>timingInfo</var>'s <a for="connection timing info">ALPN negotiated protocol</a>.
 </ol>
 
 <p>To <dfn>update timing info from stored response</dfn>, given a
@@ -2354,42 +2355,33 @@ clearly stipulates that <a>connections</a> are keyed on
  secure <var>connection</var>. [[!TLS]]
 
  <li>
-  <p><var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a> should be
+  <p><var>timingInfo</var>'s <a for="connection timing info">ALPN negotiated protocol</a> should be
   the <var>connection</var>'s ALPN Protocol ID, with the following caveats: [[RFC7301]]
-  <!-- TODO Since it's in octets, I guess we have to isomorphic decode it? -->
 
   <ul>
    <li><p>When a proxy is configured, if a tunnel connection is established then this must be the
    ALPN Protocol ID of the tunneled protocol, otherwise it must be the ALPN Protocol ID of the first
    hop to the proxy.
 
-   <li><p>Octets in the ALPN Protocol ID must not be percent-encoded if they are valid token
-   characters except "%", and when using percent-encoding, uppercase hex digits must be used.
-   <!-- TODO I don't think we have to state this as the network does this. -->
-
-   <li><p>Formally registered ALPN Protocol IDs are documented by
-   <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">IANA</a>.
-   <!-- TODO I'm not sure we need to reference this? -->
-
    <li>
     <p>In case the user agent is using an experimental, non-registered protocol, the user agent must
     use the used ALPN Protocol ID, if any. If ALPN was not used for protocol negotiations, the user
     agent may use another descriptive string.
 
-    <p class=note>The "<code>h3</code>" ALPN Protocol ID is defined for the final version of the
-    HTTP/3 protocol in the
-    <a href="https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3 Internet Draft</a>.
-
     <p class=note><var>timingInfo</var>'s
-    <a for="connection timing info">alpn negotiated protocol</a> is intended to identify the network
+    <a for="connection timing info">ALPN negotiated protocol</a> is intended to identify the network
     protocol in use regardless of how it was actually negotiated; that is, even if ALPN is not used
     to negotiate the network protocol, this is the ALPN Protocol IDs that indicates the protocol in
     use.
   </ul>
 
-  <p class=note>The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that
-  details of reused connections are not exposed.
+  <p class=note>IANA maintains a
+  <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">list of ALPN Protocol IDs</a>.
 </ol>
+
+<p class=note>The <a for=/>clamp connection timing to fetch timing</a> algorithm ensures that
+details of reused connections are not exposed.
+
 
 <h3 id=network-partition-keys>Network partition keys</h3>
 
@@ -4138,8 +4130,7 @@ these steps:
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
 
-   <li><p>Let <var>workerStartTime</var> be the <a for=/>unsafe shared current time</a>.
-   <!-- TODO: can we rename this to service worker start time? -->
+   <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>unsafe shared current time</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
@@ -4149,7 +4140,7 @@ these steps:
 
     <ol>
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-     <a for="fetch timing info">worker start time</a> to <var>workerStartTime</var>.
+     <a for="fetch timing info">service worker start time</a> to <var>serviceWorkerStartTime</var>.
 
      <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3950,15 +3950,8 @@ steps:
 
  <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
- <ol>
-  <li><p>Otherwise, <var>timingInfo</var>'s <a for="fetch timing info">start time</a> to
-  <var>startTime</var>.
-
-  <li><p>Return <var>timingInfo</var>.
- </ol>
-
  <li><p>If <var>timingInfo</var> is null, then return.
- 
+
  <li><p>Let <var>startTime</var> be <var>timingInfo</var>'s
  <a for="fetch timing info">fetch start time</a>.
 
@@ -4116,8 +4109,7 @@ these steps:
    <a for="fetch timing info">worker start time</a> to the <a for=/>unsafe shared current time</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>requestForServiceWorker</var> and <var>fetchParams</var>
-   <a for="fetch params">process response done</a>. [[!HTML]] [[!SW]]
+   <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -2238,7 +2238,7 @@ false), and an optional boolean <dfn export for="obtain a connection"><var>dedic
    <li>
     <p>Set <var>connection</var> to the result of establishing an HTTP connection to
     <var>origin</var>, following the requirements for
-    <a>recording <var>connection</var> timing info</a>.
+    <a>recording connection timing info</a> given <var>connection</var>.
     [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]] [[!TLS]]
 
     <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -197,7 +197,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <p class=XXX>Remove this once HR-TIME-3 refs are available.
 
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
-information later required by the resource timing and navigation timing specs. It has the following
+information required by the resource timing and navigation timing specs. It has the following
 <a for=struct>items</a>:
 <dl>
  <dt><dfn export for="fetch timing info">start time</dfn> (default zero)

--- a/fetch.bs
+++ b/fetch.bs
@@ -4135,7 +4135,7 @@ these steps:
      <a for="fetch timing info">worker start time</a> to <var>workerStartTime</var>.
 
      <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
-     <a for="fetch params">timing info</a> anf <var>response</var>.
+     <a for="fetch params">timing info</a> and <var>response</var>.
 
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
@@ -4804,7 +4804,7 @@ steps. They return a <a for=/>response</a>.
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
      <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
-     <a for="fetch params">timing info</a> anf <var>response</var>.
+     <a for="fetch params">timing info</a> and <var>response</var>.
     </ol>
 
    <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5242,7 +5242,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
        normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
-       <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>Finalize response</a> for
+       <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>finalize response</a> for
        <var>response</var> and <var>fetchParams</var>, and abort these in-parallel steps.
       </ol>
     </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2278,8 +2278,9 @@ clearly stipulates that <a>connections</a> are keyed on
 <!-- See https://github.com/whatwg/fetch/issues/114#issuecomment-143500095 for when we make
      WebSocket saner -->
 
-<p>The requirements for <dfn>recording connection timing info</dfn> given a <a for=/>connection</a>
-<var>connection</var> and its <a for=/>connection timing info</a> <var>timingInfo</var>, are as
+<p>The requirements for <dfn export id="concept-record-connection-timing-info">recording connection
+timing info</dfn> given a <a for=/>connection</a> <var>connection</var> and its
+<a for=/>connection timing info</a> <var>timingInfo</var>, are as
 follows:
 <ul>
  <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -193,9 +193,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
-
- <dt><dfn for="fetch params">redirect timing info list</dfn> (default « »)
- <dd>A <a for=/>list</a> of 0 or more <a for=/>fetch timing info</a>.
 </dl>
 
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
@@ -4317,15 +4314,6 @@ these steps:
     <!-- not resetting actualResponse since it's no longer used anyway -->
   </ol>
 
- <li><p>Let <var>redirectTimingList</var> be <var>fetchParams</var>'s
- <a for="fetch params">redirect timing info list</a>.
-
- <li><p>If <var>redirectTimingList</var> <a for=list>is not empty</a>, then set
- <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> to
- <var>redirectTimingList</var>[0]'s <a for="fetch timing info">fetch start time</a> and
- <a for="fetch timing info">redirect end time</a> to <var>redirectTimingList</var>'s last item's
- <a for="fetch timing info">fetch start time</a>.
-
  <li>
   <p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.
 
@@ -4420,8 +4408,15 @@ run these steps:
   <p class="note no-backref"><var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>'s
   nullity has already been checked.
 
- <li><p>Append <var>fetchParams</var>'s <a for="fetch params">timing info</a> to
- <var>fetchParams</var>'s <a for="fetch params">redirect timing info list</a>.
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">redirect end time</a> to the
+ <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+ <a for="fetch params">cross-origin isolated capability</a>.
+
+ <li><p>If <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> is 0, then set
+ <var>timingInfo</var>'s <a for="fetch timing info">redirect start time</a> to
+ <var>timingInfo</var>'s <a for="fetch timing info">fetch start time</a>.
 
  <li><p><a for=list>Append</a> <var>locationURL</var> to <var>request</var>'s
  <a for=request>URL list</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3933,7 +3933,7 @@ steps:
  <li><p>If <var>timingInfo</var> is not null, then set <var>timingInfo</var>'s
  <a for="fetch timing info">response end time</a> to the <a for=/>unsafe shared current time</a>.
 
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a ofr=request>done flag</a>.
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>done flag</a>.
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
  then <a>queue a fetch task</a> given <var>fetchParams</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -4112,7 +4112,7 @@ these steps:
 
  <li><p>Let <var>actualResponse</var> be null.
 
- <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s<a for="fetch params">timing
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing
  info</a>.
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2397,7 +2397,7 @@ clearly stipulates that <a>connections</a> are keyed on
 
   <p class=note>IANA maintains a
   <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">list of ALPN Protocol IDs</a>.
-</ol>
+</ul>
 
 <p class=note>The <a for=/>clamp and coarsen connection timing info</a> algorithm ensures that
 details of reused connections are not exposed and time values are coarsened.

--- a/fetch.bs
+++ b/fetch.bs
@@ -193,9 +193,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dd>A <a for=/>list</a> of <a for=/>fetch timing info</a>.
 </dl>
 
-<p><dfn>Unsafe shared current time</dfn> is defined in [[HR-TIME]].
-<p class=XXX>Remove this once HR-TIME-3 refs are available.
-
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
 information required by the resource timing and navigation timing specs. It has the following
 <a for=struct>items</a>:

--- a/fetch.bs
+++ b/fetch.bs
@@ -247,6 +247,20 @@ steps:
  set to <var>timingInfo</var>'s <a for="connection timing info">alpn negotiated protocol</a>.
 </ol>
 
+<p>To <dfn>update timing info from stored response</dfn>, given <a for=/>connection timing info</a>
+<var>timingInfo</var> and <a for=/>response</a> <var>response</var>, perform the following steps:
+<ol>
+ <li><p>Let <var>storedTimingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
+
+ <li><p>If <var>storedTimingInfo</var> is null, then return.
+
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> to
+ <var>storedTimingInfo</var>'s <a for="fetch timing info">encoded body size</a>.
+
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> to
+ <var>storedTimingInfo</var>'s <a for="fetch timing info">decoded body size</a>.
+</ol>
+
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
 steps:
@@ -4120,11 +4134,8 @@ these steps:
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
      <a for="fetch timing info">worker start time</a> to <var>workerStartTime</var>.
 
-     <p class=note>If the response is cached, the current <a for="fetch params">timing info</a>'s
-     <a for="fetch timing info">encoded body size</a>,
-     <a for="fetch timing info">decoded body size</a>,
-     <a for="fetch timing info">request start time</a>,
-     and <a for="fetch timing info">response start time</a> will remain zero.
+     <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
+     <a for="fetch params">timing info</a> anf <var>response</var>.
 
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
@@ -4792,6 +4803,8 @@ steps. They return a <a for=/>response</a>.
 
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
+     <li><p><a for=/>Update timing info from stored response</a> for <var>fetchParams</var>'s
+     <a for="fetch params">timing info</a> anf <var>response</var>.
     </ol>
 
    <li>
@@ -4807,6 +4820,9 @@ steps. They return a <a for=/>response</a>.
 
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
+
+      <p class=note>The associated <a for=response>timing info</a> is stored in the cache
+      alongside the response.
     </ol>
   </ol>
 


### PR DESCRIPTION
Created a "fetch timing info" struct to hold the bookkeeping necessary for resource timing.

Populated it with some of the required values, leaving some of them for later patches as this is a big undertaking.

See https://github.com/w3c/resource-timing/issues/252


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1185.html" title="Last updated on Mar 25, 2021, 10:41 AM UTC (66772da)">Preview</a> | <a href="https://whatpr.org/fetch/1185/59da2a4...66772da.html" title="Last updated on Mar 25, 2021, 10:41 AM UTC (66772da)">Diff</a>