### PR TITLE
Editorial: remove some duplicate abort logic

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7854,21 +7854,19 @@ method steps are:
   <ol>
    <li><p>Set <var>locallyAborted</var> to true.
 
-   <li><p><a>Abort the <code>fetch()</code> call</a> with <var>p</var>, <var>request</var>, <var>responseObject</var>,
-   and <var>requestObject</var>'s <a for=Request>signal</a>'s <a for=AbortSignal>abort reason</a>.
+   <li><p><a for=/>Assert</a>: <var>controller</var> is non-null.
 
-   <li><p>If <var>controller</var> is not null, then <a for="fetch controller">abort</a>
-   <var>controller</var> with <var>requestObject</var>'s <a for=Request>signal</a>'s
-   <a for=AbortSignal>abort reason</a>.
+   <li><p><a for="fetch controller">Abort</a> <var>controller</var> with <var>requestObject</var>'s
+   <a for=Request>signal</a>'s <a for=AbortSignal>abort reason</a>.
   </ol>
 
  <li>
   <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given
   <var>request</var> and <a for=fetch><i>processResponse</i></a> given <var>response</var> being
-  these substeps:
+  these steps:
 
   <ol>
-   <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
+   <li><p>If <var>locallyAborted</var> is true, then abort these steps.
 
    <li>
     <p>If <var>response</var>'s <a for=response>aborted flag</a> is set, then:
@@ -7880,10 +7878,12 @@ method steps are:
 
      <li><p><a>Abort the <code>fetch()</code> call</a> with <var>p</var>, <var>request</var>,
      <var>responseObject</var>, and <var>deserializedError</var>.
+
+     <li><p>Abort these steps.
     </ol>
 
    <li><p>If <var>response</var> is a <a>network error</a>, then <a for=/>reject</a> <var>p</var>
-   with a {{TypeError}} and terminate these substeps.
+   with a {{TypeError}} and abort these steps.
 
    <li><p>Set <var>responseObject</var> to the result of <a for=Response>creating</a> a {{Response}}
    object, given <var>response</var>, "<code>immutable</code>", and <var>relevantRealm</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -7906,14 +7906,6 @@ method steps are:
  <li><p>If <var>request</var>'s <a for=request>body</a> is not null and is
  <a for=ReadableStream>readable</a>, then <a for=ReadableStream>cancel</a> <var>request</var>'s
  <a for=request>body</a> with <var>error</var>.
-
- <li><p>If <var>responseObject</var> is null, then return.
-
- <li><p>Let <var>response</var> be <var>responseObject</var>'s <a for=Response>response</a>.
-
- <li><p>If <var>response</var>'s <a for=response>body</a> is not null and is
- <a for=ReadableStream>readable</a>, then <a for=ReadableStream>error</a> <var>response</var>'s
- <a for=response>body</a> with <var>error</var>.
 </ol>
 
 


### PR DESCRIPTION
The fetch algorithm also errors this stream with an "AbortError" DOMException in HTTP-network fetch.

(I could see waiting with landing this until more is cleaned up around how abort/terminate works. My tentative plan is that we keep much of the current structure, but rather than "the ongoing fetch is terminated" we could check something like "fetchHandle's stop is not 'none'" with other values being 'abort' and 'terminate'.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1187.html" title="Last updated on Oct 19, 2022, 3:39 PM UTC (01bd945)">Preview</a> | <a href="https://whatpr.org/fetch/1187/e5f025a...01bd945.html" title="Last updated on Oct 19, 2022, 3:39 PM UTC (01bd945)">Diff</a>