### PR TITLE
Make response body streams readable byte streams

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5397,9 +5397,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <p>While true:
 
       <ol>
-       <li><p>User agents should use the <a for=ReadableStream>current requested number of bytes</a>
-       for <var>stream</var> to inform the transmission process about how many bytes are being
-       requested for this stream, if it is non-null.
+       <li><p>If <var>stream</var>'s <a for=ReadableStream>current BYOB request view</a> is
+       non-null, then user agents should use its <a for=BufferSource>byte length</a> to inform the
+       transmission process about how many bytes are being requested for this stream.
 
        <li>
         <p>If one or more bytes have been transmitted from <var>response</var>'s message body, then:
@@ -5426,8 +5426,20 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>If <var>bytes</var> is failure, then <a lt=terminated for=fetch>terminate</a> the
          ongoing fetch.
 
+         <li><p>Let <var>view</var> be null.
+
+         <li><p>If <var>stream</var>'s <a for=ReadableStream>current BYOB request view</a> is
+         non-null, and <var>bytes</var>'s <a for="byte sequence">length</a> is less than
+         <var>stream</var>'s <a for=ReadableStream>current BYOB request view</a>'s
+         <a for=BufferSource>byte length</a>, then set <var>view</var> to <var>stream</var>'s
+         <a for=ReadableStream>current BYOB request view</a>, and <a for=ArrayBufferView>write</a>
+         <var>bytes</var> into <var>view</var>.
+
+         <li><p>Otherwise, set <var>view</var> to the result of <a for=ArrayBufferView>creating</a>
+         a {{Uint8Array}} from <var>bytes</var>.
+
          <li><p><a for=ReadableStream>Enqueue bytes</a> into <var>stream</var> given
-         <var>bytes</var>.
+         <var>view</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
          <a lt=terminated for=fetch>terminate</a> the ongoing fetch.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5337,16 +5337,12 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
- <li><p>Let <var>sizeAlgorithm</var> be an algorithm that accepts a <a>chunk</a> object and returns
- a non-negative, non-NaN, non-infinite number, chosen by the user agent.
-
  <li><p>Let <var>stream</var> be a <a>new</a> {{ReadableStream}}.
 
- <li><p><a for=ReadableStream>Set up</a> <var>stream</var> with
+ <li><p><a for=ReadableStream>Set up with byte reading support</a> <var>stream</var> with
  <a for="ReadableStream/set up"><var>pullAlgorithm</var></a> set to <var>pullAlgorithm</var>,
  <a for="ReadableStream/set up"><var>cancelAlgorithm</var></a> set to <var>cancelAlgorithm</var>,
- <a for="ReadableStream/set up"><var>highWaterMark</var></a> set to <var>highWaterMark</var>, and
- <a for="ReadableStream/set up"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.
+ <a for="ReadableStream/set up"><var>highWaterMark</var></a> set to <var>highWaterMark</var>.
 
  <li>
   <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
@@ -5398,6 +5394,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <p>While true:
 
       <ol>
+       <li><p>User agents should use the <a for=ReadableStream>current requested number of bytes</a>
+       for <var>stream</var> to inform the transmission process about how many bytes are being
+       requested for this stream, if it is non-null.</p></li>
+
        <li>
         <p>If one or more bytes have been transmitted from <var>response</var>'s message body, then:
 
@@ -5423,8 +5423,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>If <var>bytes</var> is failure, then <a lt=terminated for=fetch>terminate</a> the
          ongoing fetch.
 
-         <li><p><a for=ReadableStream>Enqueue</a> a {{Uint8Array}} wrapping an {{ArrayBuffer}}
-         containing <var>bytes</var> into <var>stream</var>.
+         <li><p><a for=ReadableStream>Enqueue bytes</a> into <var>stream</var> given
+         <var>bytes</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
          <a lt=terminated for=fetch>terminate</a> the ongoing fetch.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5438,8 +5438,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Otherwise, set <var>view</var> to the result of <a for=ArrayBufferView>creating</a>
          a {{Uint8Array}} from <var>bytes</var>.
 
-         <li><p><a for=ReadableStream>Enqueue a view</a> into <var>stream</var> given
-         <var>view</var>.
+         <li><p><a for=ReadableStream>Enqueue</a> <var>view</var> into <var>stream</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
          <a lt=terminated for=fetch>terminate</a> the ongoing fetch.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5340,9 +5340,12 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>stream</var> be a <a>new</a> {{ReadableStream}}.
 
  <li><p><a for=ReadableStream>Set up with byte reading support</a> <var>stream</var> with
- <a for="ReadableStream/set up"><var>pullAlgorithm</var></a> set to <var>pullAlgorithm</var>,
- <a for="ReadableStream/set up"><var>cancelAlgorithm</var></a> set to <var>cancelAlgorithm</var>,
- <a for="ReadableStream/set up"><var>highWaterMark</var></a> set to <var>highWaterMark</var>.
+ <a for="ReadableStream/set up with byte reading support"><var>pullAlgorithm</var></a> set to
+ <var>pullAlgorithm</var>,
+ <a for="ReadableStream/set up with byte reading support"><var>cancelAlgorithm</var></a> set to
+ <var>cancelAlgorithm</var>, and
+ <a for="ReadableStream/set up with byte reading support"><var>highWaterMark</var></a> set to
+ <var>highWaterMark</var>.
 
  <li>
   <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
@@ -5396,7 +5399,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <ol>
        <li><p>User agents should use the <a for=ReadableStream>current requested number of bytes</a>
        for <var>stream</var> to inform the transmission process about how many bytes are being
-       requested for this stream, if it is non-null.</p></li>
+       requested for this stream, if it is non-null.
 
        <li>
         <p>If one or more bytes have been transmitted from <var>response</var>'s message body, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -5438,7 +5438,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Otherwise, set <var>view</var> to the result of <a for=ArrayBufferView>creating</a>
          a {{Uint8Array}} from <var>bytes</var>.
 
-         <li><p><a for=ReadableStream>Enqueue bytes</a> into <var>stream</var> given
+         <li><p><a for=ReadableStream>Enqueue a view</a> into <var>stream</var> given
          <var>view</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then


### PR DESCRIPTION
Depends on https://github.com/whatwg/streams/pull/1130. Closes https://github.com/whatwg/fetch/issues/267.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * I think most implementers have expressed _interest_, but I'm not sure it's on anyone's near-term plan to implement this, so we may want to leave this PR open for a while...
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * TODO
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: TODO
   * Firefox: TODO
   * Safari: TODO

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1246.html" title="Last updated on Jul 20, 2021, 9:24 AM UTC (3f03a81)">Preview</a> | <a href="https://whatpr.org/fetch/1246/613aad9...3f03a81.html" title="Last updated on Jul 20, 2021, 9:24 AM UTC (3f03a81)">Diff</a>