### PR TITLE
Remove response CSP list

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1938,11 +1938,6 @@ message as HTTP/2 does not support them.
      need to mask it, whether the cache API needs to store it, etc. -->
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response id=concept-response-csp-list>CSP list</dfn>, which is a <a for=/>list</a>
-of <a>Content Security Policy objects</a> for the <a for=/>response</a>. The list is empty unless
-otherwise specified. [[!CSP]]
-
-<p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</dfn>
 (a list of zero or more <a for=/>header</a>
 <a lt=name for=header>names</a>). The list is empty unless otherwise specified.
@@ -3758,8 +3753,7 @@ steps:
 
      <li>
       <p>Return a new <a for=/>response</a> whose <a for=response>status</a> is
-      <var>noCorsResponse</var>'s <a for=response>status</a>, and <a for=response>CSP list</a>
-      is <var>noCorsResponse</var>'s <a for=response>CSP list</a>.
+      <var>noCorsResponse</var>'s <a for=response>status</a>.
 
       <p class="warning">This is only an effective defense against side channel attacks if
       <var>noCorsResponse</var> is kept isolated from the process that initiated the request.
@@ -3860,8 +3854,6 @@ steps:
 
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
-
- <li><p><a lt="Set response's CSP list">Set <var>internalResponse</var>'s CSP list</a>.
 
  <li>
   <p>If <var>response</var> is not a <a>network error</a> and any of the following returns


### PR DESCRIPTION
This is a companion PR to https://github.com/w3c/webappsec-csp/pull/493, removing the CSP list from the response.
