### PR TITLE
Editorial: update Upgrade Insecure Requests reference

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -51,9 +51,6 @@ url:https://tools.ietf.org/html/rfc8941#section-4.2;text:parsing structured fiel
     "SW": {
         "aliasOf": "service-workers"
     },
-    "UPGRADE": {
-        "aliasOf": "upgrade-insecure-requests"
-    },
     "HSTS": {
         "aliasOf": "RFC6797"
     },
@@ -120,6 +117,7 @@ everything that involves, including:
  <li>Fetch Metadata [[!FETCH-METADATA]]
  <li>Service workers [[!SW]]
  <li>Mixed Content [[!MIX]]
+ <li>Upgrade Insecure Requests [[!UPGRADE-INSECURE-REQUESTS]]
  <li>`<code>Referer</code>` [[!REFERRER]]
 </ul>
 
@@ -162,8 +160,8 @@ Streams, and URL Standards.
 [[!STREAMS]]
 [[!URL]]
 
-<p><dfn>ABNF</dfn> means ABNF as augmented by HTTP (in particular the addition <code>#</code>) and
-RFC 7405. [[!RFC7405]]
+<p><dfn>ABNF</dfn> means ABNF as augmented by HTTP (in particular the addition of <code>#</code>)
+and RFC 7405. [[!RFC7405]]
 
 <hr>
 
@@ -1318,7 +1316,6 @@ the empty string,
      * CSP: https://w3c.github.io/webappsec-csp/#effective-directive-for-a-request
      * Mixed Content
      * Preload: https://w3c.github.io/preload/#processing
-     * SRI
      * HTML -->
 
 <p>A <a for=/>request</a>'s <a for=request>destination</a> is
@@ -3450,8 +3447,7 @@ steps:
 
  <li><p>Run <a>report Content Security Policy violations for <var>request</var></a>.
 
- <li><p><a href=https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request>Upgrade <var>request</var> to a potentially secure URL, if appropriate</a>.
- [[!UPGRADE]]
+ <li><p><a>Upgrade <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
  <li><p>If <a lt="block bad port">should <var>request</var> be blocked due to a bad port</a>,
  <a lt="should fetching request be blocked as mixed content?">should fetching <var>request</var> be blocked as mixed content</a>, or


### PR DESCRIPTION
Also fix a minor typo in the ABNF definition and remove SRI from the list of things depending on request destination. I don't think it ever did.

Fixes #409.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1196.html" title="Last updated on Mar 16, 2021, 1:23 PM UTC (2221ec3)">Preview</a> | <a href="https://whatpr.org/fetch/1196/873a42e...2221ec3.html" title="Last updated on Mar 16, 2021, 1:23 PM UTC (2221ec3)">Diff</a>