### PR TITLE
Allow timing reporting with origin (for iframes)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4337,18 +4337,6 @@ steps:
  and set <var>response</var>'s <a for="response">timing info</a> to the result.
 </ol>
 
-<p>To <dfn export>report timing</dfn> given a <a for=/>response</a>
-<var>response</var>, a <a for=/>global object</a> <var>global</var>, and a <a for=/>string</a>
-<var>initiatorType</var> (default "<code>other</code>"), run these steps:
-
-<ol>
- <li><p>Let <var>allowTiming</var> be true if <var>response</var>'s
- <a for=response>timing allow passed flag</a> is set; otherwise false.
-
- <li><a>Report timing</a> for <var>response</var>, <var>global</var>, and <var>initiatorType</var>,
- and set <var>response</var>'s <a for="response">timing info</a> to the result.
-</ol>
-
 <p>To <dfn export>report timing with origin</dfn> given a <a for=/>response</a>
 <var>response</var>, a <a for=/>global object</a> <var>global</var>, an <a for=/>origin</a>
 <var>origin</var>, and a <a for=/>string</a> <var>initiatorType</var> (default

--- a/fetch.bs
+++ b/fetch.bs
@@ -4346,9 +4346,9 @@ steps:
 <var>response</var> and the result of <a lt="ASCII serialization of an origin">serializing</a>
 <var>origin</var>.
 
-<p class=note>This algorithm is used by <cite>HTML</cite> to report resource timing for
-iframes, as iframes report both to the iframe's loaded document as navigation timing and to the
-containing document as resource timing. [[HTML]]
+<p class=note>This algorithm is used by <cite>HTML</cite> to report resource timing for documents
+nested through <code>iframe</code> elements, as iframes report both to the <code>iframe</code>'s
+loaded document as navigation timing and to the containing document as resource timing. [[HTML]]
 
 <p>To <dfn>report timing</dfn> given a <a for=/>response</a> <var>response</var>, a
 <a for=/>global object</a> <var>global</var>, a <a for=/>string</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4343,7 +4343,8 @@ steps:
 <var>origin</var>, and a <a for=/>string</a> <var>initiatorType</var> (default
 "<code>other</code>"), <a>report timing</a> for <var>response</var>,
 <var>global</var>, <var>initiatorType</var>, and the result of calling <a>TAO origin check</a> with
-<var>origin</var> and <var>response</var>.
+<var>response</var> and the result of <a lt="ASCII serialization of an origin">serializing</a>
+<var>origin</var>.
 
 <p>To <dfn>report timing</dfn> given a <a for=/>response</a> <var>response</var>, a
 <a for=/>global object</a> <var>global</var>, a <a for=/>string</a>
@@ -6031,13 +6032,12 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>Let <var>origin</var> be the result of <a>serializing a request origin</a> with
  <var>request</var>.
 
- <li><p>Return the result of calling <a>TAO origin check</a> with <var>origin</var> and
- <var>response</var>.
+ <li><p>Return the result of calling <a>TAO origin check</a> with <var>response</var> and
+ <var>origin</var>.
 </ol>
 
-<p>To perform a <dfn id=concept-tao-origin-check>TAO origin check</dfn> for an
-<a for=/>origin</a> <var>origin</var> and a <a for=/>response</a> <var>response</var>, run these
-steps:
+<p>To perform a <dfn id=concept-tao-origin-check>TAO origin check</dfn> for a <a for=/>response</a>
+<var>response</var> and an <a for=/>ASCII string</a> <var>origin</var> and, run these steps:
 
 <ol>
  <li><p>Let <var>values</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -6008,14 +6008,25 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>basic</code>", then
  return success.
 
+ <li><p>Let <var>origin</var> be the result of <a>serializing a request origin</a> with
+ <var>request</var>.
+
+ <li><p>Return the result of calling <a>TAO origin check</a> with <var>origin</var> and
+ <var>response</var>.
+</ol>
+
+<p>To perform a <dfn export id=concept-tao-origin-check>TAO origin check</dfn> for an
+<a for=/>origin</a> <var>origin</var> and a <a for=/>response</a> <var>response</var>, run these
+steps:
+
+<ol>
  <li><p>Let <var>values</var> be the result of
  <a for="header list">getting, decoding, and splitting</a> `<code>Timing-Allow-Origin</code>` from
  <var>response</var>'s <a for=response>header list</a>.
 
  <li><p>If <var>values</var> <a for=list>contains</a> "<code>*</code>", then return success.
 
- <li><p>If <var>values</var> <a for=list>contains</a> the result of
- <a>serializing a request origin</a> with <var>request</var>, then return success.
+ <li><p>If <var>values</var> <a for=list>contains</a> <var>origin</var>, then return success.
 
  <li><p>Return failure.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4346,6 +4346,10 @@ steps:
 <var>response</var> and the result of <a lt="ASCII serialization of an origin">serializing</a>
 <var>origin</var>.
 
+<p class=note>This algorithm is used by <cite>HTML</cite> to report resource timing for
+iframes, as iframes report both to the iframe's loaded document as navigation timing and to the
+containing document as resource timing.
+
 <p>To <dfn>report timing</dfn> given a <a for=/>response</a> <var>response</var>, a
 <a for=/>global object</a> <var>global</var>, a <a for=/>string</a>
 <var>initiatorType</var>, and a boolean <var>taoPass</var>, run these steps:

--- a/fetch.bs
+++ b/fetch.bs
@@ -4348,7 +4348,7 @@ steps:
 
 <p class=note>This algorithm is used by <cite>HTML</cite> to report resource timing for
 iframes, as iframes report both to the iframe's loaded document as navigation timing and to the
-containing document as resource timing.
+containing document as resource timing. [[HTML]]
 
 <p>To <dfn>report timing</dfn> given a <a for=/>response</a> <var>response</var>, a
 <a for=/>global object</a> <var>global</var>, a <a for=/>string</a>
@@ -6041,7 +6041,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 </ol>
 
 <p>To perform a <dfn id=concept-tao-origin-check>TAO origin check</dfn> for a <a for=/>response</a>
-<var>response</var> and an <a for=/>ASCII string</a> <var>origin</var> and, run these steps:
+<var>response</var> and an <a for=/>ASCII string</a> <var>origin</var>, run these steps:
 
 <ol>
  <li><p>Let <var>values</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -4330,11 +4330,12 @@ steps:
 <var>initiatorType</var> (default "<code>other</code>"), run these steps:
 
 <ol>
- <li><p>Let <var>opaque</var> be false <var>response</var>'s
- <a for=response>timing allow passed flag</a> is set; otherwise true.
+ <li><p>Let <var>taoPass</var> be true <var>response</var>'s
+ <a for=response>timing allow passed flag</a> is set; otherwise false.
 
- <li><a>Report timing</a> for <var>response</var>, <var>global</var>, and <var>initiatorType</var>,
- and set <var>response</var>'s <a for="response">timing info</a> to the result.
+ <li>Set <var>response</var>'s <a for="response">timing info</a> to the
+ result of calling <a>report timing</a> given <var>response</var>, <var>global</var>,
+ <var>initiatorType</var>, and <var>taoPass</var>.
 </ol>
 
 <p>To <dfn export>report timing with origin</dfn> given a <a for=/>response</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4330,6 +4330,37 @@ steps:
 <var>initiatorType</var> (default "<code>other</code>"), run these steps:
 
 <ol>
+ <li><p>Let <var>opaque</var> be false <var>response</var>'s
+ <a for=response>timing allow passed flag</a> is set; otherwise true.
+
+ <li><a>Report timing</a> for <var>response</var>, <var>global</var>, and <var>initiatorType</var>,
+ and set <var>response</var>'s <a for="response">timing info</a> to the result.
+</ol>
+
+<p>To <dfn export>report timing</dfn> given a <a for=/>response</a>
+<var>response</var>, a <a for=/>global object</a> <var>global</var>, and a <a for=/>string</a>
+<var>initiatorType</var> (default "<code>other</code>"), run these steps:
+
+<ol>
+ <li><p>Let <var>allowTiming</var> be true if <var>response</var>'s
+ <a for=response>timing allow passed flag</a> is set; otherwise false.
+
+ <li><a>Report timing</a> for <var>response</var>, <var>global</var>, and <var>initiatorType</var>,
+ and set <var>response</var>'s <a for="response">timing info</a> to the result.
+</ol>
+
+<p>To <dfn export>report timing with origin</dfn> given a <a for=/>response</a>
+<var>response</var>, a <a for=/>global object</a> <var>global</var>, an <a for=/>origin</a>
+<var>origin</var>, and a <a for=/>string</a> <var>initiatorType</var> (default
+"<code>other</code>"), <a>report timing</a> for <var>response</var>,
+<var>global</var>, <var>initiatorType</var>, and the result of calling <a>TAO origin check</a> with
+<var>origin</var> and <var>response</var>.
+
+<p>To <dfn>report timing</dfn> given a <a for=/>response</a> <var>response</var>, a
+<a for=/>global object</a> <var>global</var>, a <a for=/>string</a>
+<var>initiatorType</var>, and a boolean <var>taoPass</var>, run these steps:
+
+<ol>
  <li><p>If <var>response</var> is an <a>aborted network error</a>, then return.
 
  <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or
@@ -4347,7 +4378,7 @@ steps:
  <li><p>If <var>timingInfo</var> is null, then return.
 
  <li>
-  <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then:
+  <p>If <var>taoPass</var> is false, then:</p>
 
   <ol>
    <li><p>Set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
@@ -4361,10 +4392,10 @@ steps:
  <a>relevant settings object</a>'s
  <a for="environment settings object">cross-origin isolated capability</a>.
 
- <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
-
  <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>originalURL</var>,
  <var>initiatorType</var>, <var>global</var>, and <var>cacheState</var>.
+
+ <li><p>Return <var>timingInfo</var>.
 </ol>
 
 
@@ -6015,7 +6046,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  <var>response</var>.
 </ol>
 
-<p>To perform a <dfn export id=concept-tao-origin-check>TAO origin check</dfn> for an
+<p>To perform a <dfn id=concept-tao-origin-check>TAO origin check</dfn> for an
 <a for=/>origin</a> <var>origin</var> and a <a for=/>response</a> <var>response</var>, run these
 steps:
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4330,7 +4330,7 @@ steps:
 <var>initiatorType</var> (default "<code>other</code>"), run these steps:
 
 <ol>
- <li><p>Let <var>taoPass</var> be true <var>response</var>'s
+ <li><p>Let <var>taoPass</var> be true if <var>response</var>'s
  <a for=response>timing allow passed flag</a> is set; otherwise false.
 
  <li>Set <var>response</var>'s <a for="response">timing info</a> to the


### PR DESCRIPTION
This will allow checking TAO for an iframe, which doesn't go via CORS - the check is done upon creation of the RT entry rather than during fetch (this is aligned with implementations).

Closes https://github.com/whatwg/fetch/issues/1387 
See https://github.com/whatwg/html/pull/7531No new behavior.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1388.html" title="Last updated on Feb 14, 2022, 1:31 PM UTC (a89f4ea)">Preview</a> | <a href="https://whatpr.org/fetch/1388/8ebf2fd...a89f4ea.html" title="Last updated on Feb 14, 2022, 1:31 PM UTC (a89f4ea)">Diff</a>