### PR TITLE
Specify the behavior of `COEP: credentialless`,

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1892,8 +1892,8 @@ source of security bugs. Please seek security review for features that deal with
  <a for="URL serializer"><i>exclude fragment</i></a> set to true.
 </ol>
 
-<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
-<a for=/>request</a> <var>request</var>, run theses steps:
+<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a <a
+for=/>request</a> <var>request</var>, run theses steps:
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", return
@@ -1902,12 +1902,11 @@ source of security bugs. Please seek security review for features that deal with
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
- object">embedder policy</a> is not
- "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
+ object">embedder policy</a> is not "<code><a for="embedder policy
+ value">credentialless</a></code>", return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a>
- with <var>request</var>'s <a for=request>current URL</a>'s <a
- for=url>origin</a>, return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
+ <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
 
  <li><p>Return false.</p>
 </ol>
@@ -3536,8 +3535,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
    <dd> Do nothing.
 
    <dt>`<a for="embedder policy value">credentialless</a>`
-   <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the
-   following is true:
+   <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the following is true:
    <ul>
     <li><var>response</var>'s <a for="response">request-include-credentials</a> is true.
     <li><var>forNavigation</var> is true.
@@ -4705,9 +4703,8 @@ steps. They return a <a for=/>response</a>.
 
     <p>is true; otherwise false.
 
-   <li>
-    <p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with
-    <var>request</var> is false, set <var>includeCredentials</var> to false.</p>
+   <li><p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with <var>request</var> is
+   false, set <var>includeCredentials</var> to false.</p>
 
    <li><p>Let <var>contentLength</var> be <var>httpRequest</var>'s <a for=request>body</a>'s
    <a for=body>length</a>, if <var>httpRequest</var>'s <a for=request>body</a> is non-null;

--- a/fetch.bs
+++ b/fetch.bs
@@ -3533,6 +3533,8 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <li><p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:
   <dl class=switch>
    <dt>`<a for="embedder policy value">unsafe-none</a>`
+   <dd> Do nothing.
+
    <dt>`<a for="embedder policy value">credentialless</a>`
    <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the
    following is true:

--- a/fetch.bs
+++ b/fetch.bs
@@ -1905,7 +1905,8 @@ source of security bugs. Please seek security review for features that deal with
  is not "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
- <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
+ <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> and
+ <var>request</var>'s <a for=request>tainted origin flag</a> is not set, return true.</p>
 
  <li><p>Return false.</p>
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1896,14 +1896,15 @@ source of security bugs. Please seek security review for features that deal with
 <a for=/>request</a> <var>request</var>, run theses steps:
 
 <ol>
- <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", return
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", then return
  true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a>'s
  <a for="environment settings object">policy container</a>'s
- <a for="policy container">embedder policy</a> is not
+ <a for="policy container">embedder policy</a>'s
+ <a for="embedder policy">value</a> is not
  "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
@@ -3535,17 +3536,18 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
   <p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:</p>
   <dl class=switch>
    <dt>`<a for="embedder policy value">unsafe-none</a>`
-   <dd> Do nothing.
+   <dd><p>Do nothing.
 
    <dt>`<a for="embedder policy value">credentialless</a>`
-   <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the following is true:
-   <ul>
-    <li><var>response</var>'s <a for="response">request-include-credentials</a> is true.
-    <li><var>forNavigation</var> is true.
-   </ul>
+   <dd>
+    <p>Set <var>policy</var> to `<code>same-origin</code>` if one of the following is true:
+    <ul>
+     <li><var>response</var>'s <a for="response">request-include-credentials</a> is true.
+     <li><var>forNavigation</var> is true.
+    </ul>
 
    <dt>`<a for="embedder policy value">require-corp</a>`
-   <dd> Set <var>policy</var> to `<code>same-origin</code>`.
+   <dd><p>Set <var>policy</var> to `<code>same-origin</code>`.
   </dl>
  </li>
 
@@ -4707,7 +4709,7 @@ steps. They return a <a for=/>response</a>.
     <p>is true; otherwise false.
 
    <li><p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with <var>request</var> returns
-   false, set <var>includeCredentials</var> to false.</p>
+   false, then set <var>includeCredentials</var> to false.</p>
 
    <li><p>Let <var>contentLength</var> be <var>httpRequest</var>'s <a for=request>body</a>'s
    <a for=body>length</a>, if <var>httpRequest</var>'s <a for=request>body</a> is non-null;

--- a/fetch.bs
+++ b/fetch.bs
@@ -1892,6 +1892,25 @@ source of security bugs. Please seek security review for features that deal with
  <a for="URL serializer"><i>exclude fragment</i></a> set to true.
 </ol>
 
+<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
+<a for=/>request</a> <var>request</var>, run theses steps:
+
+<ol>
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", return
+ true.</p>
+
+ <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
+
+ <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
+ object">embedder policy</a> is not
+ "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
+
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+ <var>request</var>'s <a for=request>client</a>'s <a for="environment settings object">origin</a>,
+ return true.</p>
+
+ <li><p>Return false.</p>
+</ol>
 
 <h4 id=responses>Responses</h4>
 
@@ -1977,6 +1996,10 @@ initially unset.
 <p class=note>This is used to ensure to prevent a partial response from an earlier ranged request
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
 description of the attack.
+
+<p>A <a for=/>response</a> has an associated <dfn for=response
+id=concept-response-request-include-credentials>request-include-credentials</dfn>, which is
+initially set.
 
 <p>A <a for=/>response</a> has an associated
 <dfn for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>, which is
@@ -3507,9 +3530,22 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <li><p>If <var>policy</var> is neither `<code>same-origin</code>`, `<code>same-site</code>`, nor
  `<code>cross-origin</code>`, then set <var>policy</var> to null.
 
- <li><p>If <var>policy</var> is null and <var>embedderPolicyValue</var> is
- "<code><a for="embedder policy value">require-corp</a></code>", then set <var>policy</var> to
- `<code>same-origin</code>`.
+ <li><p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:
+  <dl class=switch>
+   <dt>`<a for="embedder policy value">unsafe-none</a>`
+   <dt>`<a for="embedder policy value">credentialless</a>`
+   <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the
+   following is true:
+   <ul>
+    <li><var>response</var>'s <a for="response">request-include-credentials</a> is true and
+        <var>response</var>'s <a for="response">type</a> is "<code>opaque</code>".
+    <li><var>forNavigation</var> is true.
+   </ul>
+
+   <dt>`<a for="embedder policy value">require-corp</a>`
+   <dd> Set <var>policy</var> to `<code>same-origin</code>`.
+  </dl>
+ </li>
 
  <li>
   <p>Switch on <var>policy</var>:
@@ -4668,6 +4704,10 @@ steps. They return a <a for=/>response</a>.
 
     <p>is true; otherwise false.
 
+   <li>
+    <p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with
+    <var>request</var> is false, set <var>includeCredentials</var> to false.</p>
+
    <li><p>Let <var>contentLength</var> be <var>httpRequest</var>'s <a for=request>body</a>'s
    <a for=body>length</a>, if <var>httpRequest</var>'s <a for=request>body</a> is non-null;
    otherwise null.
@@ -5027,6 +5067,9 @@ steps. They return a <a for=/>response</a>.
 
  <li><p>If <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">contains</a>
  `<code>Range</code>`, then set <var>response</var>'s <a for=response>range-requested flag</a>.
+
+ <li><p>Set <var>response</var>'s <a for=response>request-include-credentials</a> to
+ <var>includeCredentials</var>.
 
  <li>
   <p>If <var>response</var>'s <a for=response>status</a> is 401, <var>httpRequest</var>'s
@@ -7843,6 +7886,7 @@ Arkadiusz Michalski,
 Arne Johannessen,
 Artem Skoretskiy,
 Arthur Barstow,
+Arthur Sonzogni,
 Asanka Herath,
 Axel Rauschmayer,
 Ben Kelly,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1901,9 +1901,8 @@ source of security bugs. Please seek security review for features that deal with
 
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
- object">embedder policy</a> is not
- "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings object">embedder policy</a>
+ is not "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
  <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
@@ -3529,7 +3528,8 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <li><p>If <var>policy</var> is neither `<code>same-origin</code>`, `<code>same-site</code>`, nor
  `<code>cross-origin</code>`, then set <var>policy</var> to null.
 
- <li><p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:
+ <li>
+  <p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:</p>
   <dl class=switch>
    <dt>`<a for="embedder policy value">unsafe-none</a>`
    <dd> Do nothing.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1905,9 +1905,9 @@ source of security bugs. Please seek security review for features that deal with
  object">embedder policy</a> is not
  "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
- <var>request</var>'s <a for=request>client</a>'s <a for="environment settings object">origin</a>,
- return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
+ object">origin</a> is <a>same origin</a> with <var>request</var>'s <a
+ for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
 
  <li><p>Return false.</p>
 </ol>
@@ -7887,7 +7887,7 @@ Arkadiusz Michalski,
 Arne Johannessen,
 Artem Skoretskiy,
 Arthur Barstow,
-Arthur Sonzogni,
+Arthur Sonzogni, <!-- ArthurSonzogni; GitHub -->,
 Asanka Herath,
 Axel Rauschmayer,
 Ben Kelly,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1902,8 +1902,8 @@ for=/>request</a> <var>request</var>, run theses steps:
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
- object">embedder policy</a> is not "<code><a for="embedder policy
- value">credentialless</a></code>", return true.</p>
+ object">embedder policy</a> is not
+ "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
  <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
@@ -1997,8 +1997,8 @@ being provided to an API that didn't make a range request. See the flag's usage 
 description of the attack.
 
 <p>A <a for=/>response</a> has an associated <dfn for=response
-id=concept-response-request-include-credentials>request-include-credentials</dfn>, which is
-initially set.
+id=concept-response-request-include-credentials>request-include-credentials</dfn> (a boolean), which
+is initially true.
 
 <p>A <a for=/>response</a> has an associated
 <dfn for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>, which is
@@ -4703,7 +4703,7 @@ steps. They return a <a for=/>response</a>.
 
     <p>is true; otherwise false.
 
-   <li><p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with <var>request</var> is
+   <li><p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with <var>request</var> returns
    false, set <var>includeCredentials</var> to false.</p>
 
    <li><p>Let <var>contentLength</var> be <var>httpRequest</var>'s <a for=request>body</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -1905,9 +1905,9 @@ source of security bugs. Please seek security review for features that deal with
  object">embedder policy</a> is not
  "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings
- object">origin</a> is <a>same origin</a> with <var>request</var>'s <a
- for=request>current URL</a>'s <a for=url>origin</a>, return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a>
+ with <var>request</var>'s <a for=request>current URL</a>'s <a
+ for=url>origin</a>, return true.</p>
 
  <li><p>Return false.</p>
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1893,7 +1893,7 @@ source of security bugs. Please seek security review for features that deal with
 </ol>
 
 <p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
-<a for=/>request</a> <var>request</var>, run theses steps:
+<a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", then return
@@ -3535,10 +3535,10 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <li>
   <p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:</p>
   <dl class=switch>
-   <dt>`<a for="embedder policy value">unsafe-none</a>`
+   <dt>"<a for="embedder policy value">unsafe-none</a>"
    <dd><p>Do nothing.
 
-   <dt>`<a for="embedder policy value">credentialless</a>`
+   <dt>"<a for="embedder policy value">credentialless</a>"
    <dd>
     <p>Set <var>policy</var> to `<code>same-origin</code>` if one of the following is true:
     <ul>
@@ -3546,7 +3546,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
      <li><var>forNavigation</var> is true.
     </ul>
 
-   <dt>`<a for="embedder policy value">require-corp</a>`
+   <dt>"<a for="embedder policy value">require-corp</a>"
    <dd><p>Set <var>policy</var> to `<code>same-origin</code>`.
   </dl>
  </li>
@@ -4709,7 +4709,7 @@ steps. They return a <a for=/>response</a>.
     <p>is true; otherwise false.
 
    <li><p>If <a>Cross-Origin-Embedder-Policy allows credentials</a> with <var>request</var> returns
-   false, then set <var>includeCredentials</var> to false.</p>
+   false, then set <var>includeCredentials</var> to false.
 
    <li><p>Let <var>contentLength</var> be <var>httpRequest</var>'s <a for=request>body</a>'s
    <a for=body>length</a>, if <var>httpRequest</var>'s <a for=request>body</a> is non-null;
@@ -7889,7 +7889,7 @@ Arkadiusz Michalski,
 Arne Johannessen,
 Artem Skoretskiy,
 Arthur Barstow,
-Arthur Sonzogni, <!-- ArthurSonzogni; GitHub -->,
+Arthur Sonzogni, <!-- ArthurSonzogni; GitHub -->
 Asanka Herath,
 Axel Rauschmayer,
 Ben Kelly,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1901,8 +1901,10 @@ source of security bugs. Please seek security review for features that deal with
 
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>client</a>'s <a for="environment settings object">embedder policy</a>
- is not "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>client</a>'s
+ <a for="environment settings object">policy container</a>'s
+ <a for="policy container">embedder policy</a> is not
+ "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
  <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> and

--- a/fetch.bs
+++ b/fetch.bs
@@ -1905,7 +1905,7 @@ source of security bugs. Please seek security review for features that deal with
  object">embedder policy</a> is not
  "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>origin</a> is not <a>same origin</a> with
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
  <var>request</var>'s <a for=request>client</a>'s <a for="environment settings object">origin</a>,
  return true.</p>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1892,8 +1892,8 @@ source of security bugs. Please seek security review for features that deal with
  <a for="URL serializer"><i>exclude fragment</i></a> set to true.
 </ol>
 
-<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a <a
-for=/>request</a> <var>request</var>, run theses steps:
+<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
+<a for=/>request</a> <var>request</var>, run theses steps:
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", return
@@ -1996,9 +1996,9 @@ initially unset.
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
 description of the attack.
 
-<p>A <a for=/>response</a> has an associated <dfn for=response
-id=concept-response-request-include-credentials>request-include-credentials</dfn> (a boolean), which
-is initially true.
+<p>A <a for=/>response</a> has an associated
+<dfn for=response id=concept-response-request-include-credentials>request-include-credentials</dfn>
+(a boolean), which is initially true.
 
 <p>A <a for=/>response</a> has an associated
 <dfn for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>, which is

--- a/fetch.bs
+++ b/fetch.bs
@@ -1892,27 +1892,27 @@ source of security bugs. Please seek security review for features that deal with
  <a for="URL serializer"><i>exclude fragment</i></a> set to true.
 </ol>
 
-<p>To check <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
+<p>To check if <dfn export>Cross-Origin-Embedder-Policy allows credentials</dfn>, given a
 <a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", then return
  true.</p>
 
- <li><p>If <var>request</var>'s <a for=request>client</a> is null, return true.</p>
+ <li><p>If <var>request</var>'s <a for=request>client</a> is null, then return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a>'s
  <a for="environment settings object">policy container</a>'s
- <a for="policy container">embedder policy</a>'s
- <a for="embedder policy">value</a> is not
- "<code><a for="embedder policy value">credentialless</a></code>", return true.</p>
+ <a for="policy container">embedder policy</a>'s <a for="embedder policy">value</a> is not
+ "<a for="embedder policy value"><code>credentialless</code></a>", then return true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>origin</a> is <a>same origin</a> with
  <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> and
- <var>request</var>'s <a for=request>tainted origin flag</a> is not set, return true.</p>
+ <var>request</var>'s <a for=request>tainted origin flag</a> is not set, then return true.</p>
 
  <li><p>Return false.</p>
 </ol>
+
 
 <h4 id=responses>Responses</h4>
 
@@ -1999,8 +1999,7 @@ initially unset.
 being provided to an API that didn't make a range request. See the flag's usage for a detailed
 description of the attack.
 
-<p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-request-include-credentials>request-include-credentials</dfn>
+<p>A <a for=/>response</a> has an associated <dfn for=response>request-includes-credentials</dfn>
 (a boolean), which is initially true.
 
 <p>A <a for=/>response</a> has an associated
@@ -3481,7 +3480,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
 
  <li>
   <p>If the <a>cross-origin resource policy internal check</a> with <var>origin</var>,
-  "<code><a for="embedder policy value">unsafe-none</a></code>", <var>response</var>, and
+  "<a for="embedder policy value"><code>unsafe-none</code></a>", <var>response</var>, and
   <var>forNavigation</var> returns <b>blocked</b>, then return <b>blocked</b>.
 
   <p class="note">This step is needed because we don't want to report violations not related to
@@ -3516,7 +3515,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
 
 <ol>
  <li><p>If <var>forNavigation</var> is true and <var>embedderPolicyValue</var> is
- "<code><a for="embedder policy value">unsafe-none</a></code>", then return <b>allowed</b>.
+ "<a for="embedder policy value"><code>unsafe-none</code></a>", then return <b>allowed</b>.
 
  <li>
   <p>Let <var>policy</var> be the result of <a for="header list">getting</a>
@@ -3525,7 +3524,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
 
   <p class=note>This means that `<code>Cross-Origin-Resource-Policy: same-site, same-origin</code>`
   ends up as <b>allowed</b> below as it will never match anything, as long as
-  <var>embedderPolicyValue</var> is "<code><a for="embedder policy value">unsafe-none</a></code>".
+  <var>embedderPolicyValue</var> is "<a for="embedder policy value"><code>unsafe-none</code></a>".
   Two or more `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` headers will have the
   same effect.
 
@@ -3533,20 +3532,22 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  `<code>cross-origin</code>`, then set <var>policy</var> to null.
 
  <li>
-  <p>If <var>policy</var> is null, switch on <var>embedderPolicyValue</var>:</p>
+  <p>If <var>policy</var> is null, then switch on <var>embedderPolicyValue</var>:</p>
+
   <dl class=switch>
-   <dt>"<a for="embedder policy value">unsafe-none</a>"
+   <dt>"<a for="embedder policy value"><code>unsafe-none</code></a>"
    <dd><p>Do nothing.
 
-   <dt>"<a for="embedder policy value">credentialless</a>"
+   <dt>"<a for="embedder policy value"><code>credentialless</code></a>"
    <dd>
-    <p>Set <var>policy</var> to `<code>same-origin</code>` if one of the following is true:
+    <p>Set <var>policy</var> to `<code>same-origin</code>` if:
+
     <ul>
-     <li><var>response</var>'s <a for="response">request-include-credentials</a> is true.
+     <li><var>response</var>'s <a for="response">request-includes-credentials</a> is true, or
      <li><var>forNavigation</var> is true.
     </ul>
 
-   <dt>"<a for="embedder policy value">require-corp</a>"
+   <dt>"<a for="embedder policy value"><code>require-corp</code></a>"
    <dd><p>Set <var>policy</var> to `<code>same-origin</code>`.
   </dl>
  </li>
@@ -5071,7 +5072,7 @@ steps. They return a <a for=/>response</a>.
  <li><p>If <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">contains</a>
  `<code>Range</code>`, then set <var>response</var>'s <a for=response>range-requested flag</a>.
 
- <li><p>Set <var>response</var>'s <a for=response>request-include-credentials</a> to
+ <li><p>Set <var>response</var>'s <a for=response>request-includes-credentials</a> to
  <var>includeCredentials</var>.
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3539,8 +3539,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
    <dd> Set <var>policy</var> to `<code>same-origin</code>` if one of the
    following is true:
    <ul>
-    <li><var>response</var>'s <a for="response">request-include-credentials</a> is true and
-        <var>response</var>'s <a for="response">type</a> is "<code>opaque</code>".
+    <li><var>response</var>'s <a for="response">request-include-credentials</a> is true.
     <li><var>forNavigation</var> is true.
    </ul>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1896,7 +1896,7 @@ source of security bugs. Please seek security review for features that deal with
 <a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
- <li><p>If <var>request</var>'s <a for=request>mode</a> is not <code>no-cors</code>", then return
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is not "<code>no-cors</code>", then return
  true.</p>
 
  <li><p>If <var>request</var>'s <a for=request>client</a> is null, then return true.</p>


### PR DESCRIPTION
Originally described in: https://github.com/mikewest/credentiallessness

`credentialless` and `require-corp` are similar. One or the other is a requirements for the `window.crossOriginIsolated` capability.
They differ mostly in the fetch specification. `require-corp` requires a CORP header for cross-origin no-cors responses. `credentialless` doesn't, but omits credentials (Cookies, clients certificates, etc...) in the request.

* HTML (https://github.com/whatwg/html/pull/6638)
  * Define how to parse the `credentialless` value.
  * From the HTML spec point of view, `credentialless` and `require-corp` are equivalent. They have been grouped into `compatible with cross-origin isolation` and the HTML spec rewritten to use this concept.

* Fetch: (https://github.com/whatwg/fetch/pull/1229)
  * Define `Cross-Origin-Embedder-Policy allows credentials` algorithm. It omit credentials for no-cors, cross-origin, COEP:credentialless requests.
  * Define `response's` `request-include-credentials` flag.
  * In the `Cross-Origin-Resource-Policy check`, if `embedderPolicy` is `credentialless`, require CORP for navigational responses, and opaque responses with `request-include-credentials`.

See: https://github.com/whatwg/html/issues/6637

----

- [x] At least two implementers are interested (and none opposed):
   * Chrome: https://chromestatus.com/feature/4918234241302528#details
   * Firefox: https://github.com/mozilla/standards-positions/issues/539  (worth prototyping)
   * Safari: https://lists.webkit.org/pipermail/webkit-dev/2021-June/031898.html (pending)
  
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/html/cross-origin-embedder-policy/credentialless

- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1175099
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1731778
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=230550

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1229.html" title="Last updated on Nov 3, 2021, 7:54 AM UTC (60a8cf1)">Preview</a> | <a href="https://whatpr.org/fetch/1229/b2f04e2...60a8cf1.html" title="Last updated on Nov 3, 2021, 7:54 AM UTC (60a8cf1)">Diff</a>