### PR TITLE
Use referrer policy from policy container

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1541,8 +1541,8 @@ to not have to set <a for=/>request</a>'s <a for=request>referrer</a>.
 <dfn export for=request id=concept-request-referrer-policy>referrer policy</dfn>, which is a
 <a for=/>referrer policy</a>. Unless stated otherwise it is the empty string. [[!REFERRER]]
 
-<p class="note no-backref">This can be used to override a referrer policy associated with an
-<a>environment settings object</a>.
+<p class="note no-backref">This can be used to override the referrer policy to be used for this
+<a for=/>request</a>.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-mode>mode</dfn>, which is

--- a/fetch.bs
+++ b/fetch.bs
@@ -3689,14 +3689,9 @@ steps:
  <a lt="should request be blocked by Content Security Policy?">should <var>request</var> be blocked by Content Security Policy</a>
  returns <b>blocked</b>, then set <var>response</var> to a <a>network error</a>.
 
- <li><p>If <var>request</var>'s <a for=request>referrer policy</a> is the empty string and
- <var>request</var>'s <a for=request>client</a> is non-null, then set <var>request</var>'s
- <a for=request>referrer policy</a> to <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">referrer policy</a>. [[!REFERRER]]
-
  <li><p>If <var>request</var>'s <a for=request>referrer policy</a> is the empty string, then set
- <var>request</var>'s <a for=request>referrer policy</a> to the
- <a for=/>default referrer policy</a>.
+ <var>request</var>'s <a for=request>referrer policy</a> to <var>request</var>'s
+ <a for=request>policy container</a>'s <a for="policy container">referrer policy</a>.
 
  <li>
   <p>If <var>request</var>'s <a for=request>referrer</a> is not "<code>no-referrer</code>", then set


### PR DESCRIPTION
This is a companion change to https://github.com/whatwg/html/pull/6677, which moves referrer policy into the policy container.

As a consequence of this change, the referrer policy used for the request is a snapshot of the relevant referrer policy when the request is being created, and won't change during the lifetime of the request, addressing a variant of https://github.com/whatwg/fetch/issues/832 for referrer policy.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1233.html" title="Last updated on May 17, 2021, 8:44 AM UTC (c08fa08)">Preview</a> | <a href="https://whatpr.org/fetch/1233/3c0dd16...c08fa08.html" title="Last updated on May 17, 2021, 8:44 AM UTC (c08fa08)">Diff</a>