### PR TITLE
Block port 989, 990 (ftps-data and ftp)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2577,6 +2577,8 @@ run these steps:
  <tr><td>587<td>submission
  <tr><td>601<td>syslog-conn
  <tr><td>636<td>ldaps
+ <tr><td>989<td>ftps-data
+ <tr><td>990<td>ftps
  <tr><td>993<td>imaps
  <tr><td>995<td>pop3s
  <tr><td>1719<td>h323gatestat


### PR DESCRIPTION
CC @ricea, @youennf, @annevk 

Taking out our imperfect ban hammer again.
In the light of the recently published [ALPACA attack](https://alpaca-attack.com/), it might be worthwhile disallowing ports 989 and 990. We consider this the least controversial ports to add to the list, given they are assigned and below 1024.

One could also block port 2525, but that's... trickier?
Would be great if you,  @ricea, could help us gather some numbers.

I know Microsoft did _something_ in https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-31971 and Chromium was considering something in https://bugs.chromium.org/p/chromium/issues/detail?id=1197149

- [x] At least two implementers are interested (and none opposed):
   * Mozilla
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/29343
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1197149 
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1715684
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=226971


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1250.html" title="Last updated on Jun 14, 2021, 2:24 PM UTC (8695ecd)">Preview</a> | <a href="https://whatpr.org/fetch/1250/3babdcb...8695ecd.html" title="Last updated on Jun 14, 2021, 2:24 PM UTC (8695ecd)">Diff</a>