### PR TITLE
Add policy container to request

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1519,9 +1519,10 @@ user-agent-defined object). Unless otherwise stated it is null.
 <a lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set
 <a for=/>request</a>'s <a for=request>origin</a>.
 
-<p>A <a for=/>request</a> has an associated <dfn export for=request
-id=concept-request-policy-container>policy container</dfn>, which is "<code>client</code>" or a <a
-for=/>policy container</a>. Unless stated otherwise it is "<code>client</code>".
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-policy-container>policy container</dfn>, which is
+"<code>client</code>" or a <a for=/>policy container</a>. Unless stated otherwise it is
+"<code>client</code>".
 
 <p class="note">"<code>client</code>" is changed to a <a for=/>policy container</a> during <a
 lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set <a

--- a/fetch.bs
+++ b/fetch.bs
@@ -1519,6 +1519,14 @@ user-agent-defined object). Unless otherwise stated it is null.
 <a lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set
 <a for=/>request</a>'s <a for=request>origin</a>.
 
+<p>A <a for=/>request</a> has an associated <dfn export for=request
+id=concept-request-policy-container>policy container</dfn>, which is "<code>client</code>" or a <a
+for=/>policy container</a>. Unless stated otherwise it is "<code>client</code>".
+
+<p class="note no-backref">"<code>client</code>" is changed to a <a for=/>policy container</a>
+during <a lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set
+<a for=/>request</a>'s <a for=request>policy container</a>.
+
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-referrer>referrer</dfn>, which is
 "<code>no-referrer</code>", "<code>client</code>", or a <a for=/>URL</a>. Unless stated otherwise it
@@ -3658,6 +3666,19 @@ steps:
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
  <a>network error</a>.
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
+
+  <ol>
+   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set
+   <var>request</var>'s <a for=request>policy container</a> to a <a
+   lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s <a
+   for="environment settings object">policy container</a>. [[!HTML]]
+
+   <li><p>Else, set <var>request</var>'s <a for=request>policy container</a> to a new <a
+   for=/>policy container</a>.
+  </ol>
 
  <li><p>Run <a>report Content Security Policy violations for <var>request</var></a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1523,9 +1523,9 @@ user-agent-defined object). Unless otherwise stated it is null.
 id=concept-request-policy-container>policy container</dfn>, which is "<code>client</code>" or a <a
 for=/>policy container</a>. Unless stated otherwise it is "<code>client</code>".
 
-<p class="note no-backref">"<code>client</code>" is changed to a <a for=/>policy container</a>
-during <a lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set
-<a for=/>request</a>'s <a for=request>policy container</a>.
+<p class="note">"<code>client</code>" is changed to a <a for=/>policy container</a> during <a
+lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set <a
+for=/>request</a>'s <a for=request>policy container</a>.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-referrer>referrer</dfn>, which is
@@ -3676,7 +3676,7 @@ steps:
    lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s <a
    for="environment settings object">policy container</a>. [[!HTML]]
 
-   <li><p>Else, set <var>request</var>'s <a for=request>policy container</a> to a new <a
+   <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new <a
    for=/>policy container</a>.
   </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1524,9 +1524,9 @@ user-agent-defined object). Unless otherwise stated it is null.
 "<code>client</code>" or a <a for=/>policy container</a>. Unless stated otherwise it is
 "<code>client</code>".
 
-<p class="note">"<code>client</code>" is changed to a <a for=/>policy container</a> during <a
-lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set <a
-for=/>request</a>'s <a for=request>policy container</a>.
+<p class=note>"<code>client</code>" is changed to a <a for=/>policy container</a> during
+<a lt=fetch for=/>fetching</a>. It provides a convenient way for standards to not have to set
+<a for=/>request</a>'s <a for=request>policy container</a>.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-referrer>referrer</dfn>, which is
@@ -3597,6 +3597,19 @@ the request.
  <a for="environment settings object">origin</a>.
 
  <li>
+  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
+
+  <ol>
+   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set
+   <var>request</var>'s <a for=request>policy container</a> to a
+   <a lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s
+   <a for="environment settings object">policy container</a>. [[!HTML]]
+
+   <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new
+   <a for=/>policy container</a>.
+  </ol>
+
+ <li>
   <p>If <var>request</var>'s <a for=request>header list</a>
   <a for="header list">does not contain</a> `<code>Accept</code>`, then:
 
@@ -3667,19 +3680,6 @@ steps:
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
  <a>network error</a>.
-
- <li>
-  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
-
-  <ol>
-   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set
-   <var>request</var>'s <a for=request>policy container</a> to a <a
-   lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s <a
-   for="environment settings object">policy container</a>. [[!HTML]]
-
-   <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new <a
-   for=/>policy container</a>.
-  </ol>
 
  <li><p>Run <a>report Content Security Policy violations for <var>request</var></a>.
 


### PR DESCRIPTION
This change adds a policy container to the request. The idea is to snapshot the policies when the request is created and have them available for the whole lifetime of the fetch algorithm. Together with a change to CSP, this will solve https://github.com/whatwg/fetch/issues/832.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1231.html" title="Last updated on May 10, 2021, 10:29 AM UTC (604b99d)">Preview</a> | <a href="https://whatpr.org/fetch/1231/5fac9e8...604b99d.html" title="Last updated on May 10, 2021, 10:29 AM UTC (604b99d)">Diff</a>