### PR TITLE
Send "null" Origin header on cross-origin .onion requests

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -111,6 +111,9 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
         "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram",
         "publisher": "IETF",
         "title": "Using QUIC Datagrams with HTTP/3"
+    },
+    "ONION": {
+        "aliasOf": "RFC7686"
     }
 }
 </pre>
@@ -2819,6 +2822,11 @@ given a <a for=/>request</a> <var>request</var>, run these steps:
 <ol>
  <li><p>Let <var>serializedOrigin</var> be the result of <a>byte-serializing a request origin</a>
  with <var>request</var>.
+
+ <li><p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a>'s
+ <a for=origin>host</a> ends with "<code>.onion</code>" or "<code>.onion.</code>", and
+ is not <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then set
+ <var>serializedOrigin</var> to `<code>null</code>`. [[ONION]]
 
  <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" or
  <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>", then


### PR DESCRIPTION
Fixes #1350.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * [Firefox (off by default) / Tor Browser (on by default)](https://searchfox.org/mozilla-central/rev/6c8d325e61b0b445ed2e04899da38c3a4c266cba/netwerk/protocol/http/nsCORSListenerProxy.cpp#979-984)
   * [Brave](https://github.com/brave/brave-browser/issues/18071)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1351.html" title="Last updated on Nov 10, 2021, 11:10 PM UTC (b4aebfd)">Preview</a> | <a href="https://whatpr.org/fetch/1351/3ecab20...b4aebfd.html" title="Last updated on Nov 10, 2021, 11:10 PM UTC (b4aebfd)">Diff</a>