### PR TITLE
Editorial: use AbortSignal's aborted predicate

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7476,8 +7476,8 @@ method steps are:
  <li><p>Let <var>request</var> be <var>requestObject</var>'s <a for=Request>request</a>.
 
  <li>
-  <p>If <var>requestObject</var>'s <a for=Request>signal</a>'s <a for=AbortSignal>aborted flag</a>
-  is set, then:
+  <p>If <var>requestObject</var>'s <a for=Request>signal</a> is <a for=AbortSignal>aborted</a>,
+  then:
 
   <ol>
    <li><p><a>Abort fetch</a> with <var>p</var>, <var>request</var>, and null.


### PR DESCRIPTION
Follow-up: integrating abort reason is #1343.

Fixes #1349.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1353.html" title="Last updated on Nov 9, 2021, 12:31 PM UTC (9365d69)">Preview</a> | <a href="https://whatpr.org/fetch/1353/0613515...9365d69.html" title="Last updated on Nov 9, 2021, 12:31 PM UTC (9365d69)">Diff</a>