### PR TITLE
Process 103 Early Hints response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -199,6 +199,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params" id=fetch-params-process-request-body>process request body chunk length</dfn>
  (default null)
  <dt><dfn for="fetch params">process request end-of-body</dfn> (default null)
+ <dt><dfn for="fetch params">process early hints response</dfn> (default null)
  <dt><dfn for="fetch params">process response</dfn> (default null)
  <dt><dfn for="fetch params">process response end-of-body</dfn> (default null)
  <dt><dfn for="fetch params">process response consume body</dfn> (default null)
@@ -3744,6 +3745,8 @@ optional algorithm
 <dfn export for=fetch id=process-request-body><var>processRequestBodyChunkLength</var></dfn>, an
 optional algorithm
 <dfn export for=fetch id=process-request-end-of-body oldids=process-request-end-of-file><var>processRequestEndOfBody</var></dfn>,
+an optional algorithm <dfn export for=fetch id=process-early-hints-response>
+<var>processEarlyHintsResponse</var></dfn>,
 an optional algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an
 optional algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional
 algorithm
@@ -3751,8 +3754,10 @@ algorithm
 and an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run
 the steps below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting
 an integer representing the number of bytes transmitted. If given,
-<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments. If given,
-<var>processResponse</var> must be an algorithm accepting a <a for=/>response</a>. If given,
+<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments.
+If given, <var>processEarlyHintsResponse</var> must be an algorithm accepting a
+<a for=request>header list</a>. If given, <var>processResponse</var> must be an
+algorithm accepting a <a for=/>response</a>. If given,
 <var>processResponseEndOfBody</var> must be an algorithm accepting a <a for=/>response</a>. If
 given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
 and null, failure, or a <a for=/>byte sequence</a>.
@@ -3809,6 +3814,8 @@ the request.
  <a for="fetch params">process request body chunk length</a> is
  <var>processRequestBodyChunkLength</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
+ <a for="fetch params">process early hints response</a> is
+ <var>processEarlyHintsResponse</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
  <a for="fetch params">process response consume body</a> is <var>processResponseConsumeBody</var>,
  <a for="fetch params">process response end-of-body</a> is <var>processResponseEndOfBody</var>,
@@ -5460,22 +5467,47 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <a for=request>body</a> cannot be recreated and that is why the buffer is needed.
       </div>
 
-     <li><p>Set <var>timingInfo</var>'s
-     <a for="fetch timing info">final network-response start time</a> to the
-     <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
-     <a for="fetch params">cross-origin isolated capability</a>, immediately after the user agent's
-     HTTP parser receives the first byte of the response (e.g., frame header bytes for HTTP/2 or
-     response status line for HTTP/1.x).
-
-     <li><p>Wait until all the <a for=/>headers</a> are transmitted.
+     <li><p>Let <var>responseStartTime</var> be null.
 
      <li>
-      <p>Any <a for=/>responses</a> whose <a for=response>status</a> is in the range 100 to 199,
-      inclusive, and is not 101, are to be ignored, except for the purposes of setting
-      <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> above.
+      <p>While true:
+      <ol>
+       <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
-      <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by a
-      "final" <a for=/>response</a>.
+       <li><p>If <var>responseStartTime</var> is null, set <var>responseStartTime</var> to
+       <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+       <a for="fetch params">cross-origin isolated capability</a>, immediately after the user
+       agent's HTTP parser receives the first byte of the response (e.g., frame header bytes for
+       HTTP/2 or response status line for HTTP/1.x).
+
+       <li><p>Let <var>status</var> be <a for=response>status</a> of <a for=/>response</a>.
+
+       <li><p>If <var>status</var> is in the range 100 to 199, inclusive:
+        <ol>
+         <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
+
+         <li><p>If <var>status</var> is 103, then:
+          <ol>
+           <li><p>If <var>fetchParams</var>'s <a for="fetch params">process early hints response</a>
+           is non-null, then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+           <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
+
+           <li><p><a for=iteration>Continue</a>.
+          </ol>
+
+         <li><p>Otherwise, <a for=iteration>continue</a>.
+
+         <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by
+         a "final" <a for=/>response</a>.
+        </ol>
+
+       <li><p><a for=iteration>Break</a>.
+      </ol>
+     </li>
+
+     <li><p>Set <var>timingInfo</var>'s
+     <a for="fetch timing info">final network-response start time</a> to
+     <var>responseStartTime</var>.
     </ul>
 
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and

--- a/fetch.bs
+++ b/fetch.bs
@@ -5470,8 +5470,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li>
       <p>While true:
       <ol>
-       <li><p>Wait until all the <a for=/>headers</a> are transmitted.
-
        <li><p>If <var>timingInfo</var>'s
        <a for="fetch timing info">final network-response start time</a> is 0, set
        <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> to
@@ -5479,6 +5477,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <a for="fetch params">cross-origin isolated capability</a>, immediately after the user
        agent's HTTP parser receives the first byte of the response (e.g., frame header bytes for
        HTTP/2 or response status line for HTTP/1.x).
+
+       <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
        <li><p>Let <var>status</var> be <a for=response>status</a> of <a for=/>response</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5492,8 +5492,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
            <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
            "<code>navigate</code>".
 
-           <p class=note>The following step might trigger other fetches. The assertion
-           is to avoid potential CORS breakage.
+           <p class=note>The assertion is to make sure <a for=/>request</a> is not CORS eligible.
+           If <a for=/>request</a> is CORS eligible the following step might introduce potential
+           CORS breakage.
 
            <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
            <a for="fetch params">process early hints response</a>, with <a for=/>response</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1100,7 +1100,7 @@ format of range header value can be set using <a>add a range header</a>.
 <p class=XXX>Various edge cases in mapping HTTP/1's <code>status-code</code> to this concept are
 worked on in <a href=https://github.com/whatwg/fetch/issues/1156>issue #1156</a>.
 
-<p>A <dfn export>null body status</dfn> is a <a for=/>status</a> that is 101, 204, 205, or 304.
+<p>A <dfn export>null body status</dfn> is a <a for=/>status</a> that is 101, 103, 204, 205, or 304.
 
 <p>An <dfn export>ok status</dfn> is a <a for=/>status</a> in the range 200 to 299, inclusive.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3776,6 +3776,13 @@ the request.
 [[!HTTP-CACHING]]
 
 <ol>
+ <li>
+  <p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is "<code>navigate</code>" or
+  <var>processEarlyHintsResponse</var> is null.
+
+  <p class=note>Processing of early hints (<a for=/>responses</a> whose <a for=response>status</a>
+  is 103) is only vetted for navigations.
+
  <li><p>Let <var>taskDestination</var> be null.
 
  <li><p>Let <var>crossOriginIsolatedCapability</var> be false.
@@ -5485,20 +5492,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <ol>
          <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
 
-         <li>
-          <p>If <var>status</var> is 103 and <var>fetchParams</var>'s
-          <a for="fetch params">process early hints response</a> is non-null, then:
-
-          <ol>
-           <li>
-            <p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
-            "<code>navigate</code>".
-
-            <p class=note>Processing of early hints is only vetted for navigations.
-
-           <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
-           <a for="fetch params">process early hints response</a>, with <a for=/>response</a>.
-          </ol>
+         <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
+         <a for="fetch params">process early hints response</a> is non-null, then
+         <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+         <a for="fetch params">process early hints response</a>, with <a for=/>response</a>.
 
          <li><p><a for=iteration>Continue</a>.
         </ol>
@@ -8105,6 +8102,11 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  <dt><a for=fetch><i>processRequestEndOfBody</i></a>
  <dd><p>Takes an algorithm that will be passed nothing. Indicates <a for=/>request</a>'s
  <a for=request>body</a> has been transmitted. Most standards will not need this.
+
+ <dt><a for=fetch><i>processEarlyHintsResponse</i></a>
+ <dd><p>Takes an algorithm that will be passed a <a for=/>response</a> (whose
+ <a for=response>status</a> is 103). Can only be used for navigations as defined by
+ <cite>HTML</cite>. [[HTML]]
 
  <dt><a for=fetch><i>processResponse</i></a>
  <dd><p>Takes an algorithm that will be passed a <a for=/>response</a>. Indicates

--- a/fetch.bs
+++ b/fetch.bs
@@ -5486,24 +5486,20 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <ol>
          <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
 
-         <li><p>If <var>status</var> is 103, then:
+         <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
+         <a for="fetch params">process early hints response</a> is non-null, then:
           <ol>
-           <li><p>If <var>fetchParams</var>'s <a for="fetch params">process early hints response</a>
-           is non-null, then:
-           <ol>
-            <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
-            "<code>navigate</code>".
+           <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
+           "<code>navigate</code>".
 
-            <p class=note>The following step might trigger other fetches. The assertion
-            is to avoid potential CORS breakage.
+           <p class=note>The following step might trigger other fetches. The assertion
+           is to avoid potential CORS breakage.
 
-            <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
-            <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
-           </ol>
-           <li><p><a for=iteration>Continue</a>.
+           <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
+           <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
           </ol>
 
-         <li><p>Otherwise, <a for=iteration>continue</a>.
+         <li><p><a for=iteration>Continue</a>.
 
          <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by
          a "final" <a for=/>response</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3745,19 +3745,16 @@ optional algorithm
 <dfn export for=fetch id=process-request-body><var>processRequestBodyChunkLength</var></dfn>, an
 optional algorithm
 <dfn export for=fetch id=process-request-end-of-body oldids=process-request-end-of-file><var>processRequestEndOfBody</var></dfn>,
-an optional algorithm <dfn export for=fetch id=process-early-hints-response>
-<var>processEarlyHintsResponse</var></dfn>,
-an optional algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an
-optional algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional
-algorithm
+an optional algorithm <dfn export for=fetch><var>processEarlyHintsResponse</var></dfn>, an optional
+algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an optional
+algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
 and an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run
 the steps below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting
 an integer representing the number of bytes transmitted. If given,
-<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments.
-If given, <var>processEarlyHintsResponse</var> must be an algorithm accepting a
-<a for=/>response</a>. If given, <var>processResponse</var> must be an
-algorithm accepting a <a for=/>response</a>. If given,
+<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments. If given,
+<var>processEarlyHintsResponse</var> must be an algorithm accepting a <a for=/>response</a>. If
+given, <var>processResponse</var> must be an algorithm accepting a <a for=/>response</a>. If given,
 <var>processResponseEndOfBody</var> must be an algorithm accepting a <a for=/>response</a>. If
 given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
 and null, failure, or a <a for=/>byte sequence</a>.
@@ -3814,8 +3811,7 @@ the request.
  <a for="fetch params">process request body chunk length</a> is
  <var>processRequestBodyChunkLength</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
- <a for="fetch params">process early hints response</a> is
- <var>processEarlyHintsResponse</var>,
+ <a for="fetch params">process early hints response</a> is <var>processEarlyHintsResponse</var>,
  <a for="fetch params">process response</a> is <var>processResponse</var>,
  <a for="fetch params">process response consume body</a> is <var>processResponseConsumeBody</var>,
  <a for="fetch params">process response end-of-body</a> is <var>processResponseEndOfBody</var>,
@@ -5469,42 +5465,46 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
      <li>
       <p>While true:
+
       <ol>
        <li><p>If <var>timingInfo</var>'s
-       <a for="fetch timing info">final network-response start time</a> is 0, set
+       <a for="fetch timing info">final network-response start time</a> is 0, then set
        <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> to
        <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
        <a for="fetch params">cross-origin isolated capability</a>, immediately after the user
        agent's HTTP parser receives the first byte of the response (e.g., frame header bytes for
        HTTP/2 or response status line for HTTP/1.x).
 
-       <li><p>Wait until all the <a for=/>headers</a> are transmitted.
+       <li><p>Wait until all the HTTP response headers are transmitted.
 
-       <li><p>Let <var>status</var> be <a for=response>status</a> of <a for=/>response</a>.
+       <li><p>Let <var>status</var> be the HTTP response's status code.
 
-       <li><p>If <var>status</var> is in the range 100 to 199, inclusive:
+       <li>
+        <p>If <var>status</var> is in the range 100 to 199, inclusive:
+
         <ol>
          <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
 
-         <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
-         <a for="fetch params">process early hints response</a> is non-null, then:
-          <ol>
-           <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
-           "<code>navigate</code>".
+         <li>
+          <p>If <var>status</var> is 103 and <var>fetchParams</var>'s
+          <a for="fetch params">process early hints response</a> is non-null, then:
 
-           <p class=note>The assertion is to make sure <a for=/>request</a> is not CORS eligible.
-           If <a for=/>request</a> is CORS eligible the following step might introduce potential
-           CORS breakage.
+          <ol>
+           <li>
+            <p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
+            "<code>navigate</code>".
+
+            <p class=note>Processing of early hints is only vetted for navigations.
 
            <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
            <a for="fetch params">process early hints response</a>, with <a for=/>response</a>.
           </ol>
 
          <li><p><a for=iteration>Continue</a>.
-
-         <p class="note no-backref">These kind of <a for=/>responses</a> are eventually followed by
-         a "final" <a for=/>response</a>.
         </ol>
+
+        <p class=note>These kind of HTTP responses are eventually followed by a "final" HTTP
+        response.
 
        <li><p><a for=iteration>Break</a>.
       </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5505,7 +5505,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p><a for=iteration>Break</a>.
       </ol>
-     </li>
     </ul>
 
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and

--- a/fetch.bs
+++ b/fetch.bs
@@ -5467,14 +5467,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <a for=request>body</a> cannot be recreated and that is why the buffer is needed.
       </div>
 
-     <li><p>Let <var>responseStartTime</var> be null.
-
      <li>
       <p>While true:
       <ol>
        <li><p>Wait until all the <a for=/>headers</a> are transmitted.
 
-       <li><p>If <var>responseStartTime</var> is null, set <var>responseStartTime</var> to
+       <li><p>If <var>timingInfo</var>'s
+       <a for="fetch timing info">final network-response start time</a> is 0, set
+       <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> to
        <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
        <a for="fetch params">cross-origin isolated capability</a>, immediately after the user
        agent's HTTP parser receives the first byte of the response (e.g., frame header bytes for
@@ -5508,10 +5508,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        <li><p><a for=iteration>Break</a>.
       </ol>
      </li>
-
-     <li><p>Set <var>timingInfo</var>'s
-     <a for="fetch timing info">final network-response start time</a> to
-     <var>responseStartTime</var>.
     </ul>
 
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and

--- a/fetch.bs
+++ b/fetch.bs
@@ -5489,9 +5489,17 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>If <var>status</var> is 103, then:
           <ol>
            <li><p>If <var>fetchParams</var>'s <a for="fetch params">process early hints response</a>
-           is non-null, then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
-           <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
+           is non-null, then:
+           <ol>
+            <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
+            "<code>navigate</code>".
 
+            <p class="note nobackref">The following step might trigger other fetches. The assertion
+            is to avoid potential CORS breakage.
+
+            <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
+            <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
+           </ol>
            <li><p><a for=iteration>Continue</a>.
           </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3756,7 +3756,7 @@ the steps below. If given, <var>processRequestBodyChunkLength</var> must be an a
 an integer representing the number of bytes transmitted. If given,
 <var>processRequestEndOfBody</var> must be an algorithm accepting no arguments.
 If given, <var>processEarlyHintsResponse</var> must be an algorithm accepting a
-<a for=request>header list</a>. If given, <var>processResponse</var> must be an
+<a for=/>response</a>. If given, <var>processResponse</var> must be an
 algorithm accepting a <a for=/>response</a>. If given,
 <var>processResponseEndOfBody</var> must be an algorithm accepting a <a for=/>response</a>. If
 given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
@@ -5496,7 +5496,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
            is to avoid potential CORS breakage.
 
            <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s
-           <a for="fetch params">process early hints response</a>, with <a for=/>headers</a>.
+           <a for="fetch params">process early hints response</a>, with <a for=/>response</a>.
           </ol>
 
          <li><p><a for=iteration>Continue</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5494,7 +5494,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
             <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
             "<code>navigate</code>".
 
-            <p class="note nobackref">The following step might trigger other fetches. The assertion
+            <p class=note>The following step might trigger other fetches. The assertion
             is to avoid potential CORS breakage.
 
             <li><p><a>Queue a fetch task</a> to run <var>fetchParams</var>'s


### PR DESCRIPTION
Plumb an algorithm to process 103 Early Hints responses. The
algorithm is optional.

See https://github.com/whatwg/html/issues/7598 for the overall approach.

---

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/tree/master/loading/early-hints
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/671310
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1407355
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=238921
   * Deno (not for CORS changes): N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1404.html" title="Last updated on Apr 7, 2022, 6:35 AM UTC (eda2b8d)">Preview</a> | <a href="https://whatpr.org/fetch/1404/8ebf2fd...eda2b8d.html" title="Last updated on Apr 7, 2022, 6:35 AM UTC (eda2b8d)">Diff</a>