### PR TITLE
Add colorprofile destination

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1845,7 +1845,7 @@ otherwise, it is unset.
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworklet</code>",
-"<code>colorprofile</code>" "<code>font</code>", "<code>image</code>", "<code>manifest</code>",
+"<code>colorprofile</code>", "<code>font</code>", "<code>image</code>", "<code>manifest</code>",
 "<code>paintworklet</code>", "<code>script</code>", "<code>style</code>", "<code>track</code>",
 "<code>video</code>", "<code>xslt</code>", or the empty string.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1402,6 +1402,7 @@ JavaScript. [[!CSP]] [[!MIX]]
 the empty string,
 "<code>audio</code>",
 "<code>audioworklet</code>",
+"<code>colorprofile</code>",
 "<code>document</code>",
 "<code>embed</code>",
 "<code>font</code>",
@@ -1520,6 +1521,10 @@ not always relevant and might require different behavior.
    <td>"<code>style</code>"
    <td><code>style-src</code>
    <td>HTML's <code>&lt;link rel=stylesheet></code>, CSS' <code>@import</code>
+  <tr>
+   <td>"<code>colorprofile</code>"
+   <td><code>style-src</code>
+   <td>CSS <code>@color-profile</code>
   <tr>
    <td>"<code>track</code>"
    <td><code>media-src</code>
@@ -1840,9 +1845,9 @@ otherwise, it is unset.
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworklet</code>",
-"<code>font</code>", "<code>image</code>", "<code>manifest</code>", "<code>paintworklet</code>",
-"<code>script</code>", "<code>style</code>", "<code>track</code>", "<code>video</code>",
-"<code>xslt</code>", or the empty string.
+"<code>colorprofile</code>" "<code>font</code>", "<code>image</code>", "<code>manifest</code>",
+"<code>paintworklet</code>", "<code>script</code>", "<code>style</code>", "<code>track</code>",
+"<code>video</code>", "<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>non-subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>document</code>", "<code>embed</code>",
@@ -6547,7 +6552,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "colorprofile", "document", "embed", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -1450,7 +1450,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=19>""
+   <td rowspan=20>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.


### PR DESCRIPTION
For CSS color-profiles
(https://drafts.csswg.org/css-color-4/#at-profile)

Uses `style-src` for CSP.

Closes #1324

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1331.html" title="Last updated on Oct 12, 2021, 2:55 PM UTC (5616e4c)">Preview</a> | <a href="https://whatpr.org/fetch/1331/6f37b51...5616e4c.html" title="Last updated on Oct 12, 2021, 2:55 PM UTC (5616e4c)">Diff</a>