### PR TITLE
Expose a mechanism for hiding internal timing info

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -233,7 +233,7 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
 <p>To <dfn export lt="create an opaque timing info|creating an opaque timing info">create an
 opaque timing info</dfn>, given a <a for=/>fetch timing info</a> <var>timingInfo</var>,
- create a new <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
+ return a new <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
  <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
  <a for="fetch timing info">start time</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -231,6 +231,12 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dd>Null or a <a for=/>connection timing info</a>.
 </dl>
 
+<p>To <dfn export lt="create an opaque timing info|creating an opaque timing info">create an
+opaque timing info</dfn>, given a <a for=/>fetch timing info</a> <var>timingInfo</var>,
+ create a new <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
+ <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+ <a for="fetch timing info">start time</a>.
+
 <p>To <dfn>update timing info from stored response</dfn>, given a
 <a for=/>connection timing info</a> <var>timingInfo</var> and a <a for=/>response</a>
 <var>response</var>, perform the following steps:
@@ -4131,10 +4137,8 @@ steps:
   <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then:
 
   <ol>
-   <li><p>Set <var>timingInfo</var> to a new <a for=/>fetch timing info</a> whose
-   <a for="fetch timing info">start time</a> and
-   <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
-   <a for="fetch timing info">start time</a>.
+   <li><p>Set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
+   <var>timingInfo</var>.
 
    <li><p>Set <var>cacheState</var> to the empty string.
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -231,11 +231,12 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dd>Null or a <a for=/>connection timing info</a>.
 </dl>
 
-<p>To <dfn export lt="create an opaque timing info|creating an opaque timing info">create an
-opaque timing info</dfn>, given a <a for=/>fetch timing info</a> <var>timingInfo</var>,
- return a new <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
- <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
- <a for="fetch timing info">start time</a>.
+<p>To
+<dfn export lt="create an opaque timing info|creating an opaque timing info">create an opaque timing info</dfn>,
+given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
+<a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
+<a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
+<a for="fetch timing info">start time</a>.
 
 <p>To <dfn>update timing info from stored response</dfn>, given a
 <a for=/>connection timing info</a> <var>timingInfo</var> and a <a for=/>response</a>


### PR DESCRIPTION
This is needed for https://github.com/whatwg/html/issues/7104
and later on for https://github.com/whatwg/fetch/issues/1215.

Navigation timing reports the timing info from the HTML spec,
so it needs a mechanism to obfuscate the internals. So far that
obfuscation was internal to fetch and was done upon reporting.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1309.html" title="Last updated on Sep 28, 2021, 2:33 PM UTC (d6889b0)">Preview</a> | <a href="https://whatpr.org/fetch/1309/b2f04e2...d6889b0.html" title="Last updated on Sep 28, 2021, 2:33 PM UTC (d6889b0)">Diff</a>