### PR TITLE
Add chunk type checking of requestForServiceWorker's body's stream

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4156,6 +4156,30 @@ these steps:
    <li><p>Let <var>requestForServiceWorker</var> be a <a for=request>clone</a> of
    <var>request</var>.
 
+   <li>
+    <p> If <var>requestForServiceWorker</var>'s <a for=/>body</a> is non-null, then:
+
+    <ol>
+     <li> Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
+      <ol>
+        <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+
+        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
+         <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+
+        <li>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may split
+         the chunk and enqueues multiple times.
+      </ol>
+
+     <li> Let <var>transformStream</var> be result of <a for=TransformStream>creating</a> a
+      {{TransformStream}} with <var>transformAlgorithm</var>.
+
+     <li> Let <var>streamForServiceWorker</var> be result of pipeThrough
+      the stream with <var>transformStream</var>.
+
+     <li> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to <var>streamForServiceWorker</var>.
+    </ol>
+
    <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>coarsened shared current time</a>
    given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4160,27 +4160,28 @@ these steps:
     <p> If <var>requestForServiceWorker</var>'s <a for=/>body</a> is non-null, then:
 
     <ol>
-     <li> Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
+     <li><p> Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
       <ol>
-        <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+       <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
 
-        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
-         <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+       <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
+        <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
 
-        <li>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may split
-         the chunk in <a>implementation-defined</a> practical size and
-         <a for=ReadableStream>enqueues</a> each of them.
+       <li>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may split
+        the chunk into <a>implementation-defined</a> practical sizes and
+        <a for=ReadableStream>enqueue</a> each of them. The user agent also may concatenate the
+        chunks into an <a>implementation-defined</a> practical size and
+        <a for=ReadableStream>enqueue</a> it.
       </ol>
 
-     <li> Let <var>transformStream</var> be result of <a for=TransformStream>setting up</a> a
+     <li><p> Let <var>transformStream</var> be result of <a for=TransformStream>setting up</a> a
       {{TransformStream}} with <var>transformAlgorithm</var>.
 
-     <li> Perform <a href=https://streams.spec.whatwg.org/#readable-stream-pipe-to>ReadableStreamPipeTo</a>(
-       <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream, <var>transformStream</var>'s
-        writable stream).
+     <li><p> Let <var>transformedStream</var> be result of <var>requestForServiceWorker</var>'s
+      <a for=/>body</a>'s stream <a for=ReadableStream>piped through</a> <var>transformStream</var>.
 
-     <li> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
-      <var>transformStream</var>'s readable stream.
+     <li><p> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
+      <var>transformedStream</var>.
     </ol>
 
    <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>coarsened shared current time</a>
@@ -7856,6 +7857,7 @@ Xabier Rodríguez,
 Yehuda Katz,
 Yoav Weiss,
 Youenn Fablet<!-- youennf; GitHub -->,
+Yoichi Osato,
 平野裕 (Yutaka Hirano), and
 Zhenbin Xu
 for being awesome.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4157,31 +4157,33 @@ these steps:
    <var>request</var>.
 
    <li>
-    <p> If <var>requestForServiceWorker</var>'s <a for=/>body</a> is non-null, then:
+    <p>If <var>requestForServiceWorker</var>'s <a for=/>body</a> is non-null, then:
 
     <ol>
-     <li><p> Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
+     <li>
+      <p>Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
+
       <ol>
        <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
 
        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
-        <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+       <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
 
-       <li>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may split
-        the chunk into <a>implementation-defined</a> practical sizes and
-        <a for=ReadableStream>enqueue</a> each of them. The user agent also may concatenate the
-        chunks into an <a>implementation-defined</a> practical size and
-        <a for=ReadableStream>enqueue</a> it.
+       <li><p>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may
+       split the chunk into <a>implementation-defined</a> practical sizes and
+       <a for=ReadableStream>enqueue</a> each of them. The user agent also may concatenate the
+       chunks into an <a>implementation-defined</a> practical size and
+       <a for=ReadableStream>enqueue</a> it.
       </ol>
 
-     <li><p> Let <var>transformStream</var> be result of <a for=TransformStream>setting up</a> a
-      {{TransformStream}} with <var>transformAlgorithm</var>.
+     <li><p>Let <var>transformStream</var> be the result of <a for=TransformStream>setting up</a> a
+     {{TransformStream}} with <var>transformAlgorithm</var>.
 
-     <li><p> Let <var>transformedStream</var> be result of <var>requestForServiceWorker</var>'s
-      <a for=/>body</a>'s stream <a for=ReadableStream>piped through</a> <var>transformStream</var>.
+     <li><p>Let <var>transformedStream</var> be the result of <var>requestForServiceWorker</var>'s
+     <a for=/>body</a>'s stream <a for=ReadableStream>piped through</a> <var>transformStream</var>.
 
-     <li><p> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
-      <var>transformedStream</var>.
+     <li><p>Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
+     <var>transformedStream</var>.
     </ol>
 
    <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>coarsened shared current time</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4173,7 +4173,7 @@ these steps:
       </ol>
 
      <li> Let <var>transformStream</var> be result of <a for=TransformStream>creating</a> a
-      {{TransformStream}} with <var>transformAlgorithm</var>.      
+      {{TransformStream}} with <var>transformAlgorithm</var>.
 
      <li> Perform <a href=https://streams.spec.whatwg.org/#readable-stream-pipe-to>ReadableStreamPipeTo</a>(
        <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream, <var>transformStream</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -4168,16 +4168,19 @@ these steps:
          <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
 
         <li>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may split
-         the chunk and enqueues multiple times.
+         the chunk in <a>implementation-defined</a> practical size and
+         <a for=ReadableStream>enqueues</a> each of them.
       </ol>
 
      <li> Let <var>transformStream</var> be result of <a for=TransformStream>creating</a> a
-      {{TransformStream}} with <var>transformAlgorithm</var>.
+      {{TransformStream}} with <var>transformAlgorithm</var>.      
 
-     <li> Let <var>streamForServiceWorker</var> be result of pipeThrough
-      the stream with <var>transformStream</var>.
+     <li> Perform <a href=https://streams.spec.whatwg.org/#readable-stream-pipe-to>ReadableStreamPipeTo</a>(
+       <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream, <var>transformStream</var>'s
+        writable stream).
 
-     <li> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to <var>streamForServiceWorker</var>.
+     <li> Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
+      <var>transformStream</var>'s readable stream.
     </ol>
 
    <li><p>Let <var>serviceWorkerStartTime</var> be the <a for=/>coarsened shared current time</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4180,9 +4180,10 @@ these steps:
      {{TransformStream}} with <var>transformAlgorithm</var>.
 
      <li><p>Let <var>transformedStream</var> be the result of <var>requestForServiceWorker</var>'s
-     <a for=/>body</a>'s stream <a for=ReadableStream>piped through</a> <var>transformStream</var>.
+     <a for=/>body</a>'s <a for=body>stream</a> <a for=ReadableStream>piped through</a>
+     <var>transformStream</var>.
 
-     <li><p>Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s stream to
+     <li><p>Set <var>requestForServiceWorker</var>'s <a for=/>body</a>'s <a for=body>stream</a> to
      <var>transformedStream</var>.
     </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4172,7 +4172,7 @@ these steps:
          <a for=ReadableStream>enqueues</a> each of them.
       </ol>
 
-     <li> Let <var>transformStream</var> be result of <a for=TransformStream>creating</a> a
+     <li> Let <var>transformStream</var> be result of <a for=TransformStream>setting up</a> a
       {{TransformStream}} with <var>transformAlgorithm</var>.
 
      <li> Perform <a href=https://streams.spec.whatwg.org/#readable-stream-pipe-to>ReadableStreamPipeTo</a>(


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/28203
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1191310
   * Firefox: N/A as streaming request body has not been implemented.
   * Safari: N/A as streaming request body has not been implemented.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

This change addresses the inconsistency discussed in #267 that a chunk type in stream body on uploading to the network is 
limited only to `Uint8Array` but passing it to a service worker is not restricted.
This PR changes later to limiting `Uint8Array` as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1199.html" title="Last updated on Apr 15, 2021, 2:04 AM UTC (4ad580d)">Preview</a> | <a href="https://whatpr.org/fetch/1199/f361d9c...4ad580d.html" title="Last updated on Apr 15, 2021, 2:04 AM UTC (4ad580d)">Diff</a>