### PR TITLE
processResponseDone should receive a response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7281,7 +7281,7 @@ method steps are:
   </ol>
 
  <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
- <a>finalize and report timing</a> with <var>responseObject</var>, <var>globalObject</var>, and
+ <a>finalize and report timing</a> with <var>response</var>, <var>globalObject</var>, and
  "<code>fetch</code>".
 
  <li>
@@ -7293,16 +7293,16 @@ method steps are:
    <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
 
    <li><p>If <var>response</var>'s <a for=response>aborted flag</a> is set, then <a>abort fetch</a>
-   with <var>p</var>, <var>request</var>, and <var>response</var>, and terminate these
+   with <var>p</var>, <var>request</var>, and <var>responseObject</var>, and terminate these
    substeps.
 
    <li><p>If <var>response</var> is a <a>network error</a>, then <a for=/>reject</a> <var>p</var>
    with a {{TypeError}} and terminate these substeps.
 
-   <li><p>Set <var>response</var> to the result of <a for=Response>creating</a> a {{Response}}
+   <li><p>Set <var>responseObject</var> to the result of <a for=Response>creating</a> a {{Response}}
    object, given <var>response</var>, "<code>immutable</code>", and <var>relevantRealm</var>.
 
-   <li><p><a for=/>Resolve</a> <var>p</var> with <var>response</var>.
+   <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
   </ol>
 
  <li><p>Return <var>p</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3988,8 +3988,8 @@ steps:
  <a for=request>done flag</a>.
 
  <li><p>If <var>timingInfo</var> is null, then return.
- 
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to
+
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to
  the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
  <a for="fetch params">cross-origin isolated capability</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4011,13 +4011,20 @@ steps:
 
  <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
+ <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
+
  <li><p>If <var>timingInfo</var> is null, then return.
 
- <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then set
- <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
- <a for="fetch timing info">start time</a> and
- <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
- <a for="fetch timing info">start time</a>.
+ <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
+ perform the following steps:
+ <ol>
+  <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
+  <a for="fetch timing info">start time</a> and
+  <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+  <a for="fetch timing info">start time</a>.
+
+  <li><p>Set <var>cacheState</var> to an empty string.
+ </ol>
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
  <a for=/>coarsened shared current time</a> given <var>global</var>'s
@@ -4027,7 +4034,8 @@ steps:
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
  <li><p><a>Mark resource timing</a> for
- <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
+ <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var> and
+ <var>cacheState</var>.
  <!-- TODO -->
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1932,6 +1932,9 @@ message as HTTP/2 does not support them.
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string or
 "<code>local</code>"). Unlesss stated otherwise, it is the empty string.
 
+<p class=note>This is intended for usage by <cite>Service Workers</cite> and
+<cite>Resource Timing</cite>.  [[SW]]
+
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-csp-list>CSP list</dfn>, which is a <a for=/>list</a>
 of <a>Content Security Policy objects</a> for the <a for=/>response</a>. The list is empty unless

--- a/fetch.bs
+++ b/fetch.bs
@@ -1933,7 +1933,9 @@ message as HTTP/2 does not support them.
 "<code>local</code>"). Unlesss stated otherwise, it is the empty string.
 
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
-<cite>Resource Timing</cite>.  [[SW]]
+<cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]
+<!-- If we ever expand the utility of this we need to carefully consider whether filtered responses
+     need to mask it, whether the cache API needs to store it, etc. -->
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-csp-list>CSP list</dfn>, which is a <a for=/>list</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4009,8 +4009,7 @@ steps:
  <li><p>If <var>timingInfo</var> is null, then return.
 
  <li>
-  <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
-  perform the following steps:
+  <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then:
 
   <ol>
    <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
@@ -4018,7 +4017,7 @@ steps:
    <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
    <a for="fetch timing info">start time</a>.
 
-   <li><p>Set <var>cacheState</var> to an empty string.
+   <li><p>Set <var>cacheState</var> to the empty string.
   </ol>
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the

--- a/fetch.bs
+++ b/fetch.bs
@@ -4024,7 +4024,8 @@ steps:
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
  <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
- <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
+ <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var>, and
+ <var>cacheState</var>.
  <!-- TODO -->
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3989,10 +3989,6 @@ steps:
 
  <li><p>If <var>timingInfo</var> is null, then return.
 
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to
- the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
- <a for="fetch params">cross-origin isolated capability</a>.
-
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
  then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response done</a> given <var>response</var>,
@@ -4015,16 +4011,17 @@ steps:
 
  <li><p>If <var>timingInfo</var> is null, then return.
 
- <li><p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
- perform the following steps:
- <ol>
-  <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
-  <a for="fetch timing info">start time</a> and
-  <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
-  <a for="fetch timing info">start time</a>.
+ <li>
+  <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
+  perform the following steps:
+  <ol>
+    <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
+    <a for="fetch timing info">start time</a> and
+    <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+    <a for="fetch timing info">start time</a>.
 
-  <li><p>Set <var>cacheState</var> to an empty string.
- </ol>
+    <li><p>Set <var>cacheState</var> to an empty string.
+  </ol>
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
  <a for=/>coarsened shared current time</a> given <var>global</var>'s
@@ -4034,9 +4031,9 @@ steps:
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
  <li><p>
- <a href="https://w3c.github.io/resource-timing/#dfn-mark-resource-timing">Mark resource timing</a>
- for <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var> and
- <var>cacheState</var>.
+ <a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a>
+ for <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var>,
+ and <var>cacheState</var>.
 </ol>
 
 
@@ -7285,8 +7282,8 @@ method steps are:
    <li><p><a lt=terminated for=fetch>Terminate</a> the ongoing fetch with the aborted flag set.
   </ol>
 
- <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
- <a>finalize and report timing</a> with <var>response</var>, <var>globalObject</var>, and
+ <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>responseObject</var> be to
+ <a>finalize and report timing</a> with <var>responseObject</var>, <var>globalObject</var>, and
  "<code>fetch</code>".
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4028,9 +4028,8 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p><a for=/>Mark resource timing</a> for
- <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var>, and
- <var>cacheState</var>.
+ <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>originalURL</var>,
+ <var>initiatorType</var>, <var>global</var>, and <var>cacheState</var>.
 </ol>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4033,10 +4033,10 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p><a>Mark resource timing</a> for
- <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var> and
+ <li><p>
+ <a href="https://w3c.github.io/resource-timing/#dfn-mark-resource-timing">Mark resource timing</a>
+ for <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var> and
  <var>cacheState</var>.
- <!-- TODO -->
 </ol>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4026,7 +4026,7 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p><span>Mark resource timing</span> for
+ <li><p><a>Mark resource timing</a> for
  <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
  <!-- TODO -->
 </ol>
@@ -4289,20 +4289,9 @@ these steps:
 
    <li>
     <p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and a
-    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then:
-    <ul>
-     <li><p>Let <var>response</var> be a <a>network error</a>.
+    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return a
+    <a>network error</a>.
 
-     <li><p>Set <var>response</var>'s <a for=response>timing info</a> to a new
-     <a for=/>fetch timing info</a> with its <a for="fetch timing info">start time</a> and its
-     <a for="fetch timing info">post-redirect start time</a> set to <var>fetchParams</var>'s
-     <a for="fetch params">timing info</a>'s <a for="fetch timing info">start time</a>, and
-     its <a for="fetch timing info">end time</a> set to the <a for=/>coarsened shared current
-     time</a> given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated
-     capability</a>.
-
-     <li>Return <var>response</var>.
-    </ul>
     <p class="note no-backref">As the <a>CORS check</a> is not to be applied to
     <a for=/>responses</a> whose <a for=response>status</a> is 304 or 407, or <a for=/>responses</a>
     from a service worker for that matter, it is applied here.
@@ -4359,8 +4348,9 @@ these steps:
 
   <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
   Resource Timing entry later. This step is done here, as resource-timing entries are available only
-  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for
-  <code>data:</code> and <code>blob:</code> URL fetches.
+  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for,
+  e.g., <code>data:</code>, <code>blob:</code> URL fetches, and are only available after all the
+  relevant security checks have succeeded.
 
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -4026,7 +4026,7 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
+ <li><p><span>Mark resource timing</span> for
  <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
  <!-- TODO -->
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4028,10 +4028,9 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
+ <li><p><a for=/>Mark resource timing</a> for
  <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var>, and
  <var>cacheState</var>.
- <!-- TODO -->
 </ol>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4289,9 +4289,20 @@ these steps:
 
    <li>
     <p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and a
-    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return a
-    <a>network error</a>.
+    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then:
+    <ul>
+     <li><p>Let <var>response</var> be a <a>network error</a>.
 
+     <li><p>Set <var>response</var>'s <a for=response>timing info</a> to a new
+     <a for=/>fetch timing info</a> with its <a for="fetch timing info">start time</a> and its
+     <a for="fetch timing info">post-redirect start time</a> set to <var>fetchParams</var>'s
+     <a for="fetch params">timing info</a>'s <a for="fetch timing info">start time</a>, and
+     its <a for="fetch timing info">end time</a> set to the <a for=/>coarsened shared current
+     time</a> given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated
+     capability</a>.
+
+     <li>Return <var>response</var>.
+    </ul>
     <p class="note no-backref">As the <a>CORS check</a> is not to be applied to
     <a for=/>responses</a> whose <a for=response>status</a> is 304 or 407, or <a for=/>responses</a>
     from a service worker for that matter, it is applied here.
@@ -4348,9 +4359,8 @@ these steps:
 
   <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
   Resource Timing entry later. This step is done here, as resource-timing entries are available only
-  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for,
-  e.g., <code>data:</code>, <code>blob:</code> URL fetches, and are only available after all the
-  relevant security checks have succeeded.
+  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for
+  <code>data:</code> and <code>blob:</code> URL fetches.
 
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -3512,7 +3512,7 @@ representing the number of bytes transmitted. If given, <var>processRequestEndOf
 an algorithm accepting no arguments. If given, <var>processResponse</var> must be an algorithm
 accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be an
 algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>. If
-given, <var>processResponseDone</var> must be an algorithm accepting no arguments.
+given, <var>processResponseDone</var> must be an algorithm accepting a <a for=/>response</a>.
 
 <p>An ongoing <a for=/>fetch</a> can be
 <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> with flag <var>aborted</var>,
@@ -3982,13 +3982,21 @@ steps:
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
+ <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
+
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 
+ <li><p>If <var>timingInfo</var> is null, then return.
+ 
+ <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">response end time</a> to
+ the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+ <a for="fetch params">cross-origin isolated capability</a>.
+
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
- then <a>queue a fetch task</a> given <var>fetchParams</var>'s
- <a for="fetch params">process response done</a> and <var>fetchParams</var>'s
- <a for="fetch params">task destination</a>.
+ then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+ <a for="fetch params">process response done</a> given <var>response</var>,
+ with <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
@@ -7269,8 +7277,9 @@ method steps are:
    <li><p><a lt=terminated for=fetch>Terminate</a> the ongoing fetch with the aborted flag set.
   </ol>
 
- <li><p>Let <var>handleFetchDone</var> be to <a>finalize and report timing</a> with
- <var>response</var>, <var>globalObject</var>, and "<code>fetch</code>".
+ <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
+ <a>finalize and report timing</a> with <var>response</var>, <var>globalObject</var>, and
+ "<code>fetch</code>".
 
  <li>
   <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponseDone</i></a> set to

--- a/fetch.bs
+++ b/fetch.bs
@@ -1932,10 +1932,6 @@ message as HTTP/2 does not support them.
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string or
 "<code>local</code>"). Unlesss stated otherwise, it is the empty string.
 
-<p class=note>This is intended solely for usage by service workers. [[SW]]
-<!-- If we ever expand the utility of this we need to carefully consider whether filtered responses
-     need to mask it, whether the cache API needs to store it, etc. -->
-
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-csp-list>CSP list</dfn>, which is a <a for=/>list</a>
 of <a>Content Security Policy objects</a> for the <a for=/>response</a>. The list is empty unless
@@ -3982,8 +3978,6 @@ steps:
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
- <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
-
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3987,8 +3987,6 @@ steps:
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 
- <li><p>If <var>timingInfo</var> is null, then return.
-
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
  then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response done</a> given <var>response</var>,
@@ -4014,13 +4012,14 @@ steps:
  <li>
   <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then
   perform the following steps:
-  <ol>
-    <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
-    <a for="fetch timing info">start time</a> and
-    <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
-    <a for="fetch timing info">start time</a>.
 
-    <li><p>Set <var>cacheState</var> to an empty string.
+  <ol>
+   <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
+   <a for="fetch timing info">start time</a> and
+   <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+   <a for="fetch timing info">start time</a>.
+
+   <li><p>Set <var>cacheState</var> to an empty string.
   </ol>
 
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
@@ -4030,10 +4029,9 @@ steps:
 
  <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
 
- <li><p>
- <a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a>
- for <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, <var>global</var>,
- and <var>cacheState</var>.
+ <li><p><a href="https://github.com/w3c/resource-timing/pull/261">Mark resource timing</a> for
+ <var>timingInfo</var>, <var>originalURL</var>, <var>initiatorType</var>, and <var>global</var>.
+ <!-- TODO -->
 </ol>
 
 
@@ -7282,7 +7280,7 @@ method steps are:
    <li><p><a lt=terminated for=fetch>Terminate</a> the ongoing fetch with the aborted flag set.
   </ol>
 
- <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>responseObject</var> be to
+ <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
  <a>finalize and report timing</a> with <var>responseObject</var>, <var>globalObject</var>, and
  "<code>fetch</code>".
 
@@ -7295,16 +7293,16 @@ method steps are:
    <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
 
    <li><p>If <var>response</var>'s <a for=response>aborted flag</a> is set, then <a>abort fetch</a>
-   with <var>p</var>, <var>request</var>, and <var>responseObject</var>, and terminate these
+   with <var>p</var>, <var>request</var>, and <var>response</var>, and terminate these
    substeps.
 
    <li><p>If <var>response</var> is a <a>network error</a>, then <a for=/>reject</a> <var>p</var>
    with a {{TypeError}} and terminate these substeps.
 
-   <li><p>Set <var>responseObject</var> to the result of <a for=Response>creating</a> a {{Response}}
+   <li><p>Set <var>response</var> to the result of <a for=Response>creating</a> a {{Response}}
    object, given <var>response</var>, "<code>immutable</code>", and <var>relevantRealm</var>.
 
-   <li><p><a for=/>Resolve</a> <var>p</var> with <var>responseObject</var>.
+   <li><p><a for=/>Resolve</a> <var>p</var> with <var>response</var>.
   </ol>
 
  <li><p>Return <var>p</var>.


### PR DESCRIPTION
Only call processResponseDone for responses that have their
timing info set, which are responses that have passed CORS
and redirects.

Closes https://github.com/whatwg/fetch/issues/1201


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1202.html" title="Last updated on Apr 21, 2021, 10:57 AM UTC (b455c91)">Preview</a> | <a href="https://whatpr.org/fetch/1202/6453947...b455c91.html" title="Last updated on Apr 21, 2021, 10:57 AM UTC (b455c91)">Diff</a>