### PR TITLE
Editorial: scheme is not a standalone type

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2819,14 +2819,8 @@ request <a for=/>header</a> indicates where a
 <a lt=fetch for=/>fetches</a>.
 <!-- Ian Hickson told me Adam Barth researched that -->
 
-<p>Its <a for=header>value</a> <a>ABNF</a>:
-
-<pre><code class=lang-abnf>
-Origin                           = origin-or-null
-
-origin-or-null                   = origin / %s"null" ; case-sensitive
-origin                           = <a for=url>scheme</a> "://" <a for=url>host</a> [ ":" <a for=url>port</a> ]
-</code></pre>
+<p>Its possible <a for=header>values</a> are all the return values of
+<a>byte-serializing a request origin</a>, given a <a for=/>request</a>.
 
 <p class=note>This supplants the definition in <cite>The Web Origin Concept</cite>. [[ORIGIN]]
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -279,19 +279,19 @@ number.
 
 <h3 id=url>URL</h3>
 
-<p>A <dfn export>local scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
-"<code>blob</code>", or "<code>data</code>".
+<p>A <dfn export>local scheme</dfn> is "<code>about</code>", "<code>blob</code>", or
+"<code>data</code>".
 
 <p>A <a for=/>URL</a> <dfn export>is local</dfn> if its <a for=url>scheme</a> is a
 <a>local scheme</a>.
 
 <p class=note>This definition is also used by <cite>Referrer Policy</cite>. [[REFERRER]]
 
-<p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is a <a for=url>scheme</a> that is
-"<code>http</code>" or "<code>https</code>".
+<p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is "<code>http</code>" or
+"<code>https</code>".
 
-<p>A <dfn export>fetch scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
-"<code>blob</code>", "<code>data</code>", "<code>file</code>", or an <a>HTTP(S) scheme</a>.
+<p>A <dfn export>fetch scheme</dfn> is "<code>about</code>", "<code>blob</code>",
+"<code>data</code>", "<code>file</code>", or an <a>HTTP(S) scheme</a>.
 
 <p class="note no-backref"><a>HTTP(S) scheme</a> and <a>fetch scheme</a> are also used by
 <cite>HTML</cite>. [[HTML]]
@@ -2810,7 +2810,7 @@ run these steps:
 request <a for=/>header</a> indicates where a
 <a for=/>fetch</a> originates from.
 
-<p class="note no-backref">The `<a http-header><code>Origin</code></a>` header is a version of the
+<p class=note>The `<a http-header><code>Origin</code></a>` header is a version of the
 `<code>Referer</code>` [sic] header that does not reveal a <a for=url>path</a>. It is used for all
 <a lt="HTTP fetch">HTTP fetches</a> whose <a for=/>request</a>'s
 <a for=request>response tainting</a> is "<code>cors</code>", as well as those where


### PR DESCRIPTION
Remove more instances where a concept member is used as a type.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1361.html" title="Last updated on Nov 29, 2021, 9:41 AM UTC (837a840)">Preview</a> | <a href="https://whatpr.org/fetch/1361/5dc54a7...837a840.html" title="Last updated on Nov 29, 2021, 9:41 AM UTC (837a840)">Diff</a>