### PR TITLE
Add server-timing to timing info struct

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4314,7 +4314,8 @@ steps:
    <a for="fetch params">timing info</a>.</p></li>
   </ol>
  </li>
- <li><p>Otherwise, set <var>response</var>'s <a for=response>timing info</a>'s
+ <li><p>Otherwise, if <var>response</var>'s <a for=response>URL</a>'s <a for=url>scheme</a> is
+ "<code>https</code>", then set <var>response</var>'s <a for=response>timing info</a>'s
  <a for="fetch timing info">server timing headers</a> to the result of
  <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>` from
  <var>response</var>'s <a for=response>header list</a>.</p></li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4314,11 +4314,16 @@ steps:
    <a for="fetch params">timing info</a>.</p></li>
   </ol>
  </li>
- <li><p>Otherwise, if <var>response</var>'s <a for=response>URL</a>'s <a for=url>scheme</a> is
- "<code>https</code>", then set <var>response</var>'s <a for=response>timing info</a>'s
- <a for="fetch timing info">server timing headers</a> to the result of
- <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>` from
- <var>response</var>'s <a for=response>header list</a>.</p></li>
+ <li>
+  <p>Otherwise, if <var>response</var>'s <a for=response>URL</a>'s <a for=url>scheme</a> is
+  "<code>https</code>", then set <var>response</var>'s <a for=response>timing info</a>'s
+  <a for="fetch timing info">server timing headers</a> to the result of
+  <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>` from
+  <var>response</var>'s <a for=response>header list</a>.
+
+  <p>The user agent may decides to expose `<code>Server-Timing</code>` headers to
+  "<code>http</code>" requests as well.
+ </li>
 
  <li>
   <p>Let <var>processResponseEndOfBody</var> be the following steps:

--- a/fetch.bs
+++ b/fetch.bs
@@ -4315,14 +4315,14 @@ steps:
   </ol>
  </li>
  <li>
-  <p>Otherwise, if <var>response</var>'s <a for=response>URL</a>'s <a for=url>scheme</a> is
-  "<code>https</code>", then set <var>response</var>'s <a for=response>timing info</a>'s
-  <a for="fetch timing info">server timing headers</a> to the result of
-  <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>` from
-  <var>response</var>'s <a for=response>header list</a>.
+  <p>Otherwise, if <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+  <a for=request>client</a> is a <a>secure context</a>, then set <var>response</var>'s
+  <a for=response>timing info</a>'s <a for="fetch timing info">server timing headers</a> to the
+  result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
+  from <var>response</var>'s <a for=response>header list</a>.
 
   <p>The user agent may decides to expose `<code>Server-Timing</code>` headers to
-  "<code>http</code>" requests as well.
+  non-secure contexts requests as well.
  </li>
 
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -267,7 +267,7 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dt><dfn export for="fetch timing info">final connection timing info</dfn> (default null)
  <dd>Null or a <a for=/>connection timing info</a>.
 
- <dt><dfn export for="fetch timing info">server timing headers</dfn> (default an empty list)
+ <dt><dfn export for="fetch timing info">server-timing headers</dfn> (default « »)
  <dd>A <a for=/>list</a> of strings.
 </dl>
 
@@ -4313,17 +4313,16 @@ steps:
    <a>creating an opaque timing info</a> for <var>fetchParams</var>'s
    <a for="fetch params">timing info</a>.</p></li>
   </ol>
- </li>
+
  <li>
   <p>Otherwise, if <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-  <a for=request>client</a> is a <a>secure context</a>, then set <var>response</var>'s
-  <a for=response>timing info</a>'s <a for="fetch timing info">server timing headers</a> to the
+  <a for=request>client</a> is a <a>secure context</a>, set <var>response</var>'s
+  <a for=response>timing info</a>'s <a for="fetch timing info">server-timing headers</a> to the
   result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
   from <var>response</var>'s <a for=response>header list</a>.
 
-  <p>The user agent may decides to expose `<code>Server-Timing</code>` headers to
-  non-secure contexts requests as well.
- </li>
+  <p>The user agent may decide to expose `<code>Server-Timing</code>` headers to non-secure contexts
+  requests as well.
 
  <li>
   <p>Let <var>processResponseEndOfBody</var> be the following steps:

--- a/fetch.bs
+++ b/fetch.bs
@@ -266,6 +266,9 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
  <dt><dfn export for="fetch timing info">final connection timing info</dfn> (default null)
  <dd>Null or a <a for=/>connection timing info</a>.
+
+ <dt><dfn export for="fetch timing info">server timing headers</dfn> (default an empty list)
+ <dd>A <a for=/>list</a> of strings.
 </dl>
 
 <p>To
@@ -4311,6 +4314,10 @@ steps:
    <a for="fetch params">timing info</a>.</p></li>
   </ol>
  </li>
+ <li><p>Otherwise, set <var>response</var>'s <a for=response>timing info</a>'s
+ <a for="fetch timing info">server timing headers</a> to the result of
+ <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>` from
+ <var>response</var>'s <a for=response>header list</a>.</p></li>
 
  <li>
   <p>Let <var>processResponseEndOfBody</var> be the following steps:


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Will be used by https://github.com/w3c/server-timing/pull/87

Decode and split `Server-Timing` headers, and append the raw headers to the `fetch timing info`. The server timing spec would later parse these headers and expose them.

- [x] At least two implementers are interested (and none opposed):
   * Already implemented
  
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Rigorously tested in https://github.com/web-platform-tests/wpt/tree/master/server-timing
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/a

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1406.html" title="Last updated on Apr 20, 2022, 11:33 AM UTC (6d47c8f)">Preview</a> | <a href="https://whatpr.org/fetch/1406/3a65729...6d47c8f.html" title="Last updated on Apr 20, 2022, 11:33 AM UTC (6d47c8f)">Diff</a>