### PR TITLE
Allow range header without preflight

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -825,6 +825,9 @@ fetch("https://victim.example/naïve-endpoint", {
 </code></pre>
     </div>
 
+   <dt>`<code>Range</code>`
+   <dd><p>If <var>value</var> is not a <a>simple range header value</a>, then return false.
+
    <dt>Otherwise
    <dd><p>Return false.
   </dl>
@@ -1037,6 +1040,75 @@ run these steps:
 
  <li><p>Return <var>values</var>.
 </ol>
+
+<p>To determine if a <a>byte sequence</a> <var>value</var> is a
+<dfn>simple range header value</dfn>, perform the following steps. They return a <a>boolean</a>.
+
+<ol>
+ <li><p>If <var>value</var> does not <a for="byte sequence" lt="starts with">start with</a>
+ `<code>bytes </code>`, then return false.
+
+ <li><p>If the 6th <a>byte</a> of <var>value</var> is not in the range 0x30 (0) to 0x39 (9),
+ inclusive, then return false.
+
+ <li><p>Let <var>rangeStartBytes</var> be the 6th <a>byte</a> of <var>value</var>.
+
+ <li><p>Let <var>rangeEndBytes</var> be an empty <a>byte sequence</a>.
+
+ <li><p>Let <var>state</var> be "<code>rangeStart</code>".
+
+ <li><p>Let <var>i</var> be 7.
+
+ <li>
+  <p>While <var>i</var> is less than <var>value</var>'s <a for="byte sequence">length</a>:
+
+  <ol>
+   <li>
+    <p>Switch on <var>state</var>:
+
+    <dl class="switch">
+     <dt>"<code>rangeStart</code>"
+     <dd>
+      <ol>
+       <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is 0x2D (-), then set
+       <var>state</var> to "<code>rangeEnd</code>".
+
+       <li>
+        <p>Otherwise:
+
+        <ol>
+         <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is not in the range 0x30 (0)
+         to 0x39 (9), inclusive, then return false.
+
+         <li><p>Append the <var>i</var>th <a>byte</a> of <var>value</var> to
+         <var>rangeStartBytes</var>.
+        </ol>
+      </ol>
+
+     <dt>"<code>rangeEnd</code>"
+     <dd>
+      <ol>
+       <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is not in the range 0x30 (0) to
+       0x39 (9), inclusive, then return false.
+
+       <li><p>Append the <var>i</var>th <a>byte</a> of <var>value</var> to <var>rangeEndBytes</var>.
+      </ol>
+    </dl>
+
+    <li><p>Increment <var>i</var>.
+  </ol>
+
+ <li>If <var>rangeEndBytes</var>'s <a for="byte sequence">length</a> is 0, then return true.
+
+ <li><p>If <var>rangeStartBytes</var>, parsed as an integer, is greater than
+ <var>rangeEndBytes</var>, parsed as an integer, then return false.
+
+ <li><p>Return true.
+</ol>
+
+<p class="note">A <a>simple range header value</a> is a subset of allowed range header values, but
+it's the most common form used by user agents when requesting media or resuming downloads. This
+format of range header value can be set using <a>add a range header</a>.
 
 <hr>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -825,7 +825,7 @@ fetch("https://victim.example/naïve-endpoint", {
 </code></pre>
     </div>
 
-   <dt>`<code>Range</code>`
+   <dt>`<code>range</code>`
    <dd><p>If <var>value</var> is not a <a>simple range header value</a>, then return false.
 
    <dt>Otherwise

--- a/fetch.bs
+++ b/fetch.bs
@@ -1047,7 +1047,8 @@ run these steps:
 <ol>
  <li><p>Let <var>data</var> be the <a>isomorphic decoding</a> of <var>value</var>.
 
- <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes </code>", then return false.
+ <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes=</code>", then return
+ false.
 
  <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially pointing at the 6th <a>code point</a> of <var>data</var>.
 
@@ -1886,7 +1887,7 @@ is to return the result of <a>serializing a request origin</a> with <var>request
  <li><p>Assert: <var>last</var> is not given, or <var>first</var> is less than or equal to
  <var>last</var>.
 
- <li><p>Let <var>rangeValue</var> be `<code>bytes </code>`.
+ <li><p>Let <var>rangeValue</var> be `<code>bytes=</code>`.
 
  <li><p><a lt="serialize an integer">Serialize</a> and <a>isomorphic encode</a> <var>first</var>,
  and append the result to <var>rangeValue</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1054,8 +1054,7 @@ run these steps:
  pointing at the 6th <a>code point</a> of <var>data</var>.
 
  <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that
- are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given
- <var>position</var>.
+ are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
  <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-),
  then return false.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1064,7 +1064,7 @@ run these steps:
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
- <li><p>If <var>position</var> is not past the end of <var>data</var>, return false.
+ <li><p>If <var>position</var> is not past the end of <var>data</var>, then return false.
 
  <li>
   <p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1098,7 +1098,9 @@ run these steps:
     <li><p>Increment <var>i</var>.
   </ol>
 
- <li>If <var>rangeEndBytes</var>'s <a for="byte sequence">length</a> is 0, then return true.
+ <li><p>If <var>state</var> is not "<code>rangeEnd</code>", then return false.
+
+ <li><p>If <var>rangeEndBytes</var>'s <a for="byte sequence">length</a> is 0, then return true.
 
  <li><p>If <var>rangeStartBytes</var>, parsed as an integer, is greater than
  <var>rangeEndBytes</var>, parsed as an integer, then return false.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1060,6 +1060,8 @@ run these steps:
 
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
 
+ <li><p>If <var>position</var> is not past the end of <var>data</var>, return false.
+
  <li>
   <p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1045,8 +1045,8 @@ run these steps:
 <dfn>simple range header value</dfn>, perform the following steps. They return a <a>boolean</a>.
 
 <ol>
- <li><p>If <var>value</var> does not <a for="byte sequence" lt="starts with">start with</a>
- `<code>bytes </code>`, then return false.
+ <li><p>If <var>value</var> does not <a for="byte sequence">start with</a> `<code>bytes </code>`,
+ then return false.
 
  <li><p>If the 6th <a>byte</a> of <var>value</var> is not in the range 0x30 (0) to 0x39 (9),
  inclusive, then return false.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1062,8 +1062,7 @@ run these steps:
  <li><p>Advance <var>position</var> by 1.
 
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
- are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given
- <var>position</var>.
+ are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
  <li><p>If <var>position</var> is not past the end of <var>data</var>, return false.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1059,7 +1059,10 @@ run these steps:
 
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
 
- <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.
+ <li>
+  <p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.
+
+  <p class="note">The range end can be omitted, e.g., `<code>bytes 0-</code>` is valid.
 
  <li><p>If <var>rangeStart</var>, parsed as an integer, is greater than <var>rangeEnd</var>, parsed
  as an integer, then return false.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1045,65 +1045,24 @@ run these steps:
 <dfn>simple range header value</dfn>, perform the following steps. They return a <a>boolean</a>.
 
 <ol>
- <li><p>If <var>value</var> does not <a for="byte sequence">start with</a> `<code>bytes </code>`,
- then return false.
+ <li><p>Let <var>data</var> be the <a>isomorphic decoding</a> of <var>value</var>.
 
- <li><p>If the 6th <a>byte</a> of <var>value</var> is not in the range 0x30 (0) to 0x39 (9),
- inclusive, then return false.
+ <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes </code>", then return false.
 
- <li><p>Let <var>rangeStartBytes</var> be the 6th <a>byte</a> of <var>value</var>.
+ <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially pointing at the 6th <a>code point</a> of <var>data</var>.
 
- <li><p>Let <var>rangeEndBytes</var> be an empty <a>byte sequence</a>.
+ <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
 
- <li><p>Let <var>state</var> be "<code>rangeStart</code>".
+ <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-), then return false.
 
- <li><p>Let <var>i</var> be 7.
+ <li><p>Advance <var>position</var> by 1.
 
- <li>
-  <p>While <var>i</var> is less than <var>value</var>'s <a for="byte sequence">length</a>:
+ <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
 
-  <ol>
-   <li>
-    <p>Switch on <var>state</var>:
+ <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.
 
-    <dl class="switch">
-     <dt>"<code>rangeStart</code>"
-     <dd>
-      <ol>
-       <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is 0x2D (-), then set
-       <var>state</var> to "<code>rangeEnd</code>".
-
-       <li>
-        <p>Otherwise:
-
-        <ol>
-         <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is not in the range 0x30 (0)
-         to 0x39 (9), inclusive, then return false.
-
-         <li><p>Append the <var>i</var>th <a>byte</a> of <var>value</var> to
-         <var>rangeStartBytes</var>.
-        </ol>
-      </ol>
-
-     <dt>"<code>rangeEnd</code>"
-     <dd>
-      <ol>
-       <li><p>If the <var>i</var>th <a>byte</a> of <var>value</var> is not in the range 0x30 (0) to
-       0x39 (9), inclusive, then return false.
-
-       <li><p>Append the <var>i</var>th <a>byte</a> of <var>value</var> to <var>rangeEndBytes</var>.
-      </ol>
-    </dl>
-
-    <li><p>Increment <var>i</var>.
-  </ol>
-
- <li><p>If <var>state</var> is not "<code>rangeEnd</code>", then return false.
-
- <li><p>If <var>rangeEndBytes</var>'s <a for="byte sequence">length</a> is 0, then return true.
-
- <li><p>If <var>rangeStartBytes</var>, parsed as an integer, is greater than
- <var>rangeEndBytes</var>, parsed as an integer, then return false.
+ <li><p>If <var>rangeStart</var>, parsed as an integer, is greater than <var>rangeEnd</var>, parsed
+ as an integer, then return false.
 
  <li><p>Return true.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -770,6 +770,9 @@ production as
 <ol>
  <li><p>Let <var>value</var> be <var>header</var>'s <a for=header>value</a>.
 
+ <li><p>If <var>value</var>'s <a for="byte sequence">length</a> is greater than 128, then return
+ false.
+
  <li>
   <p><a>Byte-lowercase</a> <var>header</var>'s <a for=header>name</a> and switch on the result:
 
@@ -825,9 +828,6 @@ fetch("https://victim.example/naïve-endpoint", {
    <dt>Otherwise
    <dd><p>Return false.
   </dl>
-
- <li><p>If <var>value</var>'s <a for="byte sequence">length</a> is greater than 128, then return
- false.
 
  <li><p>Return true.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1073,8 +1073,8 @@ run these steps:
 
   <p class="note">The range end can be omitted, e.g., `<code>bytes 0-</code>` is valid.
 
- <li><p>If <var>rangeStart</var>, parsed as an integer, is greater than <var>rangeEnd</var>, parsed
- as an integer, then return false.
+ <li><p>If <var>rangeStart</var>, interpreted as decimal number, is greater than
+ <var>rangeEnd</var>, interpreted as decimal number, then return false.
 
  <li><p>Return true.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1050,15 +1050,21 @@ run these steps:
  <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes=</code>", then return
  false.
 
- <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially pointing at the 6th <a>code point</a> of <var>data</var>.
+ <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
+ pointing at the 6th <a>code point</a> of <var>data</var>.
 
- <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
+ <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that
+ are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given
+ <var>position</var>.
 
- <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-), then return false.
+ <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-),
+ then return false.
 
  <li><p>Advance <var>position</var> by 1.
 
- <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given <var>position</var>.
+ <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
+ are in the range U+0030 (0) to U+0039 (9), inclusive, from <var>data</var> given
+ <var>position</var>.
 
  <li><p>If <var>position</var> is not past the end of <var>data</var>, return false.
 
@@ -1074,7 +1080,7 @@ run these steps:
 </ol>
 
 <p class="note">A <a>simple range header value</a> is a subset of allowed range header values, but
-it's the most common form used by user agents when requesting media or resuming downloads. This
+it is the most common form used by user agents when requesting media or resuming downloads. This
 format of range header value can be set using <a>add a range header</a>.
 
 <hr>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1847,6 +1847,9 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 <var>last</var>, run these steps:
 
 <ol>
+ <li><p>Assert: <var>last</var> is not given, or <var>first</var> is less than or equal to
+ <var>last</var>.
+
  <li><p>Let <var>rangeValue</var> be `<code>bytes </code>`.
 
  <li><p><a lt="serialize an integer">Serialize</a> and <a>isomorphic encode</a> <var>first</var>,


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Fixes #1310.

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Mozilla
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/31058
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1255711
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1733981
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=231174
- [x] Security review


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1312.html" title="Last updated on Oct 4, 2021, 4:11 PM UTC (ed0a9ca)">Preview</a> | <a href="https://whatpr.org/fetch/1312/b2f04e2...ed0a9ca.html" title="Last updated on Oct 4, 2021, 4:11 PM UTC (ed0a9ca)">Diff</a>