### PR TITLE
Export "determine the network partition key"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2222,7 +2222,7 @@ clearly stipulates that <a>connections</a> are keyed on
 an <a>implementation-defined</a> value.
 
 <p>To
-<dfn lt="determine the network partition key|determining the network partition key">determine the network partition key</dfn>,
+<dfn export lt="determine the network partition key|determining the network partition key">determine the network partition key</dfn>,
 given <var>request</var>, run these steps:
 
 <ol>


### PR DESCRIPTION
Export "determine the network partition key", for external use.

It will be used by w3c/webtransport#217.

This doesn't change any behavior.
