### PR TITLE
Editorial: align with URL's cannot-be-base-URL removal

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4214,7 +4214,7 @@ steps:
 <dl class=switch>
  <dt>"<code>about</code>"
  <dd>
-  <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>path</a> is
+  <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>path</a> is the string
   "<code>blank</code>", then return a new <a for=/>response</a> whose
   <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> consist
   of a single <a for=/>header</a> whose <a for=header>name</a> is `<code>Content-Type</code>` and
@@ -6904,7 +6904,7 @@ constructor steps are:
 
       <ul class=brief>
        <li><p><var>parsedReferrer</var>'s <a for=url>scheme</a> is "<code>about</code>" and
-       <a for=url>path</a> is "<code>client</code>"
+       <a for=url>path</a> is the string "<code>client</code>"
 
        <li><p><var>parsedReferrer</var>'s <a for=url>origin</a> is not <a>same origin</a> with
        <var>origin</var>


### PR DESCRIPTION
These URLs now have a path whose value is a string rather than a list.

See https://github.com/whatwg/url/pull/655 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1337.html" title="Last updated on Oct 19, 2021, 4:12 PM UTC (f174b7e)">Preview</a> | <a href="https://whatpr.org/fetch/1337/7e5c922...f174b7e.html" title="Last updated on Oct 19, 2021, 4:12 PM UTC (f174b7e)">Diff</a>