### PR TITLE
Draft changes to "obtain a websocket connection"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7451,11 +7451,57 @@ fetch("https://www.example.com/")
  <li><p>Let <var ignore>secure</var> be false, if <var>url</var>'s <a for=url>scheme</a> is
  "<code>http</code>", and true otherwise.
 
- <li><p>Follow the requirements stated in step 2 to 5, inclusive, of the first set of steps in
- <a href=https://datatracker.ietf.org/doc/html/rfc6455#section-4.1>section 4.1</a> of The WebSocket
- Protocol to establish a <a lt="obtain a WebSocket connection">WebSocket connection</a>. [[!WSP]]
+ <li><p>If <var>host</var> is a domain and a proxy is not in use, then set <var>hosts</var> to the
+ results of resolving a domain with <var>key</var> and <var>host</var>.
 
- <li><p>If that established a connection, return it, and return failure otherwise.
+ <li><p>Otherwise, set <var>hosts</var> to « <var>host</var> ».
+
+<!-- TODO: Need to limit the total number of simultaneous pending connections for proxies. -->
+
+ <li><p>For each <var>host</var> in <var>hosts</var>,
+
+<!-- TODO: Happy eyeballs means we actually try IPv6 and IPv4 hosts in parallel. -->
+
+ <ol>
+  <li><p>If the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>, <var>port</var>)] exists, then:
+
+  <ol>
+    <li><p>Let connectingWebSocketConnection be that connection.
+
+    <li><p>Wait for that connection to established or have failed. (Note: this removes it from the
+    map.)
+
+    <li><p>Wait an additional 10ms. (Note: this slows down denial-of-service attacks a bit without
+    significantly impacting legitimate use).
+    <!-- This is Chromium behaviour, not currently standardised -->.
+  </ol>
+
+  <li><p>Assert: the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>,
+  <var>port</var>)] does not exist.
+
+  <li><p>Set the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>,
+  <var>port</var>)] to the result of obtaining a connection with <a>network partition key</a>
+  <var>key</var>, <a for=connection>origin</a> <var>origin</var>, <var>credentials</var> set to
+  true, and <a>dedicated</a> set to true.
+
+<!-- TODO: Need to do the equivalent of section 4.1 step 3 for proxies.
+
+Note: Chromium and AFAIK other browsers don't obey this paragraph as they use "http" and "https"
+instead of "ws" and "wss" when executing proxy autoconfiguration scripts.
+
+       For the purpose of proxy autoconfiguration scripts, the URI to
+       pass the function MUST be constructed from /host/, /port/,
+       /resource name/, and the /secure/ flag using the definition of a
+       WebSocket URI as given in Section 3.
+
+-->
+
+  <li><p>If establishing connection failed with a TCP error, then remove (<var>key</var>,
+  <var>host</var>, <var>port</var>) from connecting WebSocket connections and <a>continue</a>.
+
+  <li><p>Otherwise, return the user agent's connecting WebSocket connections[(<var>key</var>,
+  <var>host</var>, <var>port</var>)].
+ </ol>
 </ol>
 
 <p class=note>Although structured a little differently, carrying different properties, and
@@ -7538,6 +7584,9 @@ therefore not shareable, a WebSocket connection is very close to identical to an
   steps:
 
   <ol>
+   <li><p>Remove (<var>key</var>, <var>host</var>, <var>port</var>) from connecting WebSocket
+   connections.
+
    <li><p>If <var>response</var> is a <a>network error</a> or its <a for=response>status</a> is not
    101, <a>fail the WebSocket connection</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5092,15 +5092,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
   <dl>
    <dt>"<code>websocket</code>"
-   <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a WebSocket connection">obtaining a WebSocket connection</a>, given
-   <var>request</var>'s <a for=request>current URL</a>.
+   <dd><p>Let <var>connection</var> be the result of <a>obtaining a WebSocket connection</a>, given
+   <var>networkPartitionKey</var>, <var>request</var>'s <a for=request>current URL</a>'s
+   <a for=url>origin</a>, and <var>includeCredentials</var>.
 
    <dt>Otherwise
-   <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a connection">obtaining a connection</a>, given <var>networkPartitionKey</var>,
-   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>,
-   <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+   <dd><p>Let <var>connection</var> be the result of <a>obtaining a connection</a>, given
+   <var>networkPartitionKey</var>, <var>request</var>'s <a for=request>current URL</a>'s
+   <a for=url>origin</a>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
   </dl>
 
  <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final connection timing info</a> to the
@@ -7440,73 +7439,69 @@ fetch("https://www.example.com/")
 
 <h3 id=websocket-connections>Connections</h3>
 
+<p>A user agent has an associated <dfn>connecting WebSocket connections</dfn>, a <a for=/>map</a> of
+(<a for=/>network partition key</a>, <a for=/>host</a>, <a for=url>port</a>) to a
+<a for=/>set</a> of unique identifiers.
+
 <p>To <dfn id=concept-websocket-connection-obtain>obtain a WebSocket connection</dfn>, given a
-<var>url</var>, run these steps:
+<a>network partition key</a> <var>key</var>, <a for=/>origin</a> <var>origin</var>, and boolean
+<var>credentials</var>, run these steps:
 
 <ol>
- <li><p>Let <var ignore>host</var> be <var>url</var>'s <a for=url>host</a>.
+ <li><p>Let <var>hosts</var> be the result of running resolve an origin given <var>key</var> and
+ <var>origin</var>.
+ <!-- XXX xref depends on https://github.com/whatwg/fetch/pull/1245 -->
+ <!-- TODO: Need to limit the total number of simultaneous pending connections for proxies. -->
 
- <li><p>Let <var ignore>port</var> be <var>url</var>'s <a for=url>port</a>.
-
- <li><p>Let <var ignore>secure</var> be false, if <var>url</var>'s <a for=url>scheme</a> is
- "<code>http</code>", and true otherwise.
-
- <li><p>If <var>host</var> is a domain and a proxy is not in use, then set <var>hosts</var> to the
- results of resolving a domain with <var>key</var> and <var>host</var>.
-
- <li><p>Otherwise, set <var>hosts</var> to « <var>host</var> ».
-
-<!-- TODO: Need to limit the total number of simultaneous pending connections for proxies. -->
-
- <li><p>For each <var>host</var> in <var>hosts</var>,
-
-<!-- TODO: Happy eyeballs means we actually try IPv6 and IPv4 hosts in parallel. -->
-
- <ol>
-  <li><p>If the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>, <var>port</var>)] exists, then:
-
-  <ol>
-    <li><p>Let connectingWebSocketConnection be that connection.
-
-    <li><p>Wait for that connection to established or have failed. (Note: this removes it from the
-    map.)
-
-    <li><p>Wait an additional 10ms. (Note: this slows down denial-of-service attacks a bit without
-    significantly impacting legitimate use).
-    <!-- This is Chromium behaviour, not currently standardised -->.
-  </ol>
-
-  <li><p>Assert: the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>,
-  <var>port</var>)] does not exist.
-
-  <li><p>Set the user agent's connecting WebSocket connections[(<var>key</var>, <var>host</var>,
-  <var>port</var>)] to the result of obtaining a connection with <a>network partition key</a>
-  <var>key</var>, <a for=connection>origin</a> <var>origin</var>, <var>credentials</var> set to
-  true, and <a>dedicated</a> set to true.
-
-<!-- TODO: Need to do the equivalent of section 4.1 step 3 for proxies.
-
-Note: Chromium and AFAIK other browsers don't obey this paragraph as they use "http" and "https"
-instead of "ws" and "wss" when executing proxy autoconfiguration scripts.
-
-       For the purpose of proxy autoconfiguration scripts, the URI to
-       pass the function MUST be constructed from /host/, /port/,
-       /resource name/, and the /secure/ flag using the definition of a
-       WebSocket URI as given in Section 3.
-
--->
-
-  <li><p>If establishing connection failed with a TCP error, then remove (<var>key</var>,
-  <var>host</var>, <var>port</var>) from connecting WebSocket connections and <a>continue</a>.
-
-  <li><p>Otherwise, return the user agent's connecting WebSocket connections[(<var>key</var>,
-  <var>host</var>, <var>port</var>)].
- </ol>
+ <li><p>Let <var>connection</var> be the result of running this step: run
+ <a>inner obtain a WebSocket connection</a> given <var>key</var>, <var>origin</var>,
+ <var>credentials</var>, and an <a>implementation-defined</a> <a for=/>host</a> from
+ <var>hosts</var> an <a>implementation-defined</a> number of times, <a>in parallel</a> from each
+ other, and wait for at least 1 to return a value. In an <a>implementation-defined</a> manner,
+ select a value to return from the returned values and return it.
 </ol>
 
-<p class=note>Although structured a little differently, carrying different properties, and
-therefore not shareable, a WebSocket connection is very close to identical to an "ordinary"
-<a>connection</a>.
+<p>To <dfn>inner obtain a WebSocket connection</dfn>, given a <a>network partition key</a>
+<var>key</var>, <a for=/>origin</a> <var>origin</var>, and boolean <var>credentials</var>, and
+<a for=/>host</a> <var>host</var>, run these steps:</p>
+
+<ol>
+ <li><p>Let <var>map</var> be the user agent's <a>connecting WebSocket connections</a>.
+
+ <li><p>Let <var>mapKey</var> be
+ (<var>key</var>, <var>host</var>, <var>origin</var>'s <a for=origin>port</a>).
+
+ <li><p>Let <var>identifier</var> be a unique identifier.
+
+ <li><p>If <var>map</var>[<var>mapKey</var>] <a for=map>exists</a>, then <a for=set>append</a>
+ <var>identifier</var> to <var>map</var>[<var>mapKey</var>].
+
+ <li><p>Otherwise, set <var>map</var>[<var>mapKey</var>] to « <var>identifier</var> ».
+
+ <li><p>Wait until <var>map</var>[<var>mapKey</var>][0] is <var>identifier</var>.
+
+ <li><p>Let <var>connection</var> be the result of <a>obtaining a connection</a> given
+ <var>key</var>, <var>origin</var>, <var>credentials</var>, and XXX.
+ <!-- Need to grab an existing H/2 connection or force an H/1 connection. -->
+
+ <li><p>If <var>connection</var> is failure, then <a for=map>remove</a>
+ <var>map</var>[<var>mapKey</var>][0].
+
+ <li>
+  <p>Otherwise, <a>in parallel</a>, run these steps:
+
+  <ol>
+   <li><p>Wait for either <a>fail the WebSocket connection</a> or
+   <a>the WebSocket connection is established</a> to happen, or for this instance of
+   <a>inner obtain a WebSocket connection</a> to be ignored.
+
+   <li><p><a for=set>Remove</a> <var>identifier</var> from <var>map</var>[<var>mapKey</var>].
+  </ol>
+  <!-- This is not ideal, but carrying sufficient state through request/connection to do this as
+       part of establish a WebSocket connection would be quite a bit of effort. -->
+
+ <li><p>Return <var>connection</var>.
+</ol>
 
 
 <h3 id=websocket-opening-handshake>Opening handshake</h3>
@@ -7584,9 +7579,6 @@ therefore not shareable, a WebSocket connection is very close to identical to an
   steps:
 
   <ol>
-   <li><p>Remove (<var>key</var>, <var>host</var>, <var>port</var>) from connecting WebSocket
-   connections.
-
    <li><p>If <var>response</var> is a <a>network error</a> or its <a for=response>status</a> is not
    101, <a>fail the WebSocket connection</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -7443,29 +7443,56 @@ fetch("https://www.example.com/")
 (<a for=/>network partition key</a>, <a for=/>host</a>, <a for=url>port</a>) to a
 <a for=/>set</a> of unique identifiers.
 
+<p>A user agent has an associated <dfn>total pending proxy WebSocket connections</dfn>, a
+<a for=/>map</a> of <a for=/>network partition key</a> to an integer, starting at 0.
+
 <p>To <dfn id=concept-websocket-connection-obtain>obtain a WebSocket connection</dfn>, given a
 <a>network partition key</a> <var>key</var>, <a for=/>origin</a> <var>origin</var>, and boolean
 <var>credentials</var>, run these steps:
 
 <ol>
- <li><p>Let <var>hosts</var> be the result of running resolve an origin given <var>key</var> and
- <var>origin</var>.
+ <li><p>Let <var>proxies</var> be the result of performing proxy resolution for <var>url</var> in an
+ <a>implementation-defined</a> manner. If a proxy preference order has not been explicitly
+ configured then socks proxies should be preferred to https proxies which should be preferred to
+ http proxies.
+
+ <!-- Since this depends on the url it probably needs to be hoisted out of this algorithm. -->
+
+ <p class=note>The scheme of the URL used in proxy autoconfiguration scripts has been converted from
+ "<code>ws</code>" or "<code>wss</code>" to "<code>http</code>" or "<code>https</code>". This
+ is an intentional violation of RFC6455 that is necessary for compatibility and security. [[!WSP]]
+
+ <li><p>Let <var>direct</var> be true if <var>proxies</var> contains "DIRECT", otherwise false.
+
+ <!-- If proxy.pac returns "PROXY example.com:3128; DIRECT" then we probably shouldn't look up the
+ host unless example.com:3128 fails, but it would make the algorithm even more complex. -->
+
+ <li><p>Let <var>hosts</var> be « <var>origin</var>'s host ».
+
+ <li><p>If <var>direct</var> is true, set <var>hosts</var> to the result of running resolve an
+ origin given <var>key</var> and <var>origin</var>.
  <!-- XXX xref depends on https://github.com/whatwg/fetch/pull/1245 -->
- <!-- TODO: Need to limit the total number of simultaneous pending connections for proxies. -->
 
  <li><p>Let <var>connection</var> be the result of running this step: run
  <a>inner obtain a WebSocket connection</a> given <var>key</var>, <var>origin</var>,
- <var>credentials</var>, and an <a>implementation-defined</a> <a for=/>host</a> from
+ <var>credentials</var>, <var>direct</var>, and an <a>implementation-defined</a> <a for=/>host</a> from
  <var>hosts</var> an <a>implementation-defined</a> number of times, <a>in parallel</a> from each
  other, and wait for at least 1 to return a value. In an <a>implementation-defined</a> manner,
  select a value to return from the returned values and return it.
 </ol>
 
 <p>To <dfn>inner obtain a WebSocket connection</dfn>, given a <a>network partition key</a>
-<var>key</var>, <a for=/>origin</a> <var>origin</var>, and boolean <var>credentials</var>, and
-<a for=/>host</a> <var>host</var>, run these steps:</p>
+<var>key</var>, <a for=/>origin</a> <var>origin</var>, boolean <var>credentials</var>,
+boolean <var>direct</var> and <a for=/>host</a> <var>host</var>, run these steps:</p>
 
 <ol>
+ <li><p>Let <var>totalMap</var> be the user agent's <a>total pending proxy WebSocket connections</a>.
+
+ <li><p>If <var>direct</var> is false, increment <var>totalMap</var>[<var>key</var>].
+
+ <li><p>If <var>totalMap</var>[<var>key</var>] exceeds an <a>implementation-defined</a> limit, wait
+ until <var>totalMap</var>[<var>key</var>] is less than equal to the limit.
+
  <li><p>Let <var>map</var> be the user agent's <a>connecting WebSocket connections</a>.
 
  <li><p>Let <var>mapKey</var> be
@@ -7481,11 +7508,13 @@ fetch("https://www.example.com/")
  <li><p>Wait until <var>map</var>[<var>mapKey</var>][0] is <var>identifier</var>.
 
  <li><p>Let <var>connection</var> be the result of <a>obtaining a connection</a> given
- <var>key</var>, <var>origin</var>, <var>credentials</var>, and XXX.
+ <var>key</var>, <var>origin</var>, <var>credentials</var>, and XXX. When an HTTP(S) proxy is in use
+ a tunnel must be established via the CONNECT method, even if the protocol is not secure.
  <!-- Need to grab an existing H/2 connection or force a H/1 connection. -->
 
  <li><p>If <var>connection</var> is failure, then <a for=map>remove</a>
- <var>map</var>[<var>mapKey</var>][0].
+ <var>map</var>[<var>mapKey</var>][0] and if <var>direct</var> is false decrement
+ <var>totalMap</var>[<var>key</var>].
 
  <li>
   <p>Otherwise, <a>in parallel</a>, run these steps:
@@ -7494,6 +7523,8 @@ fetch("https://www.example.com/")
    <li><p>Wait for either <a>fail the WebSocket connection</a> or
    <a>the WebSocket connection is established</a> to happen, or for this instance of
    <a>inner obtain a WebSocket connection</a> to be ignored.
+
+   <li>If <var>direct</var> is false, decrement <var>totalMap</var>[<var>key</var>].
 
    <li><p><a for=set>Remove</a> <var>identifier</var> from <var>map</var>[<var>mapKey</var>].
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7482,7 +7482,7 @@ fetch("https://www.example.com/")
 
  <li><p>Let <var>connection</var> be the result of <a>obtaining a connection</a> given
  <var>key</var>, <var>origin</var>, <var>credentials</var>, and XXX.
- <!-- Need to grab an existing H/2 connection or force an H/1 connection. -->
+ <!-- Need to grab an existing H/2 connection or force a H/1 connection. -->
 
  <li><p>If <var>connection</var> is failure, then <a for=map>remove</a>
  <var>map</var>[<var>mapKey</var>][0].


### PR DESCRIPTION
Modify "obtain a websocket connection" section to explicitly describe
throttling behaviour rather than delegating it to RFC6455.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1244.html" title="Last updated on Jun 8, 2021, 5:56 AM UTC (938cb06)">Preview</a> | <a href="https://whatpr.org/fetch/1244/43a0c94...938cb06.html" title="Last updated on Jun 8, 2021, 5:56 AM UTC (938cb06)">Diff</a>