### PR TITLE
Minor cleanup: HTTP-network-or-cache s/httpRequest/request.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5045,7 +5045,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
  <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP cache partition</a>, given
- <var>httpRequest</var>.
+ <var>request</var>.
 
  <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
  to "<code>no-store</code>".


### PR DESCRIPTION
`httpRequest` is not defined in this function. Most likely authors wanted
to refer to `request` instead, which is set to `fetchParams`'s
request in step 1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1298.html" title="Last updated on Aug 23, 2021, 11:40 AM UTC (920c0ba)">Preview</a> | <a href="https://whatpr.org/fetch/1298/5fac9e8...920c0ba.html" title="Last updated on Aug 23, 2021, 11:40 AM UTC (920c0ba)">Diff</a>