### PR TITLE
Hard-code `localhost` to loopback addresses.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2207,11 +2207,21 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 <h3 id=resolving-domains>Resolving domains</h3>
 
 <p tracking-vector>To <dfn>resolve a domain</dfn>, given a <a for=/>network partition key</a>
-<var>key</var> and a <a for=/>domain</a> <var>domain</var>, perform an <a>implementation-defined</a>
-operation to turn <var>domain</var> into a <a for=/>set</a> of one or more
-<a for=/>IP addresses</a>. If this operation succeeds, return the <a for=/>set</a> of
-<a for=/>IP addresses</a>. If it fails, return failure. The results of this operation may be cached.
-If they are cached, <var>key</var> should be used as part of the cache key.
+<var>key</var> and a <a for=/>domain</a> <var>domain</var>:
+
+<ol>
+ <li>If <var>domain</var> is a <a for=/>host</a> whose <a for=host>public suffix</a> is "localhost",
+ return « <code>127.0.0.1</code>, <code>[::1]</code> ».
+ 
+ <li>Perform an <a>implementation-defined</a> operation to turn <var>domain</var> into a
+ <a for=/>set</a> of one or more <a for=/>IP addresses</a>. If this operation succeeds, return the
+ <a for=/>set</a> of <a for=/>IP addresses</a>.
+ 
+ <li>Return failure.
+</ol>
+
+The results of this operation may be cached. If they are cached, <var>key</var> should be used as part
+of the cache key.
 
 <div class=note>
  <p>Typically this operation would involve DNS and as such caching can happen on DNS servers without

--- a/fetch.bs
+++ b/fetch.bs
@@ -2210,18 +2210,18 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 <var>key</var> and a <a for=/>domain</a> <var>domain</var>:
 
 <ol>
- <li>If <var>domain</var> is a <a for=/>host</a> whose <a for=host>public suffix</a> is "localhost",
- return « <code>127.0.0.1</code>, <code>[::1]</code> ».
+ <li><p>If <var>domain</var> is a <a for=/>host</a> whose <a for=host>public suffix</a> is
+ "<code>localhost</code>", then return « <code>::1</code>, <code>127.0.0.1</code> ».
 
- <li>Perform an <a>implementation-defined</a> operation to turn <var>domain</var> into a
+ <li><p>Perform an <a>implementation-defined</a> operation to turn <var>domain</var> into a
  <a for=/>set</a> of one or more <a for=/>IP addresses</a>. If this operation succeeds, return the
  <a for=/>set</a> of <a for=/>IP addresses</a>.
 
- <li>Return failure.
+ <li><p>Return failure.
 </ol>
 
-The results of this operation may be cached. If they are cached, <var>key</var> should be used as part
-of the cache key.
+<p>The results of <a>resolve a domain</a> may be cached. If they are cached, <var>key</var> should
+be used as part of the cache key.
 
 <div class=note>
  <p>Typically this operation would involve DNS and as such caching can happen on DNS servers without

--- a/fetch.bs
+++ b/fetch.bs
@@ -2212,11 +2212,11 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 <ol>
  <li>If <var>domain</var> is a <a for=/>host</a> whose <a for=host>public suffix</a> is "localhost",
  return « <code>127.0.0.1</code>, <code>[::1]</code> ».
- 
+
  <li>Perform an <a>implementation-defined</a> operation to turn <var>domain</var> into a
  <a for=/>set</a> of one or more <a for=/>IP addresses</a>. If this operation succeeds, return the
  <a for=/>set</a> of <a for=/>IP addresses</a>.
- 
+
  <li>Return failure.
 </ol>
 


### PR DESCRIPTION
This patch incorporates draft-ietf-dnsop-let-localhost-be-localhost's recommendation
to hard-code resolution of `*.localhost` domains to 127.0.0.1 and [::1], matching
the existing behavior of both Chrome and Firefox. This change allows user agents
to ensure that localhost contexts meet the secure context requirements laid out
in https://w3c.github.io/webappsec-secure-contexts/#localhost.

See https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-let-localhost-be-localhost
for additional detail and justification.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [X] At least two implementers are interested (and none opposed):
   * Chrome ships this mapping.
   * Firefox does as well.
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * I don't think we can test this via WPT, as we can't ensure that a server is running on loopback addresses on the machine from which tests are being executed.
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/691930
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1220810
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=171934

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1257.html" title="Last updated on Jun 22, 2021, 12:28 PM UTC (b13ccf2)">Preview</a> | <a href="https://whatpr.org/fetch/1257/0cee83d...b13ccf2.html" title="Last updated on Jun 22, 2021, 12:28 PM UTC (b13ccf2)">Diff</a>