### PR TITLE
Give header concepts proper types

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4205,10 +4205,9 @@ steps:
  <dd>
   <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>path</a> is the string
   "<code>blank</code>", then return a new <a for=/>response</a> whose
-  <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> consist
-  of a single <a for=/>header</a> whose <a for=header>name</a> is `<code>Content-Type</code>` and
-  <a for=header>value</a> is `<code>text/html;charset=utf-8</code>`, and <a for=response>body</a> is
-  the empty byte sequence.
+  <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> is «
+  (`<code>Content-Type</code>`, `<code>text/html;charset=utf-8</code>`) », and
+  <a for=response>body</a> is the empty byte sequence.
 
   <p>Otherwise, return a <a>network error</a>.
 
@@ -4271,12 +4270,13 @@ steps:
 
    <li><p>If <var>dataURLStruct</var> is failure, then return a <a>network error</a>.
 
+   <li><p>Let <var>mimeType</var> be <var>dataURLStruct</var>'s
+   <a for="data: URL struct">MIME type</a>, <a lt="serialize a MIME type to bytes">serialized</a>.
+
    <li><p>Return a <a for=/>response</a> whose <a for=response>status message</a> is
-   `<code>OK</code>`, <a for=response>header list</a> consist of a single <a for=/>header</a> whose
-   <a for=header>name</a> is `<code>Content-Type</code>` and <a for=header>value</a> is
-   <var>dataURLStruct</var>'s <a for="data: URL struct">MIME type</a>,
-   <a lt="serialize a MIME type to bytes">serialized</a>, and <a for=response>body</a> is
-   <var>dataURLStruct</var>'s <a for="data: URL struct">body</a>.
+   `<code>OK</code>`, <a for=response>header list</a> is « (`<code>Content-Type</code>`,
+   <var>mimeType</var>) », and <a for=response>body</a> is <var>dataURLStruct</var>'s
+   <a for="data: URL struct">body</a>.
   </ol>
 
  <dt>"<code>file</code>"


### PR DESCRIPTION
This gives headers, header names, and header values each a distinct type grounded in Infra and applies that across Fetch. This also removes the usage of pair syntax in favor of tuple syntax.

Helps with https://github.com/whatwg/infra/issues/127.

HTML PR: https://github.com/whatwg/html/pull/7254.

XHR PR: https://github.com/whatwg/xhr/pull/334.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1339.html" title="Last updated on Oct 25, 2021, 6:45 AM UTC (fd566f5)">Preview</a> | <a href="https://whatpr.org/fetch/1339/9bfe9e7...fd566f5.html" title="Last updated on Oct 25, 2021, 6:45 AM UTC (fd566f5)">Diff</a>