### PR TITLE
Propagate origin and URL list through the request constructor. (Fixes #1321, #1335)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6954,10 +6954,8 @@ constructor steps are:
    <li><p>Set <var>request</var>'s <a for=request>URL</a> to <var>request</var>'s
    <a for=request>current URL</a>.
 
-   <li><p>Set <var>request</var>'s <a for=request>URL list</a> to an empty <a for=/>list</a>.
-
-   <li><p><a for=list>Append</a> <var>request</var>'s <a for=request>URL</a> to
-   <var>request</var>'s <a for=request>URL list</a>.
+   <li><p>Set <var>request</var>'s <a for=request>URL list</a> to « <var>request</var>'s
+   <a for=request>URL</a> ».
   </ol>
 
   <p class=note>This is done to ensure that when a service worker "redirects" a request, e.g., from


### PR DESCRIPTION
- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * [Navigation headers test](https://github.com/web-platform-tests/wpt/blob/master/service-workers/service-worker/navigation-headers.https.html)
   * [SameSite cookies test](https://github.com/web-platform-tests/wpt/blob/master/service-workers/service-worker/same-site-cookies.https.html)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1241188
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1658869
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=233640

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1345.html" title="Last updated on Dec 1, 2021, 10:09 AM UTC (8d0d199)">Preview</a> | <a href="https://whatpr.org/fetch/1345/5dc54a7...8d0d199.html" title="Last updated on Dec 1, 2021, 10:09 AM UTC (8d0d199)">Diff</a>