### PR TITLE
Acknowledge interaction with draft-ietf-dnsop-svcb-https scheme redirect

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2305,36 +2305,6 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 
 <h3 id=resolving-domains>Resolving domains</h3>
 
-<p tracking-vector>To <dfn>resolve a domain</dfn>, given a <a for=/>network partition key</a>
-<var>key</var> and a <a for=/>domain</a> <var>domain</var>:
-
-<ol>
- <li><p>If <var>domain</var> is a <a for=/>host</a> whose <a for=host>public suffix</a> is
- "<code>localhost</code>", then return « <code>::1</code>, <code>127.0.0.1</code> ».
-
- <li><p>Perform an <a>implementation-defined</a> operation to turn <var>domain</var> into a
- <a for=/>set</a> of one or more <a for=/>IP addresses</a>. If this operation succeeds, return the
- <a for=/>set</a> of <a for=/>IP addresses</a>.
-
- <li><p>Return failure.
-</ol>
-
-<p>The results of <a>resolve a domain</a> may be cached. If they are cached, <var>key</var> should
-be used as part of the cache key.
-
-<div class=note>
- <p>Typically this operation would involve DNS and as such caching can happen on DNS servers without
- <var>key</var> being taken into account. Depending on the implementation it might also not be
- possible to take <var>key</var> into account locally. [[RFC1035]]
-
- <p>The order of the <a for=/>IP addresses</a> <a>resolve a domain</a> can return return can differ
- between invocations.
-
- <p>The particulars (apart from the cache key) are not tied down as they are not pertinent to the
- system the Fetch Standard establishes. Other documents ought not to build on this primitive without
- having a considered discussion with the Fetch Standard community first.
-</div>
-
 <p>To <dfn>resolve an origin</dfn>, given a <a for=/>network partition key</a> <var>key</var> and an
 <a for=/>origin</a> <var>origin</var>:
 <!-- Should we assert the scheme here to be an HTTP(S) scheme or a WebRTC scheme? -->
@@ -2343,18 +2313,39 @@ be used as part of the cache key.
  <li><p>If <var>origin</var>'s <a for=origin>host</a> is an <a for=/>IP address</a>, then return
  « <var>origin</var>'s <a for=origin>host</a> ».
 
- <li><p>Return the result of running <a>resolve a domain</a> given <var>key</var> and
- <var>origin</var>'s <a for=origin>host</a>.
+ <li><p>If <var>origin</var>'s <a for=origin>host</a>'s <a for=host>public suffix</a> is
+ "<code>localhost</code>", then return « <code>::1</code>, <code>127.0.0.1</code> ».
+
+ <li>
+  <p>Perform an <a>implementation-defined</a> operation to turn <var>origin</var> into a
+  <a for=/>set</a> of one or more <a for=/>IP addresses</a>.
+
+  <p>It is also <a>implementation-defined</a> whether other operations might be performed to get
+  connection information beyond just <a for=/>IP addresses</a>. For example, if <var>origin</var>'s
+  <a for=origin>scheme</a> is "http" or "https", the implementation might perform a DNS query for
+  HTTPS RRs. [[SVCB]]
+
+  <p>If this operation succeeds, return the <a for=/>set</a> of <a for=/>IP addresses</a> and any
+  additional <a>implementation-defined</a> information.
+ </li>
+
+ <li><p>Return failure.
 </ol>
 
-<div class=note>
- <p>The same caveat applies. Do not build on this without having a considered discussion
- with the Fetch Standard community first.
+<p>The results of <a>resolve an origin</a> may be cached. If they are cached, <var>key</var> should
+be used as part of the cache key.
 
- <p>It is <a>implementation-defined</a> whether other DNS queries might be performed to get
- connection information beyond just <a for=/>IP addresses</a>. For example, if <var>origin</var>'s
- <a for=origin>scheme</a> is "http" or "https", the implementation might perform a DNS query for
- HTTPS RRs. [[SVCB]]
+<div class=note>
+ <p>Typically this operation would involve DNS and as such caching can happen on DNS servers without
+ <var>key</var> being taken into account. Depending on the implementation it might also not be
+ possible to take <var>key</var> into account locally. [[RFC1035]]
+
+ <p>The order of the <a for=/>IP addresses</a> <a>resolve an origin</a> can return return can differ
+ between invocations.
+
+ <p>The particulars (apart from the cache key) are not tied down as they are not pertinent to the
+ system the Fetch Standard establishes. Other documents ought not to build on this primitive without
+ having a considered discussion with the Fetch Standard community first.
 </div>
 
 
@@ -2494,7 +2485,7 @@ steps:
     return it. Any other returned values that are <a>connections</a> may be closed.
 
     <p class=note>Essentially this allows an implementation to pick one or more
-    <a for=/>IP addresses</a> from the return value of <a>resolve a domain</a> (assuming
+    <a for=/>IP addresses</a> from the return value of <a>resolve an origin</a> (assuming
     <var>proxy</var> is "<code>DIRECT</code>") and race them against each other, favor
     <a for=/>IPv6 addresses</a>, retry in case of a timeout, etc.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4000,7 +4000,7 @@ steps:
    <li>Matching <var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a> per
    <a href=https://datatracker.ietf.org/doc/html/rfc6797#section-8.2>Known HSTS Host Domain Name Matching</a>
    results in either a superdomain match with an asserted <code>includeSubDomains</code> directive
-   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive) or
+   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive); or
    DNS resolution for the request finds a matching HTTPS RR per
    <a href=https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https#section-8.5>HTTP Strict Transport Security</a>.
    [[!HSTS]][[!SVCB]]

--- a/fetch.bs
+++ b/fetch.bs
@@ -2305,8 +2305,9 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 
 <h3 id=resolving-domains>Resolving domains</h3>
 
-<p>To <dfn>resolve an origin</dfn>, given a <a for=/>network partition key</a> <var>key</var> and an
-<a for=/>origin</a> <var>origin</var>:
+<p tracking-vector>To
+<dfn export id=resolve-an-origin oldids=resolve-a-domain>resolve an origin</dfn>, given a
+<a for=/>network partition key</a> <var>key</var> and an <a for=/>origin</a> <var>origin</var>:
 <!-- Should we assert the scheme here to be an HTTP(S) scheme or a WebRTC scheme? -->
 
 <ol>
@@ -2322,8 +2323,8 @@ unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>termi
 
   <p>It is also <a>implementation-defined</a> whether other operations might be performed to get
   connection information beyond just <a for=/>IP addresses</a>. For example, if <var>origin</var>'s
-  <a for=origin>scheme</a> is "http" or "https", the implementation might perform a DNS query for
-  HTTPS RRs. [[SVCB]]
+  <a for=origin>scheme</a> is an <a>HTTP(S) scheme</a>, the implementation might perform a DNS query
+  for HTTPS RRs. [[SVCB]]
 
   <p>If this operation succeeds, return the <a for=/>set</a> of <a for=/>IP addresses</a> and any
   additional <a>implementation-defined</a> information.
@@ -3993,18 +3994,19 @@ steps:
    <li>Matching <var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a> per
    <a href=https://datatracker.ietf.org/doc/html/rfc6797#section-8.2>Known HSTS Host Domain Name Matching</a>
    results in either a superdomain match with an asserted <code>includeSubDomains</code> directive
-   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive); or
+   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive) [[!HSTS]]; or
    DNS resolution for the request finds a matching HTTPS RR per
-   <a href=https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https#section-8.5>HTTP Strict Transport Security</a>.
+   <a href=https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https#section-9.5>section 9.5</a>
+   of [[!SVCB]].
    [[!HSTS]][[!SVCB]]
   </ul>
   <!-- Per Mike West HSTS happens "probably after" Referrer -->
 
   <p class=note>As all DNS operations are generally <a>implementation-defined</a>, how it is
-  determined that DNS resolution contains an HTTPS RR is also <a>implementation-defined</a>.
-  As DNS operations are not traditionally performed until attempting to <a>obtain a connection</a>,
-  user agents might need to perform DNS operations earlier, consult local DNS caches, or wait until
-  later in the fetch process and potentially unwind logic on discovering the need to change
+  determined that DNS resolution contains an HTTPS RR is also <a>implementation-defined</a>. As DNS
+  operations are not traditionally performed until attempting to <a>obtain a connection</a>, user
+  agents might need to perform DNS operations earlier, consult local DNS caches, or wait until later
+  in the fetch algorithm and potentially unwind logic on discovering the need to change
   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a>.
 
  <li><p>If <var>recursive</var> is false, then run the remaining steps <a>in parallel</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2479,6 +2479,8 @@ steps:
    <li><p>If <var>proxy</var> is "<code>DIRECT</code>", then set <var>hosts</var> to the result of
    running <a>resolve an origin</a> given <var>key</var> and <var>url</var>'s <a for=url>origin</a>.
 
+   <li><p>If <var>hosts</var> is failure, then <a for=iteration>continue</a>.
+
    <li><p>Set <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> to
    the <a for=/>unsafe shared current time</a>.
 
@@ -4009,6 +4011,10 @@ steps:
 
   <p class=note>As all DNS operations are generally <a>implementation-defined</a>, how it is
   determined that DNS resolution contains an HTTPS RR is also <a>implementation-defined</a>.
+  As DNS operations are not traditionally performed until attempting to <a>obtain a connection</a>,
+  user agents might need to perform DNS operations earlier, consult local DNS caches, or wait until
+  later in the fetch process and potentially unwind logic on discovering the need to change
+  <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a>.
 
  <li><p>If <var>recursive</var> is false, then run the remaining steps <a>in parallel</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2350,7 +2350,7 @@ be used as part of the cache key.
 <div class=note>
  <p>The same caveat applies. Do not build on this without having a considered discussion
  with the Fetch Standard community first.
- 
+
  <p>It is <a>implementation-defined</a> whether other DNS queries might be performed to get
  connection information beyond just <a for=/>IP addresses</a>. For example, if <var>origin</var>'s
  <a for=origin>scheme</a> is "http" or "https", the implementation might perform a DNS query for

--- a/fetch.bs
+++ b/fetch.bs
@@ -2341,8 +2341,8 @@ be used as part of the cache key.
  <var>key</var> being taken into account. Depending on the implementation it might also not be
  possible to take <var>key</var> into account locally. [[RFC1035]]
 
- <p>The order of the <a for=/>IP addresses</a> <a>resolve an origin</a> can return return can differ
- between invocations.
+ <p>The order of the <a for=/>IP addresses</a> that the <a>resolve an origin</a> algorithm can return 
+can differ between invocations.
 
  <p>The particulars (apart from the cache key) are not tied down as they are not pertinent to the
  system the Fetch Standard establishes. Other documents ought not to build on this primitive without

--- a/fetch.bs
+++ b/fetch.bs
@@ -2341,8 +2341,8 @@ be used as part of the cache key.
  <var>key</var> being taken into account. Depending on the implementation it might also not be
  possible to take <var>key</var> into account locally. [[RFC1035]]
 
- <p>The order of the <a for=/>IP addresses</a> that the <a>resolve an origin</a> algorithm can return 
-can differ between invocations.
+ <p>The order of the <a for=/>IP addresses</a> that the <a>resolve an origin</a> algorithm can return
+ can differ between invocations.
 
  <p>The particulars (apart from the cache key) are not tied down as they are not pertinent to the
  system the Fetch Standard establishes. Other documents ought not to build on this primitive without

--- a/fetch.bs
+++ b/fetch.bs
@@ -116,6 +116,12 @@ spec:websockets; type:attribute; text:bufferedAmount; for:WebSocket
         "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram",
         "publisher": "IETF",
         "title": "Using QUIC Datagrams with HTTP/3"
+    },
+    "SVCB": {
+        "authors": ["Ben Schwartz", "Mike Bishop", "Erik Nygren"],
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https",
+        "publisher": "IETF",
+        "title": "Service binding and parameter specification via the DNS (DNS SVCB and HTTPS RRs)"
     }
 }
 </pre>
@@ -2341,8 +2347,15 @@ be used as part of the cache key.
  <var>origin</var>'s <a for=origin>host</a>.
 </ol>
 
-<p class=note>The same caveat applies. Do not build on this without having a considered discussion
-with the Fetch Standard community first.
+<div class=note>
+ <p>The same caveat applies. Do not build on this without having a considered discussion
+ with the Fetch Standard community first.
+ 
+ <p>It is <a>implementation-defined</a> whether other DNS queries might be performed to get
+ connection information beyond just <a for=/>IP addresses</a>. For example, if <var>origin</var>'s
+ <a for=origin>scheme</a> is "http" or "https", the implementation might perform a DNS query for
+ HTTPS RRs. [[SVCB]]
+</div>
 
 
 <h3 id=connections>Connections</h3>
@@ -2465,8 +2478,6 @@ steps:
 
    <li><p>If <var>proxy</var> is "<code>DIRECT</code>", then set <var>hosts</var> to the result of
    running <a>resolve an origin</a> given <var>key</var> and <var>url</var>'s <a for=url>origin</a>.
-
-   <li><p>If <var>hosts</var> is failure, then <a for=iteration>continue</a>.
 
    <li><p>Set <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> to
    the <a for=/>unsafe shared current time</a>.
@@ -3989,10 +4000,15 @@ steps:
    <li>Matching <var>request</var>'s <a for=request>current URL</a>'s <a for=url>host</a> per
    <a href=https://datatracker.ietf.org/doc/html/rfc6797#section-8.2>Known HSTS Host Domain Name Matching</a>
    results in either a superdomain match with an asserted <code>includeSubDomains</code> directive
-   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive).
-   [[!HSTS]]
+   or a congruent match (with or without an asserted <code>includeSubDomains</code> directive) or
+   DNS resolution for the request finds a matching HTTPS RR per
+   <a href=https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https#section-8.5>HTTP Strict Transport Security</a>.
+   [[!HSTS]][[!SVCB]]
   </ul>
   <!-- Per Mike West HSTS happens "probably after" Referrer -->
+
+  <p class=note>As all DNS operations are generally <a>implementation-defined</a>, how it is
+  determined that DNS resolution contains an HTTPS RR is also <a>implementation-defined</a>.
 
  <li><p>If <var>recursive</var> is false, then run the remaining steps <a>in parallel</a>.
 
@@ -8166,6 +8182,7 @@ Eero Häkkinen,
 Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,
+Eric Orth,
 François Marier,
 Frank Ellerman,
 Frederick Hirsch,


### PR DESCRIPTION
Closes #1315

Adding some vague mostly-implementation-defined language to acknowledge that scheme upgrade can occur, similarly to HSTS, on discovery of a DNS HTTPS RR.  Also added a (similarly vague and implementation-defined) note that origin resolution might query DNS for HTTPS and return more than addresses.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1325.html" title="Last updated on Oct 11, 2021, 6:12 PM UTC (38a35c3)">Preview</a> | <a href="https://whatpr.org/fetch/1325/6f37b51...38a35c3.html" title="Last updated on Oct 11, 2021, 6:12 PM UTC (38a35c3)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1325.html" title="Last updated on Apr 7, 2022, 6:23 PM UTC (9e2c56d)">Preview</a> | <a href="https://whatpr.org/fetch/1325/8ebf2fd...9e2c56d.html" title="Last updated on Apr 7, 2022, 6:23 PM UTC (9e2c56d)">Diff</a>