### PR TITLE
Attach timing info and URL to network errors, and report for fetch API

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4213,6 +4213,25 @@ steps:
   </ol>
  </li>
 
+ <li>
+  <p>Otherwise, if <var>response</var>'s <a for=response>body</a> is not null and is
+  <a for=ReadableStream>readable</a>, then:</o>
+
+  <ol>
+   <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
+
+   <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
+   <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
+
+   <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
+   <var>identityTransformAlgorithm</var> and <var>finalize</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
+   <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
+   <a for=response>body</a> through <var>transformStream</var>.
+  </ol>
+ </li>
+
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
  <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
@@ -4254,26 +4273,8 @@ steps:
   </ol>
  </li>
 
- <li>
-  <p>Otherwise, if <var>response</var>'s <a for=response>body</a> is not null and is
-  <a for=ReadableStream>readable</a>, then:</o>
-
-  <ol>
-   <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
-
-   <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
-   <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
-
-   <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
-   <var>identityTransformAlgorithm</var> and <var>finalize</var>.
-
-   <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
-   <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
-   <a for=response>body</a> through <var>transformStream</var>.
-  </ol>
- </li>
-
- <li><p>Otherwise, run <var>finalize</var>.</p></li>
+ <li><p>If <var>response</var>'s <a for=response>body</a> is null or
+ not <a for=ReadableStream>readable</a>, then run <var>finalize</var>.</p></li>
 </ol>
 
 <p>To <dfn>finalize response</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var> and a

--- a/fetch.bs
+++ b/fetch.bs
@@ -203,8 +203,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
- <dt><dfn for="fetch params">ready for clients</dfn> (default false).
- <dt><dfn for="fetch params">network read complete</dfn> (default false).
  <dd>A boolean.
 
  <dt><dfn for="fetch params">timing info</dfn>
@@ -4212,30 +4210,39 @@ steps:
    <li><p>Set <var>response</var>'s <a for=response>timing info</a> to the result of
    <a>creating an opaque timing info</a> for <var>fetchParams</var>'s
    <a for="fetch params">timing info</a>.</p></li>
-
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">network read complete</a> to true.
   </ol>
  </li>
-
- <li><p>If <var>response</var>'s <a for="response">cache state</a> is not the empty string, then
- set <var>fetchParams</var>'s <a for="fetch params">network read complete</a> to true.</p></li>
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
  <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
+ <li><p>Let <var>finalize</var> be this step: <a>finalize response</a> given <var>fetchParams</var>
+ and <var>response</var>.
+
  <li>
   <p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is non-null,
   then:
 
   <ol>
-   <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
-   <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> given
-   <var>response</var> and <var>nullOrBytes</var>.
+   <li>
+    <p>Let <var>processEndOfBody</var> given <var>nullBytesOrFailure</var> be the following
+    steps:
 
-   <li><p>Let <var>processBodyError</var> be this step: run <var>fetchParams</var>'s
-   <a for="fetch params">process response end-of-body</a> given <var>response</var> and failure.
+    <ol>
+     <li><p>Run <var>finalize</var>.
+
+     <li><p>Run <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a>
+     given <var>response</vaR> and <var>nullBytesOrFailure</var>.
+    </ol>
+   </li>
+
+   <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
+   <var>processEndOfBody</var> with <var>nullOrBytes</var>.
+
+   <li><p>Let <var>processBodyError</var> be this step: run <var>processEndOfBody</var>given
+   failure.
 
    <li><p>If <var>response</var>'s <a for=response>body</a> is null, then <a>queue a fetch task</a>
    to run <var>processBody</var> given null, with <var>fetchParams</var>'s
@@ -4248,41 +4255,35 @@ steps:
  </li>
 
  <li>
-  <p><a>Queue a fetch task</a> to run the following steps with <var>fetchParams</var>'s
-  <a for="fetch params">task destination</a>:</p>
+  <p>Otherwise, if <var>response</var>'s <a for=response>body</a> is not null and is
+  <a for=ReadableStream>readable</a>, then:</o>
 
   <ol>
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">ready for clients</a> to true.</p></li>
+   <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
 
-   <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
+   <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
+   <a for=ReadableStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
+   <a for=TransformStream>setting up</a> <var>transformStream</var> with
+   <var>identityTransformAlgorithm</var> and <var>finalize</var>.
   </ol>
-</ol>
+ </li>
 
-<p>To <dfn>fetch network finale</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var>
-and a <a for=/>response</a> <var>response</var>, <a>queue a fetch task</a>
-given the following steps with <var>fetchParams</var>'s
-<a for="fetch params">task destination</a>:</p>
-
-<ol>
- <li><p>Set <var>fetchParams</var>'s
- <a for="fetch params">network read complete</a> to true.</p></li>
-
- <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
+ <li><p>Otherwise, run <var>finalize</var>.</p></li>
 </ol>
 
 <p>To <dfn>finalize response</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var> and a
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
- <li><p>If <var>fetchParams</var>'s <a for="fetch params">ready for clients</a> is false or
- <var>fetchParams</var>'s <a for="fetch params">network read complete</a> is false, return.</p></li>
-
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
- then run <var>fetchParams</var>'s <a for="fetch params">process response done</a> with
- <var>response</var>.
+ then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+ <a for="fetch params">process response done</a> given <var>response</var> with
+ <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
@@ -5636,8 +5637,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
        normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
-       <a for=ReadableStream>close</a> <var>stream</var>, run <a for=/>fetch network finale</a> for
-       <var>fetchParams</var> and <var>response</var>, and abort these in-parallel steps.
+       <a for=ReadableStream>close</a> <var>stream</var>, and abort these in-parallel steps.
       </ol>
     </ol>
 
@@ -5645,7 +5645,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li>Run <a for=/>fetch network finale</a> for <var>fetchParams</var> and <var>response</var>.
+     <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
 
      <li><p>Let <var>aborted</var> be the termination's aborted flag.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4200,7 +4200,7 @@ steps:
   <ol>
    <li>
     <p>Set <var>response</var>'s <a for=response>URL list</a> to « <var>fetchParams</var>'s
-    <a for="fetch params">request</a>'s <a for=request>URL list</a> ≫.
+    <a for="fetch params">request</a>'s <a for=request>URL list</a>[0] ≫.
 
     <p class=note>This is needed as after <a for=list>cloning</a> <var>fetchParams</var>'s
     <a for="fetch params">request</a>'s <a for=request>URL list</a> earlier, <var>response</var>
@@ -4212,9 +4212,6 @@ steps:
    <a for="fetch params">timing info</a>.</p></li>
   </ol>
  </li>
-
- <li><p>Let <var>hasReadableStream</var> be true if <var>response</var>'s <a for=response>body</a>
- is not null and is <a for=ReadableStream>readable</a>; otherwise false.
 
  <li>
   <p>Let <var>processResponseDone</var> be the following steps:
@@ -4230,8 +4227,11 @@ steps:
   </ol>
  </li>
 
+ <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
+ <var>processResponseDone</var>.
+
  <li>
-  <p>If <var>hasReadableStream</var> is true, then:
+  <p>Otherwise:</p>
 
   <ol>
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
@@ -4240,12 +4240,16 @@ steps:
    <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
    <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
-   <var>identityTransformAlgorithm</var> and <var>processResponseDone</var>.
+   [=TransformStream/set up/transformalgorithm=] set to <var>identityTransformAlgorithm</var> and
+   [=TransformStream/set up/flushalgorithm=] set to <var>processResponseDone</var>.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
    <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
    <a for=response>body</a> through <var>transformStream</var>.
   </ol>
+
+  <p class=note>This {{TransformStream}} is needed for the purpose of receiving a notification when
+  the stream reaches its end, and is otherwise an [=identity transform stream=].
  </li>
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
@@ -4258,23 +4262,12 @@ steps:
   then:
 
   <ol>
-   <li>
-    <p>Let <var>processEndOfBody</var> given <var>nullBytesOrFailure</var> be the following
-    steps:
-
-    <ol>
-     <li><p>Run <var>processResponseDone</var>.
-
-     <li><p>Run <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a>
-     given <var>response</vaR> and <var>nullBytesOrFailure</var>.
-    </ol>
-   </li>
-
    <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
-   <var>processEndOfBody</var> with <var>nullOrBytes</var>.
+   <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> given
+   <var>response</var> and <var>nullOrBytes</var>.
 
-   <li><p>Let <var>processBodyError</var> be this step: run <var>processEndOfBody</var>given
-   failure.
+   <li><p>Let <var>processBodyError</var> be this step: run <var>fetchParams</var>'s
+   <a for="fetch params">process response end-of-body</a> given <var>response</var> and failure.
 
    <li><p>If <var>response</var>'s <a for=response>body</a> is null, then <a>queue a fetch task</a>
    to run <var>processBody</var> given null, with <var>fetchParams</var>'s
@@ -4285,8 +4278,6 @@ steps:
    <a for="fetch params">task destination</a>.
   </ol>
  </li>
-
-  <li><p>If <var>hasReadableStream</var> is false, then run <var>processResponseDone</var>.</p></li>
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4232,11 +4232,8 @@ steps:
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
- <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
- <var>processResponseDone</var>.
-
  <li>
-  <p>Otherwise:</p>
+  <p>If <var>response</var>'s <a for=response>body</a> is not null, then:
 
   <ol>
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
@@ -4276,6 +4273,9 @@ steps:
    <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
+
+ <li>If <var>response</var>'s <a for=response>body</a> is null, then run
+ <var>processResponseDone</var>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4200,7 +4200,7 @@ steps:
   <ol>
    <li>
     <p>Set <var>response</var>'s <a for=response>URL list</a> to « <var>fetchParams</var>'s
-    <a for="fetch params">request</a>'s <a for=request>URL list</a>[0] ≫.
+    <a for="fetch params">request</a>'s <a for=request>URL list</a>[0] ».
 
     <p class=note>This is needed as after <a for=list>cloning</a> <var>fetchParams</var>'s
     <a for="fetch params">request</a>'s <a for=request>URL list</a> earlier, <var>response</var>

--- a/fetch.bs
+++ b/fetch.bs
@@ -203,6 +203,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
+ <dt><dfn for="fetch params">ready for clients</dfn> (default false).
+ <dt><dfn for="fetch params">network read complete</dfn> (default false).
  <dd>A boolean.
 
  <dt><dfn for="fetch params">timing info</dfn>
@@ -4194,6 +4196,27 @@ steps:
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
+ <li>
+  <p>If <var>response</var> is a <a>network error</a>, then:
+
+  <ol>
+   <li>
+    <p>Set <var>response</var>'s <a for=response>URL list</a> to « <var>fetchParams</var>'s
+    <a for="fetch params">request</a>'s <a for=request>URL list</a> ≫.
+
+    <p class=note>This is needed as after <a for=list>cloning</a> <var>fetchParams</var>'s
+    <a for="fetch params">request</a>'s <a for=request>URL list</a> earlier, <var>response</var>
+    might have been set to a <a>network error</a>.</p>
+   </li>
+
+   <li><p>Set <var>response</var>'s <a for=response>timing info</a> to the result of
+   <a>creating an opaque timing info</a> for <var>fetchParams</var>'s
+   <a for="fetch params">timing info</a>.</p></li>
+
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">network read complete</a> to true.
+  </ol>
+ </li>
+
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
  <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
@@ -4219,19 +4242,43 @@ steps:
    <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
+ </li>
+
+ <li>
+  <p><a>Queue a fetch task</a> to run the following steps with <var>fetchParams</var>'s
+  <a for="fetch params">task destination</a>:</p>
+
+  <ol>
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">ready for clients</a> to true.</p></li>
+
+   <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
+  </ol>
+</ol>
+
+<p>To <dfn>fetch network finale</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var>
+and a <a for=/>response</a> <var>response</var>, <a>queue a fetch task</a>
+with to run the following steps with <var>fetchParams</var>'s
+<a for="fetch params">task destination</a>:</p>
+
+<ol>
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">network read complete</a>.</p></li>
+
+ <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
 </ol>
 
 <p>To <dfn>finalize response</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var> and a
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
+ <li><p>If<var>fetchParams</var>'s <a for="fetch params">ready for clients</a> is false or
+ <var>fetchParams</var>'s <a for="fetch params">network read complete</a> is false, return.</p></li>
+
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
  <a for=request>done flag</a>.
 
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
- then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
- <a for="fetch params">process response done</a> given <var>response</var>,
- with <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
+ then run <var>fetchParams</var>'s <a for="fetch params">process response done</a> with
+ <var>response</var>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
@@ -5580,7 +5627,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Otherwise, if the bytes transmission for <var>response</var>'s message body is done
        normally and <var>stream</var> is <a for=ReadableStream>readable</a>, then
-       <a for=ReadableStream>close</a> <var>stream</var>, <a for=/>finalize response</a> for
+       <a for=ReadableStream>close</a> <var>stream</var>, run <a for=/>fetch network finale</a> for
        <var>fetchParams</var> and <var>response</var>, and abort these in-parallel steps.
       </ol>
     </ol>
@@ -5589,7 +5636,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li><a for=/>Finalize response</a> for <var>fetchParams</var> and <var>response</var>.
+     <li>Run <a for=/>fetch network finale</a> for <var>fetchParams</var> and <var>response</var>.
 
      <li><p>Let <var>aborted</var> be the termination's aborted flag.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4213,11 +4213,11 @@ steps:
   </ol>
  </li>
 
- <li>
-  <li><p>Let <var>hasReadableStream</var> be true if <var>response</var>'s <a for=response>body</a>
-  is not null and is <a for=ReadableStream>readable</a>; otherwise false.
+ <li><p>Let <var>hasReadableStream</var> be true if <var>response</var>'s <a for=response>body</a>
+ is not null and is <a for=ReadableStream>readable</a>; otherwise false.
 
-  <li><p>If <var>hasReadableStream</var> is true, then:
+ <li>
+  <p>If <var>hasReadableStream</var> is true, then:
 
   <ol>
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4227,6 +4227,11 @@ steps:
   </ol>
  </li>
 
+ <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
+ <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+ <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
+ <a for="fetch params">task destination</a>.
+
  <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
  <var>processResponseDone</var>.
 
@@ -4240,8 +4245,8 @@ steps:
    <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
    <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
-   [=TransformStream/set up/transformalgorithm=] set to <var>identityTransformAlgorithm</var> and
-   [=TransformStream/set up/flushalgorithm=] set to <var>processResponseDone</var>.
+   <i><a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to <var>identityTransformAlgorithm</var> and
+   <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set to <var>processResponseDone</var>.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
    <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
@@ -4249,13 +4254,7 @@ steps:
   </ol>
 
   <p class=note>This {{TransformStream}} is needed for the purpose of receiving a notification when
-  the stream reaches its end, and is otherwise an [=identity transform stream=].
- </li>
-
- <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
- <a>queue a fetch task</a> to run <var>fetchParams</var>'s
- <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
- <a for="fetch params">task destination</a>.
+  the stream reaches its end, and is otherwise an <a>identity transform stream</a>.
 
  <li>
   <p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is non-null,
@@ -4277,7 +4276,6 @@ steps:
    <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
- </li>
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4242,7 +4242,7 @@ steps:
    <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
    <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
-   <i><a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to <var>identityTransformAlgorithm</var> and
+   <a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to <var>identityTransformAlgorithm</var> and
    <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set to <var>processResponseDone</var>.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -4286,6 +4286,8 @@ given the following steps with <var>fetchParams</var>'s
 <var>initiatorType</var> (default "<code>other</code>"), run these steps:
 
 <ol>
+ <li><p>If <var>response</var> is an <a>aborted network error</a>, then return.
+
  <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or
  <a for=list lt="is empty">empty</a>, then return.
 
@@ -4294,6 +4296,9 @@ given the following steps with <var>fetchParams</var>'s
  <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
 
  <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
+
+ <li><p>If <var>originalURL</var>'s <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then
+ return.
 
  <li><p>If <var>timingInfo</var> is null, then return.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4232,8 +4232,11 @@ steps:
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
+ <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
+ <var>processResponseDone</var>.
+
  <li>
-  <p>If <var>response</var>'s <a for=response>body</a> is not null, then:
+  <p>Otherwise:</p>
 
   <ol>
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
@@ -4273,9 +4276,6 @@ steps:
    <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
-
- <li>If <var>response</var>'s <a for=response>body</a> is null, then run
- <var>processResponseDone</var>.
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4217,6 +4217,20 @@ steps:
  is not null and is <a for=ReadableStream>readable</a>; otherwise false.
 
  <li>
+  <p>Let <var>processResponseDone</var> be the following steps:
+
+  <ol>
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+   <a for=request>done flag</a>.
+
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
+   then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+   <a for="fetch params">process response done</a> given <var>response</var> with
+   <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
+  </ol>
+ </li>
+
+ <li>
   <p>If <var>hasReadableStream</var> is true, then:
 
   <ol>
@@ -4238,20 +4252,6 @@ steps:
  <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
-
- <li>
-  <p>Let <var>processResponseDone</var> be the following steps:
-
-  <ol>
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-   <a for=request>done flag</a>.
-
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
-   then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
-   <a for="fetch params">process response done</a> given <var>response</var> with
-   <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
-  </ol>
- </li>
 
  <li>
   <p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is non-null,

--- a/fetch.bs
+++ b/fetch.bs
@@ -4264,9 +4264,12 @@ steps:
    <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
    <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
-   <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
-   <a for=TransformStream>setting up</a> <var>transformStream</var> with
+   <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
    <var>identityTransformAlgorithm</var> and <var>finalize</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
+   <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
+   <a for=response>body</a> through <var>transformStream</var>.
   </ol>
  </li>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4217,6 +4217,9 @@ steps:
   </ol>
  </li>
 
+ <li><p>If <var>response</var>'s <a for="response">cache state</a> is not the empty string, then
+ set <var>fetchParams</var>'s <a for="fetch params">network read complete</a> to true.</p></li>
+
  <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response</a> is non-null, then
  <a>queue a fetch task</a> to run <var>fetchParams</var>'s
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
@@ -4261,7 +4264,8 @@ given the following steps with <var>fetchParams</var>'s
 <a for="fetch params">task destination</a>:</p>
 
 <ol>
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">network read complete</a>.</p></li>
+ <li><p>Set <var>fetchParams</var>'s
+ <a for="fetch params">network read complete</a> to true.</p></li>
 
  <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
 </ol>
@@ -4270,7 +4274,7 @@ given the following steps with <var>fetchParams</var>'s
 <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
- <li><p>If<var>fetchParams</var>'s <a for="fetch params">ready for clients</a> is false or
+ <li><p>If <var>fetchParams</var>'s <a for="fetch params">ready for clients</a> is false or
  <var>fetchParams</var>'s <a for="fetch params">network read complete</a> is false, return.</p></li>
 
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -4214,8 +4214,10 @@ steps:
  </li>
 
  <li>
-  <p>Otherwise, if <var>response</var>'s <a for=response>body</a> is not null and is
-  <a for=ReadableStream>readable</a>, then:</o>
+  <li><p>Let <var>hasReadableStream</var> be true if <var>response</var>'s <a for=response>body</a>
+  is not null and is <a for=ReadableStream>readable</a>; otherwise false.
+
+  <li><p>If <var>hasReadableStream</var> is true, then:
 
   <ol>
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
@@ -4224,7 +4226,7 @@ steps:
    <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
    <li><p><a for=TransformStream lt="setting up">Set up</a> <var>transformStream</var> with
-   <var>identityTransformAlgorithm</var> and <var>finalize</var>.
+   <var>identityTransformAlgorithm</var> and <var>processResponseDone</var>.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
    <a for=ReadableStream lt="piping through">piping</a> <var>response</var>'s
@@ -4237,8 +4239,19 @@ steps:
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
- <li><p>Let <var>finalize</var> be this step: <a>finalize response</a> given <var>fetchParams</var>
- and <var>response</var>.
+ <li>
+  <p>Let <var>processResponseDone</var> be the following steps:
+
+  <ol>
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+   <a for=request>done flag</a>.
+
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
+   then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+   <a for="fetch params">process response done</a> given <var>response</var> with
+   <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
+  </ol>
+ </li>
 
  <li>
   <p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is non-null,
@@ -4250,7 +4263,7 @@ steps:
     steps:
 
     <ol>
-     <li><p>Run <var>finalize</var>.
+     <li><p>Run <var>processResponseDone</var>.
 
      <li><p>Run <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a>
      given <var>response</vaR> and <var>nullBytesOrFailure</var>.
@@ -4273,21 +4286,7 @@ steps:
   </ol>
  </li>
 
- <li><p>If <var>response</var>'s <a for=response>body</a> is null or
- not <a for=ReadableStream>readable</a>, then run <var>finalize</var>.</p></li>
-</ol>
-
-<p>To <dfn>finalize response</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var> and a
-<a for=/>response</a> <var>response</var>, run these steps:
-
-<ol>
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
- <a for=request>done flag</a>.
-
- <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response done</a> is not null,
- then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
- <a for="fetch params">process response done</a> given <var>response</var> with
- <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
+  <li><p>If <var>hasReadableStream</var> is false, then run <var>processResponseDone</var>.</p></li>
 </ol>
 
 <p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
@@ -5649,8 +5648,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li><p><a>Finalize response</a> given <var>fetchParams</var> and <var>response</var>.</p></li>
-
      <li><p>Let <var>aborted</var> be the termination's aborted flag.
 
      <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4262,7 +4262,7 @@ steps:
    <li><p>Let <var>transformStream</var> be a new a {{TransformStream}}.
 
    <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
-   <a for=ReadableStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
+   <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to the result of
    <a for=TransformStream>setting up</a> <var>transformStream</var> with

--- a/fetch.bs
+++ b/fetch.bs
@@ -4257,7 +4257,7 @@ steps:
 
 <p>To <dfn>fetch network finale</dfn> given a <a for=/>fetch params</a> <var>fetchParams</var>
 and a <a for=/>response</a> <var>response</var>, <a>queue a fetch task</a>
-with to run the following steps with <var>fetchParams</var>'s
+given the following steps with <var>fetchParams</var>'s
 <a for="fetch params">task destination</a>:</p>
 
 <ol>


### PR DESCRIPTION
The timing info attached to a network error is always "opaque",
containing only start/end time and the original request URL.

This change currently only applies to the fetch API, and should be
applied to the different callers of FETCCH as part of [this](whatwg/html#6542) and [this](whatwg/xhr#319) work.

Closes #1215
- [x ] At least two implementers are interested (and none opposed):
   * See discussion at #1215.

- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Currently WIP, see https://github.com/web-platform-tests/wpt/issues/30968
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=193902

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1311.html" title="Last updated on Dec 13, 2021, 12:17 PM UTC (78010e3)">Preview</a> | <a href="https://whatpr.org/fetch/1311/6257e22...78010e3.html" title="Last updated on Dec 13, 2021, 12:17 PM UTC (78010e3)">Diff</a>