### PR TITLE
Meta: anchor HR-TIME and RESOURCE-TIMING terms

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -11,15 +11,28 @@ Translate IDs: typedefdef-bodyinit bodyinit,dictdef-requestinit requestinit,type
 </pre>
 
 <pre class=anchors>
-url:https://tools.ietf.org/html/rfc7230#section-3.1.1;text:method;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-name;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-content;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2;text:field-value;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.1.2;text:reason-phrase;type:dfn;spec:http
+urlPrefix:https://tools.ietf.org/html/rfc7230#;type:dfn;spec:http
+    url:section-3.1.1;text:method
+    url:section-3.2;text:field-name
+    url:section-3.2;text:field-content
+    url:section-3.2;text:field-value
+    url:section-3.1.2;text:reason-phrase
+
 url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
-url:https://tools.ietf.org/html/rfc8941#section-2;text:structured field value;type:dfn;spec:rfc8941
-url:https://tools.ietf.org/html/rfc8941#section-4.1;text:serializing structured fields;type:dfn;spec:rfc8941
-url:https://tools.ietf.org/html/rfc8941#section-4.2;text:parsing structured fields;type:dfn;spec:rfc8941
+
+urlPrefix:https://tools.ietf.org/html/rfc8941#;type:dfn;spec:rfc8941
+    url:section-2;text:structured field value
+    url:section-4.1;text:serializing structured fields
+    url:section-4.2;text:parsing structured fields
+
+url:https://w3c.github.io/resource-timing/#dfn-mark-resource-timing;text:mark resource timing;type:dfn;spec:resource-timing
+
+urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
+    type:idl;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
+    type:dfn
+        url:dfn-coarsen-time;text:coarsen time
+        url:dfn-coarsened-shared-current-time;text:coarsened shared current time
+        url:dfn-unsafe-shared-current-time;text:unsafe shared current time
 </pre>
 
 <pre class=biblio>

--- a/fetch.bs
+++ b/fetch.bs
@@ -32,7 +32,7 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
         url:dfn-coarsen-time;text:coarsen time
         url:dfn-coarsened-shared-current-time;text:coarsened shared current time
         url:dfn-unsafe-shared-current-time;text:unsafe shared current time
-    type:idl;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
+    type:typedef;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
 </pre>
 
 <pre class=biblio>

--- a/fetch.bs
+++ b/fetch.bs
@@ -11,16 +11,16 @@ Translate IDs: typedefdef-bodyinit bodyinit,dictdef-requestinit requestinit,type
 </pre>
 
 <pre class=anchors>
-urlPrefix:https://tools.ietf.org/html/rfc7230#;type:dfn;spec:http
+urlPrefix:https://datatracker.ietf.org/doc/html/rfc7230#;type:dfn;spec:http
     url:section-3.1.1;text:method
     url:section-3.2;text:field-name
     url:section-3.2;text:field-content
     url:section-3.2;text:field-value
     url:section-3.1.2;text:reason-phrase
 
-url:https://tools.ietf.org/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
+url:https://datatracker.ietf.org/doc/html/rfc7234#section-1.2.1;text:delta-seconds;type:dfn;spec:http-caching
 
-urlPrefix:https://tools.ietf.org/html/rfc8941#;type:dfn;spec:rfc8941
+urlPrefix:https://datatracker.ietf.org/doc/html/rfc8941#;type:dfn;spec:rfc8941
     url:section-2;text:structured field value
     url:section-4.1;text:serializing structured fields
     url:section-4.2;text:parsing structured fields
@@ -87,7 +87,7 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
     },
     "EXPECT-CT": {
         "authors": ["Emily Stark"],
-        "href": "https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-02",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct",
         "publisher": "IETF",
         "title": "Expect-CT Extension for HTTP"
     },
@@ -96,19 +96,19 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
     },
     "HTTP3": {
         "authors": ["M. Bishop, Ed."],
-        "href": "https://tools.ietf.org/html/draft-ietf-quic-http",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-quic-http",
         "publisher": "IETF",
         "title": "Hypertext Transfer Protocol Version 3 (HTTP/3)"
     },
     "WEBTRANSPORT-HTTP3": {
         "authors": ["V. Vasiliev"],
-        "href": "https://tools.ietf.org/html/draft-ietf-webtrans-http3",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3",
         "publisher": "IETF",
         "title": "WebTransport over HTTP/3"
     },
     "HTTP3-DATAGRAM": {
         "authors": ["David Schinazi", "Lucas Pardue"],
-        "href": "https://tools.ietf.org/html/draft-ietf-masque-h3-datagram",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram",
         "publisher": "IETF",
         "title": "Using QUIC Datagrams with HTTP/3"
     }
@@ -843,8 +843,8 @@ following is true:
  <li><p><var>byte</var> is 0x22 ("), 0x28 (left parenthesis), 0x29 (right parenthesis), 0x3A (:),
  0x3C (&lt;), 0x3E (>), 0x3F (?), 0x40 (@), 0x5B ([), 0x5C (\), 0x5D (]), 0x7B ({), 0x7D (}), or
  0x7F DEL.
- <!-- Delimiters from https://tools.ietf.org/html/rfc7230#section-3.2.6 except for ,/;= and
-      including DEL -->
+ <!-- Delimiters from https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6 except for ,/;=
+      and including DEL -->
 </ul>
 
 <p>The <dfn noexport>CORS-unsafe request-header names</dfn>, given a <a for=/>header list</a>
@@ -2090,13 +2090,13 @@ is a <a>filtered response</a> whose
 </ol>
 
 <p>A <dfn id=concept-fresh-response>fresh response</dfn> is a <a for=/>response</a> whose
-<a href=https://tools.ietf.org/html/rfc7234#section-4.2.3>current age</a> is within its
-<a href=https://tools.ietf.org/html/rfc7234#section-4.2.1>freshness lifetime</a>.
+<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.3>current age</a> is within its
+<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.1>freshness lifetime</a>.
 
 <p>A <dfn id=concept-stale-while-revalidate-response>stale-while-revalidate response</dfn> is a
 <a for=/>response</a> that is not a <a>fresh response</a> and whose
-<a href=https://tools.ietf.org/html/rfc7234#section-4.2.3>current age</a> is within the
-<a href=https://tools.ietf.org/html/rfc5861#section-3>stale-while-revalidate lifetime</a>.
+<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.3>current age</a> is within the
+<a href=https://datatracker.ietf.org/doc/html/rfc5861#section-3>stale-while-revalidate lifetime</a>.
 
 <p>A <dfn export id=concept-stale-response>stale response</dfn> is a <a for=/>response</a> that is
 not a <a>fresh response</a> or a <a>stale-while-revalidate response</a>.
@@ -3708,7 +3708,7 @@ steps:
    <li><var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a> is a
    <a for=/>domain</a>
    <li>Matching <var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a> per
-   <a href=https://tools.ietf.org/html/rfc6797#section-8.2>Known HSTS Host Domain Name Matching</a>
+   <a href=https://datatracker.ietf.org/doc/html/rfc6797#section-8.2>Known HSTS Host Domain Name Matching</a>
    results in either a superdomain match with an asserted <code>includeSubDomains</code> directive
    or a congruent match (with or without an asserted <code>includeSubDomains</code> directive).
    [[!HSTS]]
@@ -4703,13 +4703,14 @@ steps. They return a <a for=/>response</a>.
     <ol>
      <li>
       <p>If the user agent is not configured to block cookies for <var>httpRequest</var> (see
-      <a href=https://tools.ietf.org/html/rfc6265#section-7>section 7</a> of
+      <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-7>section 7</a> of
       [[!COOKIES]]), then:
 
       <ol>
        <li><p>Let <var>cookies</var> be the result of running the "cookie-string" algorithm (see
-       <a href=https://tools.ietf.org/html/rfc6265#section-5.4>section 5.4</a> of [[!COOKIES]]) with
-       the user agent's cookie store and <var>httpRequest</var>'s <a for=request>current URL</a>.
+       <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-5.4>section 5.4</a> of
+       [[!COOKIES]]) with the user agent's cookie store and <var>httpRequest</var>'s
+       <a for=request>current URL</a>.
 
        <li>If <var>cookies</var> is not the empty string, append
        `<code>Cookie</code>`/<var>cookies</var> to <var>httpRequest</var>'s
@@ -4764,7 +4765,7 @@ steps. They return a <a for=/>response</a>.
 
       <p>Set <var>storedResponse</var> to the result of selecting a response from the
       <var>httpCache</var>, possibly needing validation, as per the
-      "<a href=https://tools.ietf.org/html/rfc7234#section-4>Constructing Responses from Caches</a>"
+      "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4>Constructing Responses from Caches</a>"
       chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]], if any.
 
       <p class=note>As mandated by HTTP, this still takes the `<code>Vary</code>`
@@ -4832,7 +4833,7 @@ steps. They return a <a for=/>response</a>.
           </ol>
 
           <p class=note>See also the
-          "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
+          "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.3.4>Sending a Validation Request</a>"
           chapter of <cite>HTTP Caching</cite> [[!HTTP-CACHING]].
 
          <li><p>Otherwise, set <var>response</var> to <var>storedResponse</var> and set
@@ -4865,10 +4866,10 @@ steps. They return a <a for=/>response</a>.
    <var>httpFetchParams</var>, <var>includeCredentials</var>, and <var>isNewConnectionFetch</var>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>method</a> is
-   <a href=https://tools.ietf.org/html/rfc7231#safe.methods>unsafe</a> and
+   <a href=https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1>unsafe</a> and
    <var>forwardResponse</var>'s <a for=response>status</a> is in the range 200 to 399, inclusive,
    invalidate appropriate stored responses in <var>httpCache</var>, as per the
-   "<a href=https://tools.ietf.org/html/rfc7234#section-4.4>Invalidation</a>" chapter of
+   "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.4>Invalidation</a>" chapter of
    <cite>HTTP Caching</cite>, and set <var>storedResponse</var> to null. [[!HTTP-CACHING]]
 
    <li>
@@ -4879,7 +4880,7 @@ steps. They return a <a for=/>response</a>.
      <li>
       <p>Update <var>storedResponse</var>'s <a for=response>header list</a> using
       <var>forwardResponse</var>'s <a for=response>header list</a>, as per the
-      "<a href=https://tools.ietf.org/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
+      "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4.3.4>Freshening Stored Responses upon Validation</a>"
       chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
 
       <p class="note">This updates the stored response in cache as well.
@@ -4898,7 +4899,7 @@ steps. They return a <a for=/>response</a>.
 
      <li>
       <p>Store <var>httpRequest</var> and <var>forwardResponse</var> in <var>httpCache</var>, as per
-      the "<a href=https://tools.ietf.org/html/rfc7234#section-3>Storing Responses in Caches</a>"
+      the "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-3>Storing Responses in Caches</a>"
       chapter of <cite>HTTP Caching</cite>. [[!HTTP-CACHING]]
 
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
@@ -5271,12 +5272,12 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <li>
     <p>If <var>includeCredentials</var> is true and the user agent is not configured to block
     cookies for <var>request</var> (see
-    <a href=https://tools.ietf.org/html/rfc6265#section-7>section 7</a> of [[!COOKIES]]), then run
-    the "set-cookie-string" parsing algorithm (see
-    <a href=https://tools.ietf.org/html/rfc6265#section-5.2>section 5.2</a> of [[!COOKIES]]) on the
-    <a for=header>value</a> of each <var>header</var> whose <a for=header>name</a> is a
-    <a>byte-case-insensitive</a> match for `<code>Set-Cookie</code>` in <var>response</var>'s
-    <a for=response>header list</a>, if any, and <var>request</var>'s
+    <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-7>section 7</a> of [[!COOKIES]]),
+    then run the "set-cookie-string" parsing algorithm (see
+    <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-5.2>section 5.2</a> of
+    [[!COOKIES]]) on the <a for=header>value</a> of each <var>header</var> whose
+    <a for=header>name</a> is a <a>byte-case-insensitive</a> match for `<code>Set-Cookie</code>` in
+    <var>response</var>'s <a for=response>header list</a>, if any, and <var>request</var>'s
     <a for=request>current URL</a>.
 
     <p class=note>This is a fingerprinting vector.
@@ -7427,9 +7428,8 @@ fetch("https://www.example.com/")
  "<code>http</code>", and true otherwise.
 
  <li><p>Follow the requirements stated in step 2 to 5, inclusive, of the first set of steps in
- <a href=http://tools.ietf.org/html/rfc6455#section-4.1>section 4.1</a> of The WebSocket Protocol
- to establish a <a lt="obtain a WebSocket connection">WebSocket connection</a>.
- [[!WSP]]
+ <a href=https://datatracker.ietf.org/doc/html/rfc6455#section-4.1>section 4.1</a> of The WebSocket
+ Protocol to establish a <a lt="obtain a WebSocket connection">WebSocket connection</a>. [[!WSP]]
 
  <li><p>If that established a connection, return it, and return failure otherwise.
 </ol>
@@ -7527,9 +7527,9 @@ therefore not shareable, a WebSocket connection is very close to identical to an
     by the client, but not acknowledged by the server.
 
    <li><p>Follow the requirements stated step 2 to step 6, inclusive, of the last set of steps in
-   <a href=http://tools.ietf.org/html/rfc6455#section-4.1>section 4.1</a> of The WebSocket Protocol
-   to validate <var>response</var>. This either results in <a>fail the WebSocket connection</a>
-   or <a>the WebSocket connection is established</a>.
+   <a href=https://datatracker.ietf.org/doc/html/rfc6455#section-4.1>section 4.1</a> of The
+   WebSocket Protocol to validate <var>response</var>. This either results in
+   <a>fail the WebSocket connection</a> or <a>the WebSocket connection is established</a>.
   </ol>
 </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -28,11 +28,11 @@ urlPrefix:https://tools.ietf.org/html/rfc8941#;type:dfn;spec:rfc8941
 url:https://w3c.github.io/resource-timing/#dfn-mark-resource-timing;text:mark resource timing;type:dfn;spec:resource-timing
 
 urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
-    type:idl;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
     type:dfn
         url:dfn-coarsen-time;text:coarsen time
         url:dfn-coarsened-shared-current-time;text:coarsened shared current time
         url:dfn-unsafe-shared-current-time;text:unsafe shared current time
+    type:idl;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
 </pre>
 
 <pre class=biblio>


### PR DESCRIPTION
ReSpec-authored specifications are best anchored as otherwise outgoing links go all over the map.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1224.html" title="Last updated on May 25, 2021, 6:42 PM UTC (8080de9)">Preview</a> | <a href="https://whatpr.org/fetch/1224/208e271...8080de9.html" title="Last updated on May 25, 2021, 6:42 PM UTC (8080de9)">Diff</a>