### PR TITLE
Fix build with embedder policy in policy container

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3421,7 +3421,8 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
  <li><p>Set <var>forNavigation</var> to false if it is not given.
 
  <li><p>Let <var>embedderPolicy</var> be <var>settingsObject</var>'s
- <a for="environment settings object">embedder policy</a>.
+ <a for="environment settings object">policy container</a>'s
+ <a for="policy container">embedder policy</a>.
 
  <li>
   <p>If the <a>cross-origin resource policy internal check</a> with <var>origin</var>,
@@ -3526,9 +3527,11 @@ run these steps:
 
 <ol>
  <li><p>Let <var>endpoint</var> be <var>settingsObject</var>'s
- <a for="environment settings object">embedder policy</a>'s
+ <a for="environment settings object">policy container</a>'s
+ <a for="policy container">embedder policy</a>'s
  <a for="embedder policy">report only reporting endpoint</a> if <var>reportOnly</var> is true and
- <var>settingsObject</var>'s <a for="environment settings object">embedder policy</a>'s
+ <var>settingsObject</var>'s <a for="environment settings object">policy container</a>'s
+ <a for="policy container">embedder policy</a>'s
  <a for="embedder policy">reporting endpoint</a> otherwise.
 
  <li><p>Let <var>serializedURL</var> be the result of


### PR DESCRIPTION
This is a PR to fix the build now that in html embedder policy moved into the policy container (https://github.com/whatwg/html/pull/6793).

This replaces https://github.com/whatwg/fetch/pull/1258.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1264.html" title="Last updated on Jul 2, 2021, 7:21 AM UTC (63c07ee)">Preview</a> | <a href="https://whatpr.org/fetch/1264/0cee83d...63c07ee.html" title="Last updated on Jul 2, 2021, 7:21 AM UTC (63c07ee)">Diff</a>