### PR TITLE
Add a limited size buffer for streaming upload in HTTP request.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5063,14 +5063,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
-      <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer of
-      <a>implementation-defined</a> size and store a part of <var>request</var>'s
-      <a for=request>body</a> to the buffer. The buffer is used to resend <var>request</var>'s
-      <a for=request>body</a> to the network. If the user agent sent more than the buffer size and
-      is required to resend, return a <a>network error</a>.
+      <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer up
+      to 64k bytes and store a part of <var>request</var>'s <a for=request>body</a> to the buffer.
+      If the user agent reads from <var>request</var>'s <a for=request>body</a> beyond the buffer
+      size, <var>request</var> is no longer eligible for resending.
 
       <div class="note no-backref">
-       <p>The re-sending is needed when the connection is timed out, for example.
+       <p>The resending is needed when the connection is timed out, for example.
 
        <p>The buffer is not needed when request's <a for=request>body</a>'s
        <a for=body>source</a> is non-null, because the <a for=request>body</a> can be re-created

--- a/fetch.bs
+++ b/fetch.bs
@@ -5066,7 +5066,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <a for=request>body</a>'s <a for=body>source</a> is null, then the user agent may have a
       buffer up to 64 kibibytes and store a part of <var>request</var>'s <a for=request>body</a> in
       the buffer. If the user agent reads from <var>request</var>'s <a for=request>body</a> beyond
-      the buffer size, then <var>request</var> is no longer eligible for resending.
+      the buffer size and the user agent is required to resend <var>request</var>, return a
+      return a <a>network error</a>.
 
       <div class=note>
        <p>The resending is needed when the connection is timed out, for example.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5064,19 +5064,19 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
       <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer up
-      to 64k bytes and store a part of <var>request</var>'s <a for=request>body</a> to the buffer.
+      to 64 kibibytes and store a part of <var>request</var>'s <a for=request>body</a> to the buffer.
       If the user agent reads from <var>request</var>'s <a for=request>body</a> beyond the buffer
       size, <var>request</var> is no longer eligible for resending.
 
       <div class="note no-backref">
        <p>The resending is needed when the connection is timed out, for example.
 
-       <p>The buffer is not needed when request's <a for=request>body</a>'s
+       <p>The buffer is not needed when <var>request</var>'s <a for=request>body</a>'s
        <a for=body>source</a> is non-null, because the <a for=request>body</a> can be recreated
-       from <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>.
+       from it.
 
-       <p>When <var>request</var>'s <a for=request>body</a>'s source is null, it means
-       <a for=request>body</a> is created from {{ReadableStream}}, which means
+       <p>When <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a> is null, it
+       means <a for=request>body</a> is created from {{ReadableStream}}, which means
        <a for=request>body</a> cannot be recreated and that is why the buffer is needed.
       </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5066,7 +5066,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer up
       to 64 kibibytes and store a part of <var>request</var>'s <a for=request>body</a> to the buffer.
       If the user agent reads from <var>request</var>'s <a for=request>body</a> beyond the buffer
-      size, <var>request</var> is no longer eligible for resending.
+      size and the user agent is required to resend <var>request</var>, return a
+      <a>network error</a>.
 
       <div class="note no-backref">
        <p>The resending is needed when the connection is timed out, for example.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5064,14 +5064,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
       <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer of
-      <a>implementation-defined</a> size and store the part of <var>request</var>'s
+      <a>implementation-defined</a> size and store a part of <var>request</var>'s
       <a for=request>body</a> to the buffer. The buffer is used to resend <var>request</var>'s
       <a for=request>body</a> to the network. If the user agent sent more than the buffer size and
       is required to resend, return a <a>network error</a>.
 
       <div class="note no-backref">
-       <p>The re-sending in resolving the HTTP request is needed when the
-       connection is timed out, for example.
+       <p>The re-sending is needed when the connection is timed out, for example.
 
        <p>The buffer is not needed when request's <a for=request>body</a>'s
        <a for=body>source</a> is non-null, because the <a for=request>body</a> can be re-created

--- a/fetch.bs
+++ b/fetch.bs
@@ -5077,7 +5077,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <p>When <var>request</var>'s <a for=request>body</a>'s source is null, it means
        <a for=request>body</a> is created from {{ReadableStream}}, which means
-       <a for=request>body</a> can not be re-created and that's because why the buffer is needed.
+       <a for=request>body</a> cannot be recreated and that is why the buffer is needed.
       </div>
 
      <li><p>Set <var>timingInfo</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -5072,7 +5072,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <p>The resending is needed when the connection is timed out, for example.
 
        <p>The buffer is not needed when request's <a for=request>body</a>'s
-       <a for=body>source</a> is non-null, because the <a for=request>body</a> can be re-created
+       <a for=body>source</a> is non-null, because the <a for=request>body</a> can be recreated
        from <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>.
 
        <p>When <var>request</var>'s <a for=request>body</a>'s source is null, it means

--- a/fetch.bs
+++ b/fetch.bs
@@ -5064,9 +5064,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
       <a for=request>body</a>'s <a for=body>source</a> is null, then the user agent may have a
-      buffer up to 64 kibibytes and store a part of <var>request</var>'s <a for=request>body</a> in
-      the buffer. If the user agent reads from <var>request</var>'s <a for=request>body</a> beyond
-      the buffer size and the user agent is required to resend <var>request</var>, return a
+      buffer of up to 64 kibibytes and store a part of <var>request</var>'s <a for=request>body</a>
+      in that buffer. If the user agent reads from <var>request</var>'s <a for=request>body</a>
+      beyond that buffer's size and the user agent needs to resend <var>request</var>, then instead
       return a <a>network error</a>.
 
       <div class=note>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5061,12 +5061,26 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
-     <li><p> In resolving the HTTP request, there is an evitable situaion that the user agent must
-     resend the <var>request</var> body (e.g. socket time-out).
-     If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
-      <a for=request>body</a>'s <a for=body>source</a> is null, there is an <a>implementation-defined</a>
-      cache limit not to cache the entire <a for=request>body</a>'s stream. If the cache runs out,
-      return a <a>network error</a>.
+     <li>
+      <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
+      <a for=request>body</a>'s <a for=body>source</a> is null, the user agent may have a buffer of
+      <a>implementation-defined</a> size and store the part of <var>request</var>'s
+      <a for=request>body</a> to the buffer. The buffer is used to resend <var>request</var>'s
+      <a for=request>body</a> to the network. If the user agent sent more than the buffer size and
+      is required to resend, return a <a>network error</a>.
+
+      <div class="note no-backref">
+       <p>The re-sending in resolving the HTTP request is needed when the
+       connection is timed out, for example.
+
+       <p>The buffer is not needed when request's <a for=request>body</a>'s
+       <a for=body>source</a> is non-null, because the <a for=request>body</a> can be re-created
+       from <var>request</var>'s <a for=request>body</a>'s <a for=body>source</a>.
+
+       <p>When <var>request</var>'s <a for=request>body</a>'s source is null, it means
+       <a for=request>body</a> is created from {{ReadableStream}}, which means
+       <a for=request>body</a> can not be re-created and that's because why the buffer is needed.
+      </div>
 
      <li><p>Set <var>timingInfo</var>'s
      <a for="fetch timing info">final network-response start time</a> to the

--- a/fetch.bs
+++ b/fetch.bs
@@ -5061,6 +5061,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
 
+     <li><p> In resolving the HTTP request, there is an evitable situaion that the user agent must
+     resend the <var>request</var> body (e.g. socket time-out).
+     If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
+      <a for=request>body</a>'s <a for=body>source</a> is null, there is an <a>implementation-defined</a>
+      cache limit not to cache the entire <a for=request>body</a>'s stream. If the cache runs out,
+      return a <a>network error</a>.
+
      <li><p>Set <var>timingInfo</var>'s
      <a for="fetch timing info">final network-response start time</a> to the
      <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/issues/28568
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1077174
   * Firefox: N/A as streaming request body has not been implemented
   * Safari: N/A as streaming request body has not been implemented

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

This fixes #538.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1204.html" title="Last updated on Apr 19, 2021, 9:34 AM UTC (ff67a7a)">Preview</a> | <a href="https://whatpr.org/fetch/1204/f361d9c...ff67a7a.html" title="Last updated on Apr 19, 2021, 9:34 AM UTC (ff67a7a)">Diff</a>