### PR TITLE
Editorial: a network error's body is always null

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4162,10 +4162,9 @@ steps:
    <li><p>Let <var>processBodyError</var> be this step: run <a>fetch finale</a> given
    <var>fetchParams</var> and a <a>network error</a>.
 
-
-   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
-   <var>response</var> is a <a>network error</a>, or <var>response</var>'s <a for=response>body</a>
-   is null, then run <var>processBodyError</var> and abort these steps.
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" or
+   <var>response</var>'s <a for=response>body</a> is null, then run <var>processBodyError</var> and
+   abort these steps.
 
    <li>
     <p>Let <var>processBody</var> given <var>bytes</var> be these steps:


### PR DESCRIPTION
@noamr could you review this as well?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1370.html" title="Last updated on Dec 13, 2021, 12:44 PM UTC (de109f3)">Preview</a> | <a href="https://whatpr.org/fetch/1370/ed6221d...de109f3.html" title="Last updated on Dec 13, 2021, 12:44 PM UTC (de109f3)">Diff</a>