### PR TITLE
Add `Response.json` static method

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7298,6 +7298,7 @@ interface Response {
 
   [NewObject] static Response error();
   [NewObject] static Response redirect(USVString url, optional unsigned short status = 302);
+  [NewObject] static Response json(any data, optional ResponseInit init = {});
 
   readonly attribute ResponseType type;
 
@@ -7348,6 +7349,10 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <dt><code><var>response</var> = <a idl>Response</a> . <a method for=Response lt=redirect()>redirect</a>(<var>url</var>, <var>status</var> = 302)</code>
  <dd><p>Creates a redirect {{Response}} that redirects to <var>url</var> with status
  <var>status</var>.
+
+ <dt><code><var>response</var> = <a idl>Response</a> . <a method for=Response lt=json()>json</a>(<var>data</var> [, <var>init</var>])</code>
+ <dd><p>Creates a {{Response}} whose body is the JSON-encoded <var>data</var>, and status, status
+ message, and headers are provided by <var>init</var>.
 
  <dt><code><var>response</var> . <a attribute for=Response>type</a></code>
  <dd><p>Returns <var>response</var>'s type, e.g., "<code>cors</code>".
@@ -7476,6 +7481,48 @@ are:
 
  <li><p><a for="header list">Append</a> (`<code>Location</code>`, <var>value</var>) to
  <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>.
+
+ <li><p>Return <var>responseObject</var>.
+</ol>
+
+
+<p>The static
+<dfn method for=Response><code>json(<var>data</var>, <var>init</var>)</code></dfn> method steps
+are:
+
+<ol>
+ <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
+ then <a>throw</a> a {{RangeError}}.
+
+ <li><p>If <var>init</var>["{{ResponseInit/status}}"] is a <a>null body status</a>, then
+ <a>throw</a> a {{TypeError}}.
+
+ <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
+ <a spec=http>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
+
+ <li><p>Let <var>responseObject</var> be the result of <a for=Response>creating</a> a {{Response}}
+ object, given a new <a for=/>response</a>, "<code>response</code>", and <a>this</a>'s
+ <a>relevant Realm</a>.
+
+ <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
+ <var>init</var>["{{ResponseInit/status}}"].
+
+ <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s
+ <a for=response>status message</a> to <var>init</var>["{{ResponseInit/statusText}}"].
+
+ <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
+ <a for=Headers>fill</a> <var>responseObject</var>'s <a for=Response>headers</a> with
+ <var>init</var>["{{ResponseInit/headers}}"].
+
+ <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>body</a> to
+ the <a>UTF-8 encoding</a> of the result of running
+ <a>serialize a JavaScript value to a JSON string</a> on <var>data</var>.
+
+ <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>
+ <a for="header list">does not contain</a> `<code>Content-Type</code>`, then
+ <a for="header list">append</a> (`<code>Content-Type</code>`,
+ `<code>application/json;charset=utf-8</code>`) to <var>responseObject</var>'s
+ <a for=Response>response</a>'s <a for=response>header list</a>.
 
  <li><p>Return <var>responseObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7657,7 +7657,7 @@ are:
  <a>relevant Realm</a>.
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
- (body, <code>"application/json;charset=UTF-8"</code>).
+ (body, <code>"application/json"</code>).
 
  <li><p>Return <var>responseObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1259,7 +1259,7 @@ null), run these steps. <var>processBody</var> must be an algorithm accepting a
 <p>A <dfn export id=concept-body-with-type>body with type</dfn> is a
 <a for=/>tuple</a> that consists of a
 <dfn export for="body with type" id=concept-body-with-type-body>body</dfn> (a <a for=/>body</a>) and
-<dfn export for="body with type" id=concept-body-with-type>type</dfn> (a <a for=/>header value</a>).
+<dfn export for="body with type" id=concept-body-with-type-type>type</dfn> (a <a for=/>header value</a>).
 
 <hr>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -7544,8 +7544,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>Return <var>responseObject</var>.
 </ol>
 
-<p>To <dfn>initialize a response</dfn>, given a {{Response}} object <var>response</var>, 
-{{ResponseInit}} <var>init</var>, and an optional <a for=/>body with type</a> <var>body</var>, run 
+<p>To <dfn>initialize a response</dfn>, given a {{Response}} object <var>response</var>,
+{{ResponseInit}} <var>init</var>, and an optional <a for=/>body with type</a> <var>body</var>, run
 these steps:
 
 <ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1256,10 +1256,9 @@ null), run these steps. <var>processBody</var> must be an algorithm accepting a
 
 <hr>
 
-<p>A <dfn export id=concept-body-with-type>body with type</dfn> is a
-<a for=/>tuple</a> that consists of a
-<dfn export for="body with type" id=concept-body-with-type-body>body</dfn> (a <a for=/>body</a>) and
-<dfn export for="body with type" id=concept-body-with-type-type>type</dfn> (a <a for=/>header value</a>).
+<p>A <dfn export>body with type</dfn> is a <a for=/>tuple</a> that consists of a
+<dfn export for="body with type">body</dfn> (a <a for=/>body</a>) and
+<dfn export for="body with type">type</dfn> (a <a for=/>header value</a>).
 
 <hr>
 
@@ -7447,7 +7446,7 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 </ol>
 
 <p>To <dfn>initialize a response</dfn>, given a {{Response}} <var>response</var>, {{ResponseInit}}
-<var>init</var>, and an optional <a for/>body with type</a> <var>body</var>, run these steps:
+<var>init</var>, and an optional <a for=/>body with type</a> <var>body</var>, run these steps:
 
 <ol>
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
@@ -7485,6 +7484,7 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
    `<code>Content-Type</code>`, then <a for="header list">append</a> (`<code>Content-Type</code>`,
    <var>body</var>'s <a for="body with type">type</a>) to <var>response</var>'s
    <a for=response>header list</a>.
+  </ol>
 </ol>
 
 <hr>
@@ -7503,7 +7503,7 @@ constructor steps are:
 
  <li><p>Let <var>bodyWithType</var> be null.
 
- <li><p>If <var>body</var> is non-null, then let <var>bodyWithType</var> be the result of
+ <li><p>If <var>body</var> is non-null, then set <var>bodyWithType</var> to the result of
  <a for=BodyInit>extracting</a> <var>body</var>.
 
  <li><p>Perform <a>initialize a response</a> given <a>this</a>, <var>init</var>, and
@@ -7559,6 +7559,8 @@ are:
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
  (body, <code>"application/json;charset=utf-8"</code>).
+
+ <li><p>Return <var>responseObject</var>.
 </ol>
 
 <p>The <dfn attribute for=Response><code>type</code></dfn> getter steps are to return <a>this</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -7515,8 +7515,7 @@ are:
  <var>init</var>["{{ResponseInit/headers}}"].
 
  <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>body</a> to
- the <a>UTF-8 encoding</a> of the result of running
- <a>serialize a JavaScript value to a JSON string</a> on <var>data</var>.
+ the result of running <a>serialize a JavaScript value to a JSON bytes</a> on <var>data</var>.
 
  <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>
  <a for="header list">does not contain</a> `<code>Content-Type</code>`, then

--- a/fetch.bs
+++ b/fetch.bs
@@ -7544,8 +7544,9 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>Return <var>responseObject</var>.
 </ol>
 
-<p>To <dfn>initialize a response</dfn>, given a {{Response}} <var>response</var>, {{ResponseInit}}
-<var>init</var>, and an optional <a for=/>body with type</a> <var>body</var>, run these steps:
+<p>To <dfn>initialize a response</dfn>, given a {{Response}} object <var>response</var>, 
+{{ResponseInit}} <var>init</var>, and an optional <a for=/>body with type</a> <var>body</var>, run 
+these steps:
 
 <ol>
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
@@ -7557,8 +7558,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
  <var>init</var>["{{ResponseInit/status}}"].
 
- <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status message</a> to
- <var>init</var>["{{ResponseInit/statusText}}"].
+ <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status message</a>
+ to <var>init</var>["{{ResponseInit/statusText}}"].
 
  <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
  <a for=Headers>fill</a> <var>response</var>'s <a for=Response>headers</a> with
@@ -7657,7 +7658,7 @@ are:
  <a>relevant Realm</a>.
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
- (body, "<code>application/json</code>").
+ (<var>body</var>, "<code>application/json</code>").
 
  <li><p>Return <var>responseObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7657,7 +7657,7 @@ are:
  <a>relevant Realm</a>.
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
- (body, <code>"application/json"</code>).
+ (body, "<code>application/json</code>").
 
  <li><p>Return <var>responseObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7558,7 +7558,7 @@ are:
  <a>relevant Realm</a>.
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
- (body, <code>"application/json;charset=utf-8"</code>).
+ (body, <code>"application/json;charset=UTF-8"</code>).
 
  <li><p>Return <var>responseObject</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1256,6 +1256,13 @@ null), run these steps. <var>processBody</var> must be an algorithm accepting a
 
 <hr>
 
+<p>A <dfn export id=concept-body-with-type>body with type</dfn> is a
+<a for=/>tuple</a> that consists of a
+<dfn export for="body with type" id=concept-body-with-type-body>body</dfn> (a <a for=/>body</a>) and
+<dfn export for="body with type" id=concept-body-with-type>type</dfn> (a <a for=/>header value</a>).
+
+<hr>
+
 <p>To <dfn export>handle content codings</dfn> given <var>codings</var> and <var>bytes</var>, run
 these steps:
 
@@ -7399,8 +7406,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>Return <var>responseObject</var>.
 </ol>
 
-<p>To <dfn>initialize a response</dfn>, given a {{Response}} <var>response</var>, and
-{{ResponseInit}} <var>init</var>, run these steps:
+<p>To <dfn>initialize a response</dfn>, given a {{Response}} <var>response</var>, {{ResponseInit}}
+<var>init</var>, and an optional <a for/>body with type</a> <var>body</var>, run these steps:
 
 <ol>
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
@@ -7418,6 +7425,26 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
  <a for=Headers>fill</a> <var>response</var>'s <a for=Response>headers</a> with
  <var>init</var>["{{ResponseInit/headers}}"].
+
+ <li>
+  <p>If <var>body</var> was given, then:
+
+  <ol>
+   <li>
+    <p>If <var>response</var>'s <a for=response>status</a> is a <a>null body status</a>, then
+    <a>throw</a> a {{TypeError}}.
+
+    <p class="note no-backref">101 is included in <a>null body status</a> due to its use elsewhere.
+    It does not affect this step.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>body</var>'s
+   <a for="body with type">body</a>.
+
+   <li><p>If <var>body</var>'s <a for="body with type">type</a> is non-null and
+   <var>response</var>'s <a for=response>header list</a> <a for="header list">does not contain</a>
+   `<code>Content-Type</code>`, then <a for="header list">append</a> (`<code>Content-Type</code>`,
+   <var>body</var>'s <a for="body with type">type</a>) to <var>response</var>'s
+   <a for=response>header list</a>.
 </ol>
 
 <hr>
@@ -7434,30 +7461,13 @@ constructor steps are:
  <a for=Response>response</a>'s <a for=response>header list</a> and <a for=Headers>guard</a> is
  "<code>response</code>".
 
- <li><p>Perform <a>initialize a response</a> given <a>this</a>, and <var>init</var>.
+ <li><p>Let <var>bodyWithType</var> be null.
 
- <li>
-  <p>If <var>body</var> is non-null, then:
+ <li><p>If <var>body</var> is non-null, then let <var>bodyWithType</var> be the result of
+ <a for=BodyInit>extracting</a> <var>body</var>.
 
-  <ol>
-   <li>
-    <p>If <a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a> is a
-    <a>null body status</a>, then <a>throw</a> a {{TypeError}}.
-
-    <p class="note no-backref">101 is included in <a>null body status</a> due to its use elsewhere.
-    It does not affect this step.
-
-   <li><p>Let <var>Content-Type</var> be null.
-
-   <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>body</a> and
-   <var>Content-Type</var> to the result of <a for=BodyInit>extracting</a> <var>body</var>.
-
-   <li><p>If <var>Content-Type</var> is non-null and <a>this</a>'s <a for=Response>response</a>'s
-   <a for=response>header list</a> <a for="header list">does not contain</a>
-   `<code>Content-Type</code>`, then <a for="header list">append</a> (`<code>Content-Type</code>`,
-   <var>Content-Type</var>) to <a>this</a>'s <a for=Response>response</a>'s
-   <a for=response>header list</a>.
-  </ol>
+ <li><p>Perform <a>initialize a response</a> given <a>this</a>, <var>init</var>, and
+ <var>bodyWithType</var>.
 </ol>
 
 <p>The static <dfn method for=Response><code>error()</code></dfn> method steps are to return the
@@ -7498,25 +7508,17 @@ are:
 are:
 
 <ol>
+ <li><p>Let <var>bytes</var> the result of running <a>serialize a JavaScript value to JSON bytes</a>
+ on <var>data</var>.
+
+ <li><p>Let <var>body</var> be the result of <a for=BodyInit>extracting</a> <var>bytes</var>.
+
  <li><p>Let <var>responseObject</var> be the result of <a for=Response>creating</a> a {{Response}}
  object, given a new <a for=/>response</a>, "<code>response</code>", and <a>this</a>'s
  <a>relevant Realm</a>.
 
- <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, and <var>init</var>.
-
- <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>status</a> is
- a <a>null body status</a>, then <a>throw</a> a {{TypeError}}.
-
- <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>body</a> to
- the result of running <a>serialize a JavaScript value to JSON bytes</a> on <var>data</var>.
-
- <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>
- <a for="header list">does not contain</a> `<code>Content-Type</code>`, then
- <a for="header list">append</a> (`<code>Content-Type</code>`,
- `<code>application/json;charset=utf-8</code>`) to <var>responseObject</var>'s
- <a for=Response>response</a>'s <a for=response>header list</a>.
-
- <li><p>Return <var>responseObject</var>.
+ <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
+ (body, <code>"application/json;charset=utf-8"</code>).
 </ol>
 
 <p>The <dfn attribute for=Response><code>type</code></dfn> getter steps are to return <a>this</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -7399,11 +7399,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>Return <var>responseObject</var>.
 </ol>
 
-<hr>
-
-<p>The
-<dfn constructor for=Response id=dom-response lt="Response(body, init)"><code>new Response(<var>body</var>, <var>init</var>)</code></dfn>
-constructor steps are:
+<p>To <dfn>initialize a response</dfn>, given a {{Response}} <var>response</var>, and
+{{ResponseInit}} <var>init</var>, run these steps:
 
 <ol>
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
@@ -7412,6 +7409,24 @@ constructor steps are:
  <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
  <a spec=http>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
 
+ <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
+ <var>init</var>["{{ResponseInit/status}}"].
+
+ <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status message</a> to
+ <var>init</var>["{{ResponseInit/statusText}}"].
+
+ <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
+ <a for=Headers>fill</a> <var>response</var>'s <a for=Response>headers</a> with
+ <var>init</var>["{{ResponseInit/headers}}"].
+</ol>
+
+<hr>
+
+<p>The
+<dfn constructor for=Response id=dom-response lt="Response(body, init)"><code>new Response(<var>body</var>, <var>init</var>)</code></dfn>
+constructor steps are:
+
+<ol>
  <li><p>Set <a>this</a>'s <a for=Response>response</a> to a new <a for=/>response</a>.
 
  <li><p>Set <a>this</a>'s <a for=Response>headers</a> to a <a for=/>new</a> {{Headers}} object with
@@ -7419,23 +7434,15 @@ constructor steps are:
  <a for=Response>response</a>'s <a for=response>header list</a> and <a for=Headers>guard</a> is
  "<code>response</code>".
 
- <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a> to
- <var>init</var>["{{ResponseInit/status}}"].
-
- <li><p>Set <a>this</a>'s <a for=Response>response</a>'s <a for=response>status message</a> to
- <var>init</var>["{{ResponseInit/statusText}}"].
-
- <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
- <a for=Headers>fill</a> <a>this</a>'s <a for=Response>headers</a> with
- <var>init</var>["{{ResponseInit/headers}}"].
+ <li><p>Perform <a>initialize a response</a> given <a>this</a>, and <var>init</var>.
 
  <li>
   <p>If <var>body</var> is non-null, then:
 
   <ol>
    <li>
-    <p>If <var>init</var>["{{ResponseInit/status}}"] is a <a>null body status</a>, then <a>throw</a>
-    a {{TypeError}}.
+    <p>If <a>this</a>'s <a for=Response>response</a>'s <a for=response>status</a> is a
+    <a>null body status</a>, then <a>throw</a> a {{TypeError}}.
 
     <p class="note no-backref">101 is included in <a>null body status</a> due to its use elsewhere.
     It does not affect this step.
@@ -7491,31 +7498,17 @@ are:
 are:
 
 <ol>
- <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
- then <a>throw</a> a {{RangeError}}.
-
- <li><p>If <var>init</var>["{{ResponseInit/status}}"] is a <a>null body status</a>, then
- <a>throw</a> a {{TypeError}}.
-
- <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
- <a spec=http>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
-
  <li><p>Let <var>responseObject</var> be the result of <a for=Response>creating</a> a {{Response}}
  object, given a new <a for=/>response</a>, "<code>response</code>", and <a>this</a>'s
  <a>relevant Realm</a>.
 
- <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
- <var>init</var>["{{ResponseInit/status}}"].
+ <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, and <var>init</var>.
 
- <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s
- <a for=response>status message</a> to <var>init</var>["{{ResponseInit/statusText}}"].
-
- <li><p>If <var>init</var>["{{ResponseInit/headers}}"] <a for=map>exists</a>, then
- <a for=Headers>fill</a> <var>responseObject</var>'s <a for=Response>headers</a> with
- <var>init</var>["{{ResponseInit/headers}}"].
+ <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>status</a> is
+ a <a>null body status</a>, then <a>throw</a> a {{TypeError}}.
 
  <li><p>Set <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>body</a> to
- the result of running <a>serialize a JavaScript value to a JSON bytes</a> on <var>data</var>.
+ the result of running <a>serialize a JavaScript value to JSON bytes</a> on <var>data</var>.
 
  <li><p>If <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>
  <a for="header list">does not contain</a> `<code>Content-Type</code>`, then


### PR DESCRIPTION
This commit adds a `Response.json` static method that can be used to
create well formed JSON responses will very little effort.

The JSON response is _not_ pretty printed.

Closes #1389

---

- [x] At least two implementers are interested (and none opposed):
   * [Chrome](https://github.com/whatwg/fetch/pull/1392#issuecomment-1123133441)
   * [Firefox](https://github.com/whatwg/fetch/pull/1392#pullrequestreview-970555855)
   * Deno
   * Cloudflare Workers
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/32825
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1305358
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1758943
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=240375
   * Deno: https://github.com/denoland/deno/issues/13902


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1392.html" title="Last updated on May 13, 2022, 9:02 AM UTC (7ef2f43)">Preview</a> | <a href="https://whatpr.org/fetch/1392/3ab5102...7ef2f43.html" title="Last updated on May 13, 2022, 9:02 AM UTC (7ef2f43)">Diff</a>