### PR TITLE
Use tasks to manipulate streams

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4199,9 +4199,7 @@ steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+     <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
      <li><p>Return a <a>network error</a>.
     </ol>
@@ -4937,9 +4935,7 @@ steps. They return a <a for=/>response</a>.
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-   <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+   <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
    <li><p>Return a <a>network error</a>.
   </ol>
@@ -5039,9 +5035,7 @@ steps. They return a <a for=/>response</a>.
       <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
 
       <ol>
-       <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-       <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+       <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
        <li><p>Return a <a>network error</a>.
       </ol>
@@ -5075,9 +5069,7 @@ steps. They return a <a for=/>response</a>.
     <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
 
     <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+     <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
      <li><p>Return a <a>network error</a>.
     </ol>
@@ -5113,9 +5105,7 @@ steps. They return a <a for=/>response</a>.
     <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
 
     <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+     <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
      <li><p>Return a <a>network error</a>.
     </ol>
@@ -5320,11 +5310,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
    <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
-   <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
+   <li><p>If the termination's aborted flag is set, then return an <a>aborted network error</a>.
 
    <li><p>Return a <a>network error</a>.
   </ol>
@@ -5378,9 +5366,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-   <li><p>If <var>aborted</var> is set, then set <var>response</var>'s
+   <li><p>If the termination's aborted flag is set, then set <var>response</var>'s
    <a for=response>aborted flag</a>.
 
    <li><p>Return <var>response</var>.
@@ -5423,20 +5409,28 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>If <var>bytes</var> is failure, then <a lt=terminated for=fetch>terminate</a> the
          ongoing fetch.
 
-         <li><p><a for=ReadableStream>Enqueue</a> a {{Uint8Array}} wrapping an {{ArrayBuffer}}
-         containing <var>bytes</var> into <var>stream</var>.
+         <li>
+          <p>Let <var>handleResponseBytes</var> be these steps:
 
-         <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
-         <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+          <ol>
+           <li><p><a for=ReadableStream>Enqueue</a> a {{Uint8Array}} wrapping an {{ArrayBuffer}}
+           containing <var>bytes</var> into <var>stream</var>.
 
-         <li><p>If <var>stream</var> doesn't <a for=ReadableStream>need more data</a> ask the user
-         agent to <a for=fetch>suspend</a> the ongoing fetch.
+           <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
+           <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+
+           <li><p>If <var>stream</var> doesn't <a for=ReadableStream>need more data</a> ask the user
+           agent to <a for=fetch>suspend</a> the ongoing fetch.
+          </ol>
+
+         <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
+         normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
+         <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>finalize response</a> for
+         <var>fetchParams</var> and <var>response</var>.
         </ol>
 
-       <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
-       normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
-       <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>finalize response</a> for
-       <var>fetchParams</var> and <var>response</var>, and abort these in-parallel steps.
+       <li><p><a>Queue a fetch task</a> given <var>handleResponseBytes</var> and
+       <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
       </ol>
     </ol>
 
@@ -5445,22 +5439,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ol>
      <li><a for=/>Finalize response</a> for <var>fetchParams</var> and <var>response</var>.
-
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li>
-      <p>If <var>aborted</var> is set, then:
-
-      <ol>
-       <li><p>Set <var>response</var>'s <a for=response>aborted flag</a>.
-
-       <li><p>If <var>stream</var> is <a for=ReadableStream>readable</a>,
-       <a for=ReadableStream>error</a> <var>stream</var> with an
-       "<code><a exception>AbortError</a></code>" {{DOMException}}.
-      </ol>
-
-     <li><p>Otherwise, if <var>stream</var> is <a for=ReadableStream>readable</a>,
-     <a for=ReadableStream>error</a> <var>stream</var> with a {{TypeError}}.
 
      <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
@@ -5471,6 +5449,28 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <p class=note>For instance, the user agent could keep the connection open if it knows there's
       only a few bytes of transfer remaining on a reusable connection. In this case it could be
       worse to close the connection and go through the handshake process again for the next fetch.
+
+     <li>
+      <p>Let <var>handleResponseError</var> be these steps:
+
+      <ol>
+       <li>
+        <p>If the termination's aborted flag is set, then:
+
+        <ol>
+         <li><p>Set <var>response</var>'s <a for=response>aborted flag</a>.
+
+         <li><p>If <var>stream</var> is <a for=ReadableStream>readable</a>,
+         <a for=ReadableStream>error</a> <var>stream</var> with an
+         "<code><a exception>AbortError</a></code>" {{DOMException}}.
+        </ol>
+
+       <li><p>Otherwise, if <var>stream</var> is <a for=ReadableStream>readable</a>,
+       <a for=ReadableStream>error</a> <var>stream</var> with a {{TypeError}}.
+      </ol>
+
+     <li><p><a>Queue a fetch task</a> given <var>handleResponseError</var> and
+     <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
     </ol>
   </ol>
 


### PR DESCRIPTION
Helps with #1246.

The main problem with this PR (which is why I marked it WIP) is that the stream itself is created in parallel and I don't see a good way to avoid that. If we had low-level streams this would be different.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
