### PR TITLE
Adapt to embedder policy being in policy container

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3413,15 +3413,13 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
 </code></pre>
 
 <p>To perform a <dfn export>cross-origin resource policy check</dfn>, given an <a for=url>origin</a>
-<var>origin</var>, an <a for=/>environment settings object</a> <var>settingsObject</var>, a string
-<var>destination</var>, a <a for=/>response</a> <var>response</var>, and an optional boolean
-<var>forNavigation</var>, run these steps:
+<var>origin</var>, an <a for=/>environment settings object</a> <var>settingsObject</var>, an
+<a for=/>embedder policy</a> <var>embedderPolicy</var>, a string <var>destination</var>, a
+<a for=/>response</a> <var>response</var>, and an optional boolean <var>forNavigation</var>,
+run these steps:
 
 <ol>
  <li><p>Set <var>forNavigation</var> to false if it is not given.
-
- <li><p>Let <var>embedderPolicy</var> be <var>settingsObject</var>'s
- <a for="environment settings object">embedder policy</a>.
 
  <li>
   <p>If the <a>cross-origin resource policy internal check</a> with <var>origin</var>,
@@ -3435,14 +3433,14 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <var>embedderPolicy</var>'s <a for="embedder policy">report only value</a>, <var>response</var>,
  and <var>forNavigation</var> returns <b>blocked</b>, then
  <a>queue a cross-origin embedder policy CORP violation report</a> with <var>response</var>,
- <var>settingsObject</var>, <var>destination</var>, and true.
+ <var>settingsObject</var>, <var>embedderPolicy</var>, <var>destination</var>, and true.
 
  <li><p>If the <a>cross-origin resource policy internal check</a> with <var>origin</var>,
  <var>embedderPolicy</var>'s <a for="embedder policy">value</a>, <var>response</var>, and
  <var>forNavigation</var> returns <b>allowed</b>, then return <b>allowed</b>.
 
  <li><p><a>Queue a cross-origin embedder policy CORP violation report</a> with <var>response</var>,
- <var>settingsObject</var>, <var>destination</var>, and false.
+ <var>settingsObject</var>, <var>embedderPolicy</var>, <var>destination</var>, and false.
 
  <li><p>Return <b>blocked</b>.
 </ol>
@@ -3521,15 +3519,13 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
 
 <p>To <dfn>queue a cross-origin embedder policy CORP violation report</dfn>, given a
 <a for=/>response</a> <var>response</var>, an <a for=/>environment settings object</a>
-<var>settingsObject</var>, a string <var>destination</var>, and a boolean <var>reportOnly</var>,
-run these steps:
+<var>settingsObject</var>, an <a for=/>embedder policy</a> <var>embedderPolicy</var>,
+a string <var>destination</var>, and a boolean <var>reportOnly</var>, run these steps:
 
 <ol>
- <li><p>Let <var>endpoint</var> be <var>settingsObject</var>'s
- <a for="environment settings object">embedder policy</a>'s
+ <li><p>Let <var>endpoint</var> be <var>embedderPolicy</var>'s
  <a for="embedder policy">report only reporting endpoint</a> if <var>reportOnly</var> is true and
- <var>settingsObject</var>'s <a for="environment settings object">embedder policy</a>'s
- <a for="embedder policy">reporting endpoint</a> otherwise.
+ <var>embedderPolicy</var>'s <a for="embedder policy">reporting endpoint</a> otherwise.
 
  <li><p>Let <var>serializedURL</var> be the result of
  <a lt="serialize a response URL for reporting">serializing a response URL for reporting</a> with
@@ -4390,9 +4386,10 @@ these steps:
   <p>If either <var>request</var>'s <a for=request>response tainting</a> or <var>response</var>'s
   <a for=response>type</a> is "<code>opaque</code>", and the
   <a>cross-origin resource policy check</a> with <var>request</var>'s <a for=request>origin</a>,
-  <var>request</var>'s <a for=request>client</a>, <var>request</var>'s
-  <a for=request>destination</a>, and <var>actualResponse</var> returns <b>blocked</b>, then return
-  a <a>network error</a>.
+  <var>request</var>'s <a for=request>policy container</a>'s
+  <a for="policy container">embedder policy</a>, <var>request</var>'s <a for=request>client</a>,
+  <var>request</var>'s <a for=request>destination</a>, and <var>actualResponse</var> returns
+  <b>blocked</b>, then return a <a>network error</a>.
 
   <p class=note>The <a>cross-origin resource policy check</a> runs for responses coming from the
   network and responses coming from the service worker. This is different from the


### PR DESCRIPTION
This is an editorial PR which adapts fetch to embedder policy moving to the policy container (https://github.com/whatwg/html/pull/6793).

As a side effect, this fixes possible inconsistencies caused by concurrent accessing an environment settings object's embedder policy during fetch, since now fetch uses instead the embedder policy of the request's policy container (snapshotted at the beginning of fetch) for the checks.
