### PR TITLE
Return a "controller" instance from fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2134,7 +2134,7 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <var>fetchParams</var>:
 
 <ol>
- <li><p>Assert: <var>fetchParams</var> is  <a for="fetch params">canceled</a>.</li>
+ <li><p>Assert: <var>fetchParams</var> is <a for="fetch params">canceled</a>.</li>
 
  <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var> is
  <a for="fetch params">aborted</a>; otherwise return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4523,7 +4523,7 @@ these steps:
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>, with <var>fetchParams</var>'s
    <a for="fetch params">controller</a> and <var>fetchParams</var>'s
-   <a for="fetch params">cross-origin isolated capability</a> and . [[!HTML]] [[!SW]]
+   <a for="fetch params">cross-origin isolated capability</a>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -210,9 +210,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">terminated flag</dfn>
- <dt><dfn for="fetch params">aborted flag</dfn>
- <dd>A flag, initially unset.
+ <dt><dfn for="fetch params">fetch state</dfn>
+ <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>".
 
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
@@ -264,6 +263,15 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
  <var>storedTimingInfo</var>'s <a for="fetch timing info">decoded body size</a>.
 </ol>
 
+<p>To <dfn for="fetch params">abort</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
+set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>aborted</code>".
+
+<p>To <dfn for="fetch params">terminate</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
+set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>terminated</code>".
+
+<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <a for="fetch params">terminated</a> if
+its <a for="fetch params">fetch state</a> is "<code>aborted</code>" or "<code>terminated</code>".
+
 <p>A <dfn export>fetch controller</dfn> is an object used to enable clients of an ongoing fetch
 to perform certain actions in the context of that fetch instance.
 
@@ -271,11 +279,12 @@ to perform certain actions in the context of that fetch instance.
 <dfn for="fetch controller">ongoing fetch params</dfn>.</p>
 
 <p>To <dfn for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
-<var>controller</var> given a flag <var>aborted</var>, which is unset unless otherwise specified,
-set <var>controller</var>'s <a for="fetch controller">ongoing fetch params</a>
-<a for="fetch params">terminated flag</a>, and set <var>controller</var>'s
-<a for="fetch controller">ongoing fetch params</a> <a for="fetch params">aborted flag</a> if
-<var>aborted</var> is set.
+<var>controller</var>, <a for="fetch params">terminate</a> <var>controller</var>'s
+<a for="fetch controller">ongoing fetch params</a>.
+
+<p>To <dfn for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
+<var>controller</var>, <a for="fetch params">abort</a> <var>controller</var>'s
+<a for="fetch controller">ongoing fetch params</a>.
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2123,7 +2132,8 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 
 <p>To create the <dfn>appropriate network error</dfn> given <a for=/>fetch params</a>
 <var>fetchParams</var>, return an <a>aborted network error</a> if <var>fetchParams</var>'s
-<a for="fetch params">aborted flag</a> is set, otherwise return a <a>network error</a>.
+<a for="fetch params">fetch state</a> is "<code>aborted</code>"; otherwise return a
+<a>network error</a>.
 
 <hr>
 
@@ -2307,14 +2317,14 @@ functionality.
 
 <p>A <a for="fetch group">fetch record</a> has an associated
 <dfn export for="fetch record" id=concept-fetch-record-fetch>fetch</dfn> (a
-<a for=/>fetch</a> algorithm or null).
+<a for=/>fetch controller</a> or null).
 
 <hr>
 
 <p>When a <a for=fetch>fetch group</a> is
 <dfn export for="fetch group" id=concept-fetch-group-terminate>terminated</dfn>, for each associated
 <a for="fetch group">fetch record</a> whose <a for="fetch record">request</a>'s <a>done flag</a> is
-unset or <a for=request>keepalive</a> is false, <a lt=terminated for=fetch>terminate</a> the
+unset or <a for=request>keepalive</a> is false, <a for="fetch controller">terminate</a>
 <a for="fetch group">fetch record</a>'s <a for="fetch record">fetch</a>.
 
 
@@ -3839,7 +3849,13 @@ the request.
  <p>If this instance of <a for=/>fetch</a> is
  <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> given flag <var>aborted</var>,
  which is unset unless otherwise specified, <a for="fetch controller">terminate</a>
- <var>controller</var> with <var>aborted</var>.
+ <var>controller</var> if <var>aborted</var> is set, otherwise <a for="fetch controller">abort</a>
+ <var>controller</var>.
+
+ <p class="note">The above exported function is to be replaced by
+ <a for="fetch controller" lt=terminate>terminating</a> or
+ <a for="fetch controller" lt=abort>aborting</a> the <a for=/>fetch controller</a>
+ returned by this algorithm.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
@@ -3915,7 +3931,7 @@ the request.
 
   <ol>
    <li><p>Let <var>record</var> be a new <a for="fetch group">fetch record</a> consisting of
-   <var>request</var> and this instance of the <a for=/>fetch</a> algorithm.
+   <var>request</var> and <var>controller</var>.
 
    <li><p>Append <var>record</var> to <var>request</var>'s <a for=request>client</a>'s
    <a for=fetch>fetch group</a> list of <a for="fetch group">fetch records</a>.
@@ -4381,7 +4397,8 @@ steps:
  <dd>
   <ol>
    <li>
-    <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
+    <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
+    <a for="fetch params">terminated</a>:
 
     <ol>
      <li><p>Let <var>blob</var> be <var>request</var>'s <a for=request>current URL</a>'s
@@ -4480,10 +4497,11 @@ these steps:
       <p>Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
 
       <ol>
-       <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+       <li><p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is not
+       "<code>ongoing</code>", then abort these steps.
 
        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
-       <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+       <a for="fetch params">terminate</a> <var>fetchParams</var>.
 
        <li><p>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may
        split the chunk into <a>implementation-defined</a> practical sizes and
@@ -4812,7 +4830,8 @@ steps. They return a <a for=/>response</a>.
  <li><p>Let the <var>revalidatingFlag</var> be unset.
 
  <li>
-  <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
+  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
+  <a for="fetch params">terminated</a>:
 
   <ol>
    <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>no-window</code>" and
@@ -5244,8 +5263,8 @@ steps. They return a <a for=/>response</a>.
     <var>isAuthenticationFetch</var> is true, then:
 
     <ol>
-     <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
-     return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
+     <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then return the
+     <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
      <li><p>Let <var>username</var> and <var>password</var> be the result of prompting the end user
      for a username and password, respectively, in <var>request</var>'s
@@ -5272,7 +5291,7 @@ steps. They return a <a for=/>response</a>.
    <li class=XXX><p>Needs testing: multiple `<code>Proxy-Authenticate</code>` headers, missing,
    parsing issues.
 
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then
    return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li>
@@ -5302,7 +5321,7 @@ steps. They return a <a for=/>response</a>.
   <p>then:
 
   <ol>
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then
    return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li><p>Set <var>response</var> to the result of running <a>HTTP-network-or-cache fetch</a> given
@@ -5360,8 +5379,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   </dl>
 
  <li>
-  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
-  <a for="fetch params">terminated flag</a> is set:
+  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
+  <a for="fetch params">terminated</a>:
 
   <ol>
    <li><p>If <var>connection</var> is failure, then return a <a>network error</a>.
@@ -5463,8 +5482,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyChunk</var> given <var>bytes</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
-         abort these steps.
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         steps.
 
          <li><p>Run this step <a>in parallel</a>: transmit <var>bytes</var>.
 
@@ -5478,8 +5497,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processEndOfBody</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
-         abort these steps.
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         steps.
 
          <li><p>If <var>fetchParams</var>'s <a for="fetch params">process request end-of-body</a> is
          non-null, then run <var>fetchParams</var>'s
@@ -5490,13 +5509,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyError</var> given <var>e</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
-         abort these steps.
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         steps.
 
          <li><p>If <var>e</var> is an "<code><a exception>AbortError</a></code>" {{DOMException}},
-         then <a lt=terminated for=fetch>terminate</a> the ongoing fetch with the aborted flag set.
+         then <a for="fetch params">abort</a> <var>fetchParams</var>.
 
-         <li><p>Otherwise, <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+         <li><p>Otherwise, <a for="fetch params">terminate</a> <var>fetchParams</var>.
         </ol>
 
        <li><p><a for=body>Incrementally read</a> <var>request</var>'s <a for=request>body</a> given
@@ -5513,21 +5532,15 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
-   <a for="fetch params">aborted flag</a>.
-
    <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
-   <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-   <li><p>Return a <a>network error</a>.
+   <li><p>Return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.
   </ol>
 
  <li><p>Let <var>pullAlgorithm</var> be an action that <a lt=resumed for=fetch>resumes</a> the
  ongoing fetch if it is <a lt=suspend for=fetch>suspended</a>.
 
- <li><p>Let <var>cancelAlgorithm</var> be an action that <a lt=terminated for=fetch>terminates</a>
- the ongoing fetch with the aborted flag set.
+ <li><p>Let <var>cancelAlgorithm</var> be to <a for="fetch params">abort</a> <var>fetchParams</var>.
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
@@ -5543,8 +5556,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <a for="ReadableStream/set up"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.
 
  <li>
-  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
-  <a for="fetch params">terminated flag</a> is set:
+  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
+  <a for="fetch params">terminated</a>:
 
   <ol>
    <li><p>Set <var>response</var>'s <a for=response>body</a> to a new
@@ -5573,10 +5586,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
-   <a for="fetch params">aborted flag</a>.
+   <li><p>Let <var>state</var> be <var>fetchParams</var>'s
+   <a for="fetch params">fetch state</a>.
 
-   <li><p>If <var>aborted</var> is set, then set <var>response</var>'s
+   <li><p>If <var>state</var> is "<code>aborted</code>", then set <var>response</var>'s
    <a for=response>aborted flag</a>.
 
    <li><p>Return <var>response</var>.
@@ -5587,8 +5600,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
   <ol>
    <li>
-    <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
-    <a for="fetch params">terminated flag</a> is set:
+    <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
+    <a for="fetch params">terminated</a>:
 
     <ol>
      <li>
@@ -5617,14 +5630,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> by
          <var>bytes</var>'s <a for="byte sequence">length</a>.
 
-         <li><p>If <var>bytes</var> is failure, then <a lt=terminated for=fetch>terminate</a> the
-         ongoing fetch.
+         <li><p>If <var>bytes</var> is failure, then <a for="fetch params">terminate</a>
+         <var>fetchParams</var>.
 
          <li><p><a for=ReadableStream>Enqueue</a> a {{Uint8Array}} wrapping an {{ArrayBuffer}}
          containing <var>bytes</var> into <var>stream</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
-         <a lt=terminated for=fetch>terminate</a> the ongoing fetch.
+         <a for="fetch params">terminate</a> <var>fetchParams</var>.
 
          <li><p>If <var>stream</var> doesn't <a for=ReadableStream>need more data</a> ask the user
          agent to <a for=fetch>suspend</a> the ongoing fetch.
@@ -5641,11 +5654,11 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ol>
 
-     <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
-     <a for="fetch params">aborted flag</a>.
+     <li><p>Let <var>state</var> be <var>fetchParams</var>'s
+     <a for="fetch params">fetch state</a>.
 
      <li>
-      <p>If <var>aborted</var> is set, then:
+      <p>If <var>state</var> is "<code>aborted</code>", then:
 
       <ol>
        <li><p>Set <var>response</var>'s <a for=response>aborted flag</a>.
@@ -7571,6 +7584,8 @@ method steps are:
   <p class=note>This lets us reject promises with predictable timing, when the request to abort
   comes from the same thread as the call to fetch.
 
+ <li><p>Let <var>controller</var> be null.
+
  <li>
   <p><a for=AbortSignal lt=add>Add the following abort steps</a> to <var>requestObject</var>'s
   <a for=Request>signal</a>:
@@ -7580,7 +7595,8 @@ method steps are:
 
    <li><p><a>Abort fetch</a> with <var>p</var>, <var>request</var>, and <var>responseObject</var>.
 
-   <li><p><a lt=terminated for=fetch>Terminate</a> the ongoing fetch with the aborted flag set.
+   <li><p>If <var>controller</var> is not null, then <a for="fetch controller">abort</a>
+   <var>controller</var>.
   </ol>
 
  <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
@@ -7588,7 +7604,8 @@ method steps are:
  "<code>fetch</code>".
 
  <li>
-  <p><a for=/>Fetch</a> <var>request</var> with <a for=fetch><i>processResponseEndOfBody</i></a> set to
+  <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given
+  <var>request</var>, with <a for=fetch><i>processResponseEndOfBody</i></a> set to
   <var>handleFetchDone</var>, and <a for=fetch><i>processResponse</i></a> given <var>response</var>
   being these substeps:
 
@@ -7638,7 +7655,7 @@ method steps are:
 
 <h3 id=garbage-collection>Garbage collection</h3>
 
-<p>The user agent may <a lt=terminated for=fetch>terminate</a> an ongoing fetch if that termination
+<p>The user agent may <a for="fetch controller">terminate</a> an ongoing fetch if that termination
 is not observable through script.
 
 <p class="note no-backref">"Observable through script" means observable through

--- a/fetch.bs
+++ b/fetch.bs
@@ -269,7 +269,7 @@ set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>abo
 <p>To <dfn for="fetch params">terminate</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
 set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>terminated</code>".
 
-<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <a for="fetch params">canceled</a> if
+<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">canceled</dfn> if
 its <a for="fetch params">fetch state</a> is "<code>aborted</code>" or "<code>terminated</code>".
 
 <p>A <dfn export>fetch controller</dfn> is an object used to enable clients of an ongoing fetch
@@ -8072,6 +8072,11 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  <dd><p>Takes a <a for=/>boolean</a> that defaults to false. Indicates where the algorithms passed
  as arguments will be invoked. Hopefully most standards will not need this.
 </dl>
+
+<p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>.
+The controller is used for performing actions on a fetch operation that has already started,
+such as <a for="fetch controller" lt=abort>aborting</a> the operation by the user or page logic, or
+<a for="fetch controller" lt=abort>terminating</a> it due to a browser-internal circumstance.
 
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2324,7 +2324,7 @@ functionality.
 <p>When a <a for=fetch>fetch group</a> is
 <dfn export for="fetch group" id=concept-fetch-group-terminate>terminated</dfn>, for each associated
 <a for="fetch group">fetch record</a> whose <a for="fetch record">request</a>'s <a>done flag</a> is
-unset or <a for=request>keepalive</a> is false, <a for="fetch controller">terminate</a>
+unset or <a for=request>keepalive</a> is false, <a for="fetch controller">terminate</a> the
 <a for="fetch group">fetch record</a>'s <a for="fetch record">fetch</a>.
 
 
@@ -4486,8 +4486,8 @@ these steps:
       <p>Let <var>transformAlgorithm</var> given <var>chunk</var> be these steps:
 
       <ol>
-       <li><p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is not
-       "<code>ongoing</code>", then abort these steps.
+       <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then abort these
+       steps.
 
        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
        <a for="fetch params">terminate</a> <var>fetchParams</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4522,8 +4522,8 @@ these steps:
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
    <var>requestForServiceWorker</var>, with <var>fetchParams</var>'s
-   <a for="fetch params">cross-origin isolated capability</a> and <var>fetchParams</var>'s
-   <a for="fetch params">controller</a>. [[!HTML]] [[!SW]]
+   <a for="fetch params">controller</a> and <var>fetchParams</var>'s
+   <a for="fetch params">cross-origin isolated capability</a> and . [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -278,7 +278,7 @@ to perform certain actions in the context of that fetch instance.
 <p>A <a for=/>fetch controller</a> has an associated <a for=/>fetch params</a>
 <dfn for="fetch controller">ongoing fetch params</dfn>.</p>
 
-<p>To <dfn id="concept-fetch-terminate" for="fetch controller">terminate</dfn> a
+<p>To <dfn export id="concept-fetch-terminate" for="fetch controller">terminate</dfn> a
 <a for=/>fetch controller</a> <var>controller</var>, <a for="fetch params">terminate</a>
 <var>controller</var>'s <a for="fetch controller">ongoing fetch params</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -8088,7 +8088,7 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
 <p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>.
 The controller is used for performing actions on a fetch operation that has already started,
 such as <a for="fetch controller" lt=abort>aborting</a> the operation by the user or page logic, or
-<a for="fetch controller" lt=abort>terminating</a> it due to a browser-internal circumstance.
+<a for="fetch controller" lt=terminate>terminating</a> it due to a browser-internal circumstance.
 
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>

--- a/fetch.bs
+++ b/fetch.bs
@@ -210,12 +210,35 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">fetch state</dfn> (default "<code>ongoing</code>")
- <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>".
+ <dt><dfn for="fetch params">controller</dfn> (default a new <a for=/>fetch controller</a>)
+ <dd>A <a for=/>fetch controller</a>.
 
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
 </dl>
+
+<p>A <dfn export>fetch controller</dfn> is a <a for=/>struct</a> used to enable callers of
+<a for=/>fetch</a> to perform certain operations on it after it has started. It has the following
+<a for=struct>items</a>:
+
+<dl>
+ <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
+ <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
+</dl>
+
+<p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a> <var>controller</var>,
+set <var>controller</var>'s <a for="fetch controller">state</a> to "<code>aborted</code>".
+
+<p>To <dfn export for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a> <var>controller</var>,
+set <var>controller</var>'s <a for="fetch controller">state</a> to "<code>terminated</code>".
+
+<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">aborted</dfn> if
+its <a for="fetch params">controller</a>'s <a for="fetch controller">state</a> is
+"<code>aborted</code>".
+
+<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">canceled</dfn> if
+its <a for="fetch params">controller</a>'s <a for="fetch controller">state</a> is
+"<code>aborted</code>" or "<code>terminated</code>".
 
 <p>A <dfn export>fetch timing info</dfn> is a <a for=/>struct</a> used to maintain timing
 information needed by <cite>Resource Timing</cite> and <cite>Navigation Timing</cite>. It has the
@@ -262,29 +285,6 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> to
  <var>storedTimingInfo</var>'s <a for="fetch timing info">decoded body size</a>.
 </ol>
-
-<p>To <dfn for="fetch params">abort</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
-set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>aborted</code>".
-
-<p>To <dfn for="fetch params">terminate</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
-set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>terminated</code>".
-
-<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">canceled</dfn> if
-its <a for="fetch params">fetch state</a> is "<code>aborted</code>" or "<code>terminated</code>".
-
-<p>A <dfn export>fetch controller</dfn> is a <a for=/>struct</a> used to enable clients of an
-ongoing fetch to perform certain actions in the context of that fetch instance.
-
-<p>A <a for=/>fetch controller</a> has an associated <a for=/>fetch params</a>
-<dfn for="fetch controller">internal fetch params</dfn>.</p>
-
-<p>To <dfn export id="concept-fetch-terminate" for="fetch controller">terminate</dfn> a
-<a for=/>fetch controller</a> <var>controller</var>, <a for="fetch params">terminate</a>
-<var>controller</var>'s <a for="fetch controller">internal fetch params</a>.
-
-<p>To <dfn for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
-<var>controller</var>, <a for="fetch params">abort</a> <var>controller</var>'s
-<a for="fetch controller">internal fetch params</a>.
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2136,9 +2136,8 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <ol>
  <li><p>Assert: <var>fetchParams</var> is  <a for="fetch params">canceled</a>.</li>
 
- <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var>'s
- <a for="fetch params">fetch state</a> is "<code>aborted</code>"; otherwise return a
- <a>network error</a>.
+ <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var> is
+ <a for="fetch params">aborted</a>; otherwise return a <a>network error</a>.
 </ol>
 
 <hr>
@@ -3851,9 +3850,6 @@ the request.
  <a for="fetch params">cross-origin isolated capability</a> is
  <var>crossOriginIsolatedCapability</var>.
 
- <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> with its
- <a for="fetch controller">internal fetch params</a> set to <var>fetchParams</var>.</p></li>
-
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
  <a for=BodyInit>safely extracting</a> <var>request</var>'s <a for=request>body</a>.
@@ -3929,7 +3925,8 @@ the request.
   <ol>
    <li><p>Let <var>record</var> be a new <a for="fetch group">fetch record</a> whose
    <a for="fetch record">request</a> is <var>request</var> and
-   <a for="fetch record">controller</a> is <var>controller</var>.
+   <a for="fetch record">controller</a> is <var>fetchParams</var>'s
+   <a for="fetch params">controller</a>.
 
    <li><p>Append <var>record</var> to <var>request</var>'s <a for=request>client</a>'s
    <a for=fetch>fetch group</a> list of <a for="fetch group">fetch records</a>.
@@ -3937,7 +3934,7 @@ the request.
 
  <li><p>Run <a>main fetch</a> given <var>fetchParams</var>.
 
- <li><p>Return <var>controller</var>.
+ <li><p>Return <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 </ol>
 
 
@@ -4499,7 +4496,8 @@ these steps:
        steps.
 
        <li><p>If <var>chunk</var> is not a {{Uint8Array}} object, then
-       <a for="fetch params">terminate</a> <var>fetchParams</var>.
+       <a for="fetch controller">terminate</a> <var>fetchParams</var>'s
+       <a for="fetch params">controller</a>.
 
        <li><p>Otherwise, <a for=ReadableStream>enqueue</a> <var>chunk</var>. The user agent may
        split the chunk into <a>implementation-defined</a> practical sizes and
@@ -5511,9 +5509,11 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          steps.
 
          <li><p>If <var>e</var> is an "<code><a exception>AbortError</a></code>" {{DOMException}},
-         then <a for="fetch params">abort</a> <var>fetchParams</var>.
+         then <a for="fetch controller">abort</a> <var>fetchParams</var>'s
+         <a for="fetch params">controller</a>.
 
-         <li><p>Otherwise, <a for="fetch params">terminate</a> <var>fetchParams</var>.
+         <li><p>Otherwise, <a for="fetch controller">terminate</a> <var>fetchParams</var>'s
+         <a for="fetch params">controller</a>.
         </ol>
 
        <li><p><a for=body>Incrementally read</a> <var>request</var>'s <a for=request>body</a> given
@@ -5539,7 +5539,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  ongoing fetch if it is <a lt=suspend for=fetch>suspended</a>.
 
  <li><p>Let <var>cancelAlgorithm</var> be an algorithm that
- <a for="fetch params">abort</a>s <var>fetchParams</var>.
+ <a for="fetch controller">abort</a>s <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
@@ -5585,8 +5585,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is
-   "<code>aborted</code>", then set <var>response</var>'s <a for=response>aborted flag</a>.
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">aborted</a>, then set
+   <var>response</var>'s <a for=response>aborted flag</a>.
 
    <li><p>Return <var>response</var>.
   </ol>
@@ -5626,14 +5626,15 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> by
          <var>bytes</var>'s <a for="byte sequence">length</a>.
 
-         <li><p>If <var>bytes</var> is failure, then <a for="fetch params">terminate</a>
-         <var>fetchParams</var>.
+         <li><p>If <var>bytes</var> is failure, then <a for="fetch controller">terminate</a>
+         <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 
          <li><p><a for=ReadableStream>Enqueue</a> a {{Uint8Array}} wrapping an {{ArrayBuffer}}
          containing <var>bytes</var> into <var>stream</var>.
 
          <li><p>If <var>stream</var> is <a for=ReadableStream>errored</a>, then
-         <a for="fetch params">terminate</a> <var>fetchParams</var>.
+         <a for="fetch controller">terminate</a> <var>fetchParams</var>.'s
+         <a for="fetch params">controller</a>.
 
          <li><p>If <var>stream</var> doesn't <a for=ReadableStream>need more data</a> ask the user
          agent to <a for=fetch>suspend</a> the ongoing fetch.
@@ -5651,8 +5652,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <ol>
 
      <li>
-      <p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is
-      "<code>aborted</code>", then:
+      <p>If <var>fetchParams</var> is <a for="fetch params">aborted</a>, then:
 
       <ol>
        <li><p>Set <var>response</var>'s <a for=response>aborted flag</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -269,7 +269,7 @@ set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>abo
 <p>To <dfn for="fetch params">terminate</dfn> a <a for=/>fetch params</a> <var>fetchParams</var>,
 set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>terminated</code>".
 
-<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <a for="fetch params">terminated</a> if
+<p>A <a for=/>fetch params</a> <var>fetchParams</var> is <a for="fetch params">canceled</a> if
 its <a for="fetch params">fetch state</a> is "<code>aborted</code>" or "<code>terminated</code>".
 
 <p>A <dfn export>fetch controller</dfn> is an object used to enable clients of an ongoing fetch
@@ -278,9 +278,9 @@ to perform certain actions in the context of that fetch instance.
 <p>A <a for=/>fetch controller</a> has an associated <a for=/>fetch params</a>
 <dfn for="fetch controller">ongoing fetch params</dfn>.</p>
 
-<p>To <dfn for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
-<var>controller</var>, <a for="fetch params">terminate</a> <var>controller</var>'s
-<a for="fetch controller">ongoing fetch params</a>.
+<p>To <dfn id="concept-fetch-terminate" for="fetch controller">terminate</dfn> a
+<a for=/>fetch controller</a> <var>controller</var>, <a for="fetch params">terminate</a>
+<var>controller</var>'s <a for="fetch controller">ongoing fetch params</a>.
 
 <p>To <dfn for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
 <var>controller</var>, <a for="fetch params">abort</a> <var>controller</var>'s
@@ -3846,17 +3846,6 @@ the request.
  <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> with its
  <a for="fetch controller">ongoing fetch params</a> set to <var>fetchParams</var>.</p></li>
 
- <p>If this instance of <a for=/>fetch</a> is
- <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> given flag <var>aborted</var>,
- which is unset unless otherwise specified, <a for="fetch controller">terminate</a>
- <var>controller</var> if <var>aborted</var> is set, otherwise <a for="fetch controller">abort</a>
- <var>controller</var>.
-
- <p class="note">The above exported function is to be replaced by
- <a for="fetch controller" lt=terminate>terminating</a> or
- <a for="fetch controller" lt=abort>aborting</a> the <a for=/>fetch controller</a>
- returned by this algorithm.
-
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
  <a for=BodyInit>safely extracting</a> <var>request</var>'s <a for=request>body</a>.
@@ -4398,7 +4387,7 @@ steps:
   <ol>
    <li>
     <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-    <a for="fetch params">terminated</a>:
+    <a for="fetch params">canceled</a>:
 
     <ol>
      <li><p>Let <var>blob</var> be <var>request</var>'s <a for=request>current URL</a>'s
@@ -4831,7 +4820,7 @@ steps. They return a <a for=/>response</a>.
 
  <li>
   <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-  <a for="fetch params">terminated</a>:
+  <a for="fetch params">canceled</a>:
 
   <ol>
    <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>no-window</code>" and
@@ -5263,7 +5252,7 @@ steps. They return a <a for=/>response</a>.
     <var>isAuthenticationFetch</var> is true, then:
 
     <ol>
-     <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then return the
+     <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then return the
      <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
      <li><p>Let <var>username</var> and <var>password</var> be the result of prompting the end user
@@ -5291,7 +5280,7 @@ steps. They return a <a for=/>response</a>.
    <li class=XXX><p>Needs testing: multiple `<code>Proxy-Authenticate</code>` headers, missing,
    parsing issues.
 
-   <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then
    return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li>
@@ -5321,7 +5310,7 @@ steps. They return a <a for=/>response</a>.
   <p>then:
 
   <ol>
-   <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then
    return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li><p>Set <var>response</var> to the result of running <a>HTTP-network-or-cache fetch</a> given
@@ -5380,7 +5369,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li>
   <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-  <a for="fetch params">terminated</a>:
+  <a for="fetch params">canceled</a>:
 
   <ol>
    <li><p>If <var>connection</var> is failure, then return a <a>network error</a>.
@@ -5482,7 +5471,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyChunk</var> given <var>bytes</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then abort these
          steps.
 
          <li><p>Run this step <a>in parallel</a>: transmit <var>bytes</var>.
@@ -5497,7 +5486,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processEndOfBody</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then abort these
          steps.
 
          <li><p>If <var>fetchParams</var>'s <a for="fetch params">process request end-of-body</a> is
@@ -5509,7 +5498,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyError</var> given <var>e</var> be these steps:
 
         <ol>
-         <li><p>If <var>fetchParams</var> is <a for="fetch params">terminated</a>, then abort these
+         <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then abort these
          steps.
 
          <li><p>If <var>e</var> is an "<code><a exception>AbortError</a></code>" {{DOMException}},
@@ -5557,7 +5546,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li>
   <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-  <a for="fetch params">terminated</a>:
+  <a for="fetch params">canceled</a>:
 
   <ol>
    <li><p>Set <var>response</var>'s <a for=response>body</a> to a new
@@ -5586,11 +5575,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>state</var> be <var>fetchParams</var>'s
-   <a for="fetch params">fetch state</a>.
-
-   <li><p>If <var>state</var> is "<code>aborted</code>", then set <var>response</var>'s
-   <a for=response>aborted flag</a>.
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is
+   "<code>aborted</code>", then set <var>response</var>'s <a for=response>aborted flag</a>.
 
    <li><p>Return <var>response</var>.
   </ol>
@@ -5601,7 +5587,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <ol>
    <li>
     <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-    <a for="fetch params">terminated</a>:
+    <a for="fetch params">canceled</a>:
 
     <ol>
      <li>
@@ -5654,11 +5640,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ol>
 
-     <li><p>Let <var>state</var> be <var>fetchParams</var>'s
-     <a for="fetch params">fetch state</a>.
-
      <li>
-      <p>If <var>state</var> is "<code>aborted</code>", then:
+      <p>If <var>fetchParams</var>'s <a for="fetch params">fetch state</a> is
+      "<code>aborted</code>", then:
 
       <ol>
        <li><p>Set <var>response</var>'s <a for=response>aborted flag</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -210,7 +210,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">fetch state</dfn>
+ <dt><dfn for="fetch params">fetch state</dfn> (default "<code>ongoing</code>")
  <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>".
 
  <dt><dfn for="fetch params">timing info</dfn>
@@ -272,19 +272,19 @@ set <var>fetchParams</var>'s <a for="fetch params">fetch state</a> to "<code>ter
 <p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">canceled</dfn> if
 its <a for="fetch params">fetch state</a> is "<code>aborted</code>" or "<code>terminated</code>".
 
-<p>A <dfn export>fetch controller</dfn> is an object used to enable clients of an ongoing fetch
-to perform certain actions in the context of that fetch instance.
+<p>A <dfn export>fetch controller</dfn> is a <a for=/>struct</a> used to enable clients of an
+ongoing fetch to perform certain actions in the context of that fetch instance.
 
 <p>A <a for=/>fetch controller</a> has an associated <a for=/>fetch params</a>
-<dfn for="fetch controller">ongoing fetch params</dfn>.</p>
+<dfn for="fetch controller">internal fetch params</dfn>.</p>
 
 <p>To <dfn export id="concept-fetch-terminate" for="fetch controller">terminate</dfn> a
 <a for=/>fetch controller</a> <var>controller</var>, <a for="fetch params">terminate</a>
-<var>controller</var>'s <a for="fetch controller">ongoing fetch params</a>.
+<var>controller</var>'s <a for="fetch controller">internal fetch params</a>.
 
 <p>To <dfn for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
 <var>controller</var>, <a for="fetch params">abort</a> <var>controller</var>'s
-<a for="fetch controller">ongoing fetch params</a>.
+<a for="fetch controller">internal fetch params</a>.
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2131,9 +2131,15 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <a for=response>body</a> is always null.
 
 <p>To create the <dfn>appropriate network error</dfn> given <a for=/>fetch params</a>
-<var>fetchParams</var>, return an <a>aborted network error</a> if <var>fetchParams</var>'s
-<a for="fetch params">fetch state</a> is "<code>aborted</code>"; otherwise return a
-<a>network error</a>.
+<var>fetchParams</var>:
+
+<ol>
+ <li><p>Assert: <var>fetchParams</var> is  <a for="fetch params">canceled</a>.</li>
+
+ <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var>'s
+ <a for="fetch params">fetch state</a> is "<code>aborted</code>"; otherwise return a
+ <a>network error</a>.
+</ol>
 
 <hr>
 
@@ -2316,16 +2322,18 @@ functionality.
 <a for=/>request</a>).
 
 <p>A <a for="fetch group">fetch record</a> has an associated
-<dfn export for="fetch record" id=concept-fetch-record-fetch>fetch</dfn> (a
+<dfn export for="fetch record" id=concept-fetch-record-fetch>controller</dfn> (a
 <a for=/>fetch controller</a> or null).
 
 <hr>
 
 <p>When a <a for=fetch>fetch group</a> is
 <dfn export for="fetch group" id=concept-fetch-group-terminate>terminated</dfn>, for each associated
-<a for="fetch group">fetch record</a> whose <a for="fetch record">request</a>'s <a>done flag</a> is
-unset or <a for=request>keepalive</a> is false, <a for="fetch controller">terminate</a> the
-<a for="fetch group">fetch record</a>'s <a for="fetch record">fetch</a>.
+<a for="fetch group">fetch record</a> whose
+<a for="fetch group">fetch record</a>'s <a for="fetch record">controller</a> is not null, and whose
+<a for="fetch record">request</a>'s <a>done flag</a> is unset or <a for=request>keepalive</a> is
+false, <a for="fetch controller">terminate</a> the <a for="fetch group">fetch record</a>'s
+<a for="fetch record">controller</a>.
 
 
 <h3 id=resolving-domains>Resolving domains</h3>
@@ -3844,7 +3852,7 @@ the request.
  <var>crossOriginIsolatedCapability</var>.
 
  <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> with its
- <a for="fetch controller">ongoing fetch params</a> set to <var>fetchParams</var>.</p></li>
+ <a for="fetch controller">internal fetch params</a> set to <var>fetchParams</var>.</p></li>
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
@@ -3919,8 +3927,9 @@ the request.
   <p>If <var>request</var> is a <a>subresource request</a>, then:
 
   <ol>
-   <li><p>Let <var>record</var> be a new <a for="fetch group">fetch record</a> consisting of
-   <var>request</var> and <var>controller</var>.
+   <li><p>Let <var>record</var> be a new <a for="fetch group">fetch record</a> whose
+   <a for="fetch record">request</a> is <var>request</var> and
+   <a for="fetch record">controller</a> is <var>controller</var>.
 
    <li><p>Append <var>record</var> to <var>request</var>'s <a for=request>client</a>'s
    <a for=fetch>fetch group</a> list of <a for="fetch group">fetch records</a>.
@@ -5529,7 +5538,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>pullAlgorithm</var> be an action that <a lt=resumed for=fetch>resumes</a> the
  ongoing fetch if it is <a lt=suspend for=fetch>suspended</a>.
 
- <li><p>Let <var>cancelAlgorithm</var> be to <a for="fetch params">abort</a> <var>fetchParams</var>.
+ <li><p>Let <var>cancelAlgorithm</var> be an algorithm that
+ <a for="fetch params">abort</a>s <var>fetchParams</var>.
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -226,11 +226,13 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
 </dl>
 
-<p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a> <var>controller</var>,
-set <var>controller</var>'s <a for="fetch controller">state</a> to "<code>aborted</code>".
+<p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
+<var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
+"<code>aborted</code>".
 
-<p>To <dfn export for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a> <var>controller</var>,
-set <var>controller</var>'s <a for="fetch controller">state</a> to "<code>terminated</code>".
+<p>To <dfn export for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
+<var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
+"<code>terminated</code>".
 
 <p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">aborted</dfn> if
 its <a for="fetch params">controller</a>'s <a for="fetch controller">state</a> is
@@ -2134,7 +2136,7 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <var>fetchParams</var>:
 
 <ol>
- <li><p>Assert: <var>fetchParams</var> is <a for="fetch params">canceled</a>.</li>
+ <li><p>Assert: <var>fetchParams</var> is <a for="fetch params">canceled</a>.
 
  <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var> is
  <a for="fetch params">aborted</a>; otherwise return a <a>network error</a>.
@@ -2328,10 +2330,10 @@ functionality.
 
 <p>When a <a for=fetch>fetch group</a> is
 <dfn export for="fetch group" id=concept-fetch-group-terminate>terminated</dfn>, for each associated
-<a for="fetch group">fetch record</a> whose
-<a for="fetch group">fetch record</a>'s <a for="fetch record">controller</a> is not null, and whose
-<a for="fetch record">request</a>'s <a>done flag</a> is unset or <a for=request>keepalive</a> is
-false, <a for="fetch controller">terminate</a> the <a for="fetch group">fetch record</a>'s
+<a for="fetch group">fetch record</a> whose <a for="fetch group">fetch record</a>'s
+<a for="fetch record">controller</a> is not null, and whose <a for="fetch record">request</a>'s
+<a>done flag</a> is unset or <a for=request>keepalive</a> is false,
+<a for="fetch controller">terminate</a> the <a for="fetch group">fetch record</a>'s
 <a for="fetch record">controller</a>.
 
 
@@ -3924,9 +3926,8 @@ the request.
 
   <ol>
    <li><p>Let <var>record</var> be a new <a for="fetch group">fetch record</a> whose
-   <a for="fetch record">request</a> is <var>request</var> and
-   <a for="fetch record">controller</a> is <var>fetchParams</var>'s
-   <a for="fetch params">controller</a>.
+   <a for="fetch record">request</a> is <var>request</var> and <a for="fetch record">controller</a>
+   is <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 
    <li><p>Append <var>record</var> to <var>request</var>'s <a for=request>client</a>'s
    <a for=fetch>fetch group</a> list of <a for="fetch group">fetch records</a>.
@@ -4425,7 +4426,7 @@ steps:
     </ol>
 
    <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
-   <var>fetchParams</var>.</p></li>
+   <var>fetchParams</var>.
   </ol>
 
  <dt>"<code>data</code>"
@@ -5164,7 +5165,7 @@ steps. They return a <a for=/>response</a>.
   </ol>
 
  <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
- <var>fetchParams</var>.</p></li>
+ <var>fetchParams</var>.
 
 
  <!-- If response is still null, we require a forwarded request. -->
@@ -5262,7 +5263,7 @@ steps. They return a <a for=/>response</a>.
 
     <ol>
      <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then return the
-     <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
+     <a for=/>appropriate network error</a> for <var>fetchParams</var>.
 
      <li><p>Let <var>username</var> and <var>password</var> be the result of prompting the end user
      for a username and password, respectively, in <var>request</var>'s
@@ -5289,8 +5290,8 @@ steps. They return a <a for=/>response</a>.
    <li class=XXX><p>Needs testing: multiple `<code>Proxy-Authenticate</code>` headers, missing,
    parsing issues.
 
-   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then
-   return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then return the
+   <a for=/>appropriate network error</a> for <var>fetchParams</var>.
 
    <li>
     <p>Prompt the end user as appropriate in <var>request</var>'s
@@ -5319,8 +5320,8 @@ steps. They return a <a for=/>response</a>.
   <p>then:
 
   <ol>
-   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then
-   return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
+   <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then return the
+   <a for=/>appropriate network error</a> for <var>fetchParams</var>.
 
    <li><p>Set <var>response</var> to the result of running <a>HTTP-network-or-cache fetch</a> given
    <var>fetchParams</var>, <var>isAuthenticationFetch</var>, and true.
@@ -5537,11 +5538,11 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <li><p>Return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.
   </ol>
 
- <li><p>Let <var>pullAlgorithm</var> be an action that <a lt=resumed for=fetch>resumes</a> the
+ <li><p>Let <var>pullAlgorithm</var> be an algorithm that <a lt=resumed for=fetch>resumes</a> the
  ongoing fetch if it is <a lt=suspend for=fetch>suspended</a>.
 
- <li><p>Let <var>cancelAlgorithm</var> be an algorithm that
- <a for="fetch controller">aborts</a> <var>fetchParams</var>'s <a for="fetch params">controller</a>.
+ <li><p>Let <var>cancelAlgorithm</var> be an algorithm that <a for="fetch controller">aborts</a>
+ <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 
@@ -8017,6 +8018,7 @@ resource — for non-<a>CORS requests</a> as well as <a>CORS
 requests</a> — and do not use `<code>Vary</code>`.
 
 
+
 <h2 id=fetch-elsewhere class=no-num>Using fetch in other standards</h2>
 
 <p>In its essence <a for=/>fetching</a> is an exchange of a <a for=/>request</a> for a
@@ -8085,10 +8087,11 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  as arguments will be invoked. Hopefully most standards will not need this.
 </dl>
 
-<p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>.
-The controller is used for performing actions on a fetch operation that has already started,
-such as <a for="fetch controller" lt=abort>aborting</a> the operation by the user or page logic, or
+<p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>. The
+controller is used for performing actions on a fetch operation that has already started, such as
+<a for="fetch controller" lt=abort>aborting</a> the operation by the user or page logic, or
 <a for="fetch controller" lt=terminate>terminating</a> it due to a browser-internal circumstance.
+
 
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>

--- a/fetch.bs
+++ b/fetch.bs
@@ -210,6 +210,10 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
+ <dt><dfn for="fetch params">terminated flag</dfn>
+ <dt><dfn for="fetch params">aborted flag</dfn>
+ <dd>A flag, initially unset.
+
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
 </dl>
@@ -259,6 +263,19 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
  <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> to
  <var>storedTimingInfo</var>'s <a for="fetch timing info">decoded body size</a>.
 </ol>
+
+<p>A <dfn export>fetch controller</dfn> is an object used to enable clients of an ongoing fetch
+to perform certain actions in the context of that fetch instance.
+
+<p>A <a for=/>fetch controller</a> has an associated <a for=/>fetch params</a>
+<dfn for="fetch controller">ongoing fetch params</dfn>.</p>
+
+<p>To <dfn for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
+<var>controller</var> given a flag <var>aborted</var>, which is unset unless otherwise specified,
+set <var>controller</var>'s <a for="fetch controller">ongoing fetch params</a>
+<a for="fetch params">terminated flag</a>, and set <var>controller</var>'s
+<a for="fetch controller">ongoing fetch params</a> <a for="fetch params">aborted flag</a> if
+<var>aborted</var> is set.
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2104,6 +2121,10 @@ known as an <dfn export id=concept-aborted-network-error>aborted network error</
 <a for=response>header list</a> is always empty, and
 <a for=response>body</a> is always null.
 
+<p>To create the <dfn>appropriate network error</dfn> given <a for=/>fetch params</a>
+<var>fetchParams</var>, return an <a>aborted network error</a> if <var>fetchParams</var>'s
+<a for="fetch params">aborted flag</a> is set, otherwise return a <a>network error</a>.
+
 <hr>
 
 <p>A <dfn export id=concept-filtered-response>filtered response</dfn> is a limited view on a
@@ -3757,10 +3778,6 @@ an integer representing the number of bytes transmitted. If given,
 given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
 and null, failure, or a <a for=/>byte sequence</a>.
 
-<p>An ongoing <a for=/>fetch</a> can be
-<dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> with flag <var>aborted</var>,
-which is unset unless otherwise specified.
-
 <p>The user agent may be asked to
 <dfn export for=fetch id=concept-fetch-suspend>suspend</dfn> the ongoing fetch.
 The user agent may either accept or ignore the suspension request. The suspended fetch can be
@@ -3815,6 +3832,14 @@ the request.
  <a for="fetch params">task destination</a> is <var>taskDestination</var>, and
  <a for="fetch params">cross-origin isolated capability</a> is
  <var>crossOriginIsolatedCapability</var>.
+
+ <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> with its
+ <a for="fetch controller">ongoing fetch params</a> set to <var>fetchParams</var>.</p></li>
+
+ <p>If this instance of <a for=/>fetch</a> is
+ <dfn export for=fetch id=concept-fetch-terminate>terminated</dfn> given flag <var>aborted</var>,
+ which is unset unless otherwise specified, <a for="fetch controller">terminate</a>
+ <var>controller</var> with <var>aborted</var>.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
  <var>request</var>'s <a for=request>body</a> to the first return value of
@@ -3897,6 +3922,8 @@ the request.
   </ol>
 
  <li><p>Run <a>main fetch</a> given <var>fetchParams</var>.
+
+ <li><p>Return <var>controller</var>.
 </ol>
 
 
@@ -4385,16 +4412,8 @@ steps:
      <li><p>Return <var>response</var>.
     </ol>
 
-   <li>
-    <p><a>If aborted</a>, then:
-
-    <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-     <li><p>Return a <a>network error</a>.
-    </ol>
+   <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
+   <var>fetchParams</var>.</p></li>
   </ol>
 
  <dt>"<code>data</code>"
@@ -5127,16 +5146,9 @@ steps. They return a <a for=/>response</a>.
     </ol>
   </ol>
 
- <li>
-  <p><a>If aborted</a>, then:
+ <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
+ <var>fetchParams</var>.</p></li>
 
-  <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-   <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-   <li><p>Return a <a>network error</a>.
-  </ol>
 
  <!-- If response is still null, we require a forwarded request. -->
  <li>
@@ -5232,16 +5244,8 @@ steps. They return a <a for=/>response</a>.
     <var>isAuthenticationFetch</var> is true, then:
 
     <ol>
-     <li>
-      <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
-
-      <ol>
-       <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-       <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-       <li><p>Return a <a>network error</a>.
-      </ol>
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+     return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
      <li><p>Let <var>username</var> and <var>password</var> be the result of prompting the end user
      for a username and password, respectively, in <var>request</var>'s
@@ -5268,16 +5272,8 @@ steps. They return a <a for=/>response</a>.
    <li class=XXX><p>Needs testing: multiple `<code>Proxy-Authenticate</code>` headers, missing,
    parsing issues.
 
-   <li>
-    <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
-
-    <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-     <li><p>Return a <a>network error</a>.
-    </ol>
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+   return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li>
     <p>Prompt the end user as appropriate in <var>request</var>'s
@@ -5306,16 +5302,8 @@ steps. They return a <a for=/>response</a>.
   <p>then:
 
   <ol>
-   <li>
-    <p>If the ongoing fetch is <a for=fetch>terminated</a>, then:
-
-    <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
-
-     <li><p>If <var>aborted</var> is set, then return an <a>aborted network error</a>.
-
-     <li><p>Return a <a>network error</a>.
-    </ol>
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+   return the <a for=/>appropriate network error</a> for <var>fetchParams</var>.</p></li>
 
    <li><p>Set <var>response</var> to the result of running <a>HTTP-network-or-cache fetch</a> given
    <var>fetchParams</var>, <var>isAuthenticationFetch</var>, and true.
@@ -5372,7 +5360,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   </dl>
 
  <li>
-  <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
+  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
+  <a for="fetch params">terminated flag</a> is set:
 
   <ol>
    <li><p>If <var>connection</var> is failure, then return a <a>network error</a>.
@@ -5474,7 +5463,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyChunk</var> given <var>bytes</var> be these steps:
 
         <ol>
-         <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+         abort these steps.
 
          <li><p>Run this step <a>in parallel</a>: transmit <var>bytes</var>.
 
@@ -5488,7 +5478,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processEndOfBody</var> be these steps:
 
         <ol>
-         <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+         abort these steps.
 
          <li><p>If <var>fetchParams</var>'s <a for="fetch params">process request end-of-body</a> is
          non-null, then run <var>fetchParams</var>'s
@@ -5499,7 +5490,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>Let <var>processBodyError</var> given <var>e</var> be these steps:
 
         <ol>
-         <li><p>If the ongoing fetch is <a for=fetch>terminated</a>, then abort these steps.
+         <li><p>If <var>fetchParams</var>'s <a for="fetch params">terminated flag</a> is set, then
+         abort these steps.
 
          <li><p>If <var>e</var> is an "<code><a exception>AbortError</a></code>" {{DOMException}},
          then <a lt=terminated for=fetch>terminate</a> the ongoing fetch with the aborted flag set.
@@ -5521,7 +5513,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
+   <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
+   <a for="fetch params">aborted flag</a>.
 
    <li><p>If <var>connection</var> uses HTTP/2, then transmit an <code>RST_STREAM</code> frame.
 
@@ -5550,7 +5543,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <a for="ReadableStream/set up"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.
 
  <li>
-  <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
+  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
+  <a for="fetch params">terminated flag</a> is set:
 
   <ol>
    <li><p>Set <var>response</var>'s <a for=response>body</a> to a new
@@ -5579,7 +5573,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
   <p><a>If aborted</a>, then:
 
   <ol>
-   <li><p>Let <var>aborted</var> be the termination's aborted flag.
+   <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
+   <a for="fetch params">aborted flag</a>.
 
    <li><p>If <var>aborted</var> is set, then set <var>response</var>'s
    <a for=response>aborted flag</a>.
@@ -5592,7 +5587,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
   <ol>
    <li>
-    <p>Run these steps, but <a>abort when</a> the ongoing fetch is <a for=fetch>terminated</a>:
+    <p>Run these steps, but <a>abort when</a> <var>fetchParams</var>'s
+    <a for="fetch params">terminated flag</a> is set:
 
     <ol>
      <li>
@@ -5644,7 +5640,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p><a>If aborted</a>, then:
 
     <ol>
-     <li><p>Let <var>aborted</var> be the termination's aborted flag.
+
+     <li><p>Let <var>aborted</var> be <var>fetchParams</var>'s
+     <a for="fetch params">aborted flag</a>.
 
      <li>
       <p>If <var>aborted</var> is set, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -4521,7 +4521,9 @@ these steps:
    given <var>fetchParams</var>'s <a for="fetch params">cross-origin isolated capability</a>.
 
    <li><p>Set <var>response</var> to the result of invoking <a for=/>handle fetch</a> for
-   <var>requestForServiceWorker</var>. [[!HTML]] [[!SW]]
+   <var>requestForServiceWorker</var>, with <var>fetchParams</var>'s
+   <a for="fetch params">cross-origin isolated capability</a> and <var>fetchParams</var>'s
+   <a for="fetch params">controller</a>. [[!HTML]] [[!SW]]
 
    <li>
     <p>If <var>response</var> is not null, then:

--- a/fetch.bs
+++ b/fetch.bs
@@ -5541,7 +5541,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  ongoing fetch if it is <a lt=suspend for=fetch>suspended</a>.
 
  <li><p>Let <var>cancelAlgorithm</var> be an algorithm that
- <a for="fetch controller">abort</a>s <var>fetchParams</var>'s <a for="fetch params">controller</a>.
+ <a for="fetch controller">aborts</a> <var>fetchParams</var>'s <a for="fetch params">controller</a>.
 
  <li><p>Let <var>highWaterMark</var> be a non-negative, non-NaN number, chosen by the user agent.
 


### PR DESCRIPTION
Use the controller for external timing reporting and aborts.

This allows removing the 1:1 dependency between timing info and a response, as a response can be shared across fetch
instances (e.g. when restoring a response from cache, or when forwarding a response through a service worker).

See https://github.com/whatwg/fetch/issues/1208

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Should reflect current implementation.

- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1329.html" title="Last updated on Mar 11, 2022, 10:12 AM UTC (dc7f07c)">Preview</a> | <a href="https://whatpr.org/fetch/1329/435c5ec...dc7f07c.html" title="Last updated on Mar 11, 2022, 10:12 AM UTC (dc7f07c)">Diff</a>