### PR TITLE
Add a "revalidated" cache state

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1939,7 +1939,7 @@ message as HTTP/2 does not support them.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string,
-"<code>local</code>", or "<code>revalidated</code>"). Unlesss stated otherwise, it is the empty string.
+"<code>local</code>", or "<code>validated</code>"). Unlesss stated otherwise, it is the empty string.
 
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
 <cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]
@@ -4895,7 +4895,7 @@ steps. They return a <a for=/>response</a>.
 
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
-     <li><p>Set <var>response</var>'s <a for=response>cache state</a> to "<code>revalidated</code>".
+     <li><p>Set <var>response</var>'s <a for=response>cache state</a> to "<code>validated</code>".
 
      <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1939,7 +1939,8 @@ message as HTTP/2 does not support them.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string,
-"<code>local</code>", or "<code>validated</code>"). Unlesss stated otherwise, it is the empty string.
+"<code>local</code>", or "<code>validated</code>"). Unlesss stated otherwise, it is the empty
+string.
 
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
 <cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -1938,8 +1938,8 @@ message as HTTP/2 does not support them.
 <a for=/>response</a>'s <a for=response>body</a> are always null.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string or
-"<code>local</code>"). Unlesss stated otherwise, it is the empty string.
+<dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string,
+"<code>local</code>", or "<code>revalidated</code>"). Unlesss stated otherwise, it is the empty string.
 
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
 <cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]
@@ -4894,6 +4894,8 @@ steps. They return a <a for=/>response</a>.
       <p class="note">This updates the stored response in cache as well.
 
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
+
+     <li><p>Set <var>response</var>'s <a for=response>cache state</a> to "<code>revalidated</code>".
 
      <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
      <a for="fetch params">timing info</a> and <var>response</var>.


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

While [implementing](https://chromium-review.googlesource.com/c/chromium/src/+/2878693) the recent [Resource Timing transferSize changes](https://github.com/w3c/resource-timing/pull/266), I realized that the current spec is not sufficient to implement what was discussed in the WG, and more importantly, insufficient to maintain backwards compatibility with current `transferSize` values.

Essentially, we want `transferSize` to return different values for the cases of local caching (in which case it needs to return 0), full fetch from the network (in which case it needs to return the encoded body size + a constant) as well as the *successful revalidation* case (where it needs to return *just* the constant representing the headers used to revalidate the response).

For that purpose, the "cache state" in Fetch needs to change. This PR implements that change. 

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/2878693
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1185801
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1679737
   * Safari: N/A as they haven't implemented `transferSize` yet

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1232.html" title="Last updated on May 12, 2021, 8:58 AM UTC (0fab38a)">Preview</a> | <a href="https://whatpr.org/fetch/1232/3c0dd16...0fab38a.html" title="Last updated on May 12, 2021, 8:58 AM UTC (0fab38a)">Diff</a>