### PR TITLE
Editorial: use HTML's definition of entry

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6478,7 +6478,7 @@ the associated steps:
     <cite>Returning Values from Forms: multipart/form-data</cite>. [[!RFC7578]]</p>
 
     <p>Each part whose `<code>Content-Disposition</code>` header contains a `<code>filename</code>`
-    parameter must be parsed into an <a for=FormData>entry</a> whose value is a {{File}} object
+    parameter must be parsed into an <a for="entry list">entry</a> whose value is a {{File}} object
     whose contents are the contents of the part. The {{File/name}} attribute of the {{File}} object
     must have the value of the `<code>filename</code>` parameter of the part. The {{Blob/type}}
     attribute of the {{File}} object must have the value of the `<code>Content-Type</code>` header
@@ -6486,8 +6486,8 @@ the associated steps:
     [[!RFC7578]] section 4.4) otherwise.</p>
 
     <p>Each part whose `<code>Content-Disposition</code>` header does not contain a
-    `<code>filename</code>` parameter must be parsed into an <a for=FormData>entry</a> whose value
-    is the <a lt="UTF-8 decode without BOM">UTF-8 decoded without BOM</a> content of the part.
+    `<code>filename</code>` parameter must be parsed into an <a for="entry list">entry</a> whose
+    value is the <a lt="UTF-8 decode without BOM">UTF-8 decoded without BOM</a> content of the part.
     <span class=note>This is done regardless of the presence or the value of a
     `<code>Content-Type</code>` header and regardless of the presence or the value of a
     `<code>charset</code>` parameter.</span></p>

--- a/fetch.bs
+++ b/fetch.bs
@@ -6499,8 +6499,8 @@ the associated steps:
 
    <li><p>If that fails for some reason, then <a>throw</a> a {{TypeError}}.
 
-   <li><p>Return a new {{FormData}} object, appending each <a for=FormData>entry</a>, resulting from
-   the parsing operation, to <a for=FormData>entries</a>.
+   <li><p>Return a new {{FormData}} object, appending each <a for="entry list">entry</a>, resulting
+   from the parsing operation, to its <a for=FormData>entry list</a>.
   </ol>
 
   <p class=XXX>The above is a rough approximation of what is needed for
@@ -6516,8 +6516,8 @@ the associated steps:
 
    <li><p>If <var>entries</var> is failure, then <a>throw</a> a {{TypeError}}.
 
-   <li><p>Return a new {{FormData}} object whose
-   <a spec=xhr>entries</a> are <var>entries</var>.
+   <li><p>Return a new {{FormData}} object whose <a for=FormData>entry list</a> is
+   <var>entries</var>.
   </ol>
 
   <p>Otherwise, <a>throw</a> a {{TypeError}}.


### PR DESCRIPTION
It moved from XMLHttpRequest to HTML.

---

It seems this broke the build.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1364.html" title="Last updated on Dec 2, 2021, 10:31 AM UTC (cc9738d)">Preview</a> | <a href="https://whatpr.org/fetch/1364/8e4553b...cc9738d.html" title="Last updated on Dec 2, 2021, 10:31 AM UTC (cc9738d)">Diff</a>