### PR TITLE
Perform a CSP check when consuming preloaded response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3895,19 +3895,19 @@ the request.
    <a for="environment settings object">origin</a>.
 
    <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
-   step given a <a for=/>response</a> <var>response</var>: Set <var>fetchParams</var>'s
+   step given a <a for=/>response</a> <var>response</var>: set <var>fetchParams</var>'s
    <a for="fetch params">preloaded response candidate</a> to <var>response</var>.
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking
-   <a>consume a preloaded resource</a> for <var>req</var>'s <a for=request>window</a>,
-   given <var>req</var>'s <a for=request>URL</a>, <var>req</var>'s <a for=request>destination</a>,
-   <var>req</var>'s <a for=request>mode</a>, <var>req</var>'s <a for=request>credentials mode</a>,
-   <var>req</var>'s <a for=request>integrity metadata</a>, and
-   <var>onPreloadedResponseAvailable</var>.
+   <a>consume a preloaded resource</a> for <var>request</var>'s <a for=request>window</a>, given
+   <var>request</var>'s <a for=request>URL</a>, <var>request</var>'s <a for=request>destination</a>,
+   <var>request</var>'s <a for=request>mode</a>, <var>request</var>'s
+   <a for=request>credentials mode</a>, <var>request</var>'s <a for=request>integrity metadata</a>,
+   and <var>onPreloadedResponseAvailable</var>.
 
    <li><p>If <var>foundPreloadedResource</var> is true and <var>fetchParams</var>'s
    <a for="fetch params">preloaded response candidate</a> is null, then set <var>fetchParams</var>'s
-   <a for="fetch params">preloaded response candidate</a> to "<code>pending</code>".</p></li>
+   <a for="fetch params">preloaded response candidate</a> to "<code>pending</code>".
   </ol>
  </li>
 
@@ -4046,17 +4046,15 @@ steps:
 
   <dl class=switch>
    <dt><var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> is not null
-
    <dd>
     <ol>
      <li><p>Wait until <var>fetchParams</var>'s
      <a for="fetch params">preloaded response candidate</a> is not "<code>pending</code>".
 
-     <li><p>Assert: <var>fetchParams</var>'s
+     <li><p><a for=/>Assert</a>: <var>fetchParams</var>'s
      <a for="fetch params">preloaded response candidate</a> is a <a for=/>response</a>.
 
-     <li><p>Return <var>fetchParams</var>'s
-     <a for="fetch params">preloaded response candidate</a>.
+     <li><p>Return <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a>.
     </ol>
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is
@@ -4066,7 +4064,6 @@ steps:
    "<code>data</code>"
    <dt><var>request</var>'s <a for=request>mode</a> is
    "<code>navigate</code>" or "<code>websocket</code>"
-
    <dd>
     <ol>
      <li><p>Set <var>request</var>'s
@@ -4083,7 +4080,6 @@ steps:
 
    <dt><var>request</var>'s <a for=request>mode</a> is
    "<code>same-origin</code>"
-
    <dd><p>Return a <a>network error</a>.
 
    <dt><var>request</var>'s <a for=request>mode</a> is
@@ -4115,7 +4111,6 @@ steps:
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is not an
    <a>HTTP(S) scheme</a>
-
    <dd><p>Return a <a>network error</a>.
 
    <dt><var>request</var>'s <a>use-CORS-preflight flag</a> is set

--- a/fetch.bs
+++ b/fetch.bs
@@ -216,7 +216,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
 
- <dt><dfn export for="fetch params">preloaded response</dfn> (default "<code>pending</code>")
+ <dt><dfn export for="fetch params">preloaded response candidate</dfn> (default null)
  <dd>Null, "<code>pending</code>", or a <a for=/>response</a>.
 </dl>
 
@@ -3894,9 +3894,12 @@ the request.
    with <var>request</var>'s <a for=request>client</a>'s
    <a for="environment settings object">origin</a>.
 
+   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> to
+   "<code>pending</code>".
+
    <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
-   step given a <a for=/>response</a> <var>response</var>: set <var>fetchParams</var>'s
-   <a for="fetch params">preloaded response</a> to <var>response</var>.
+   step given a <a for=/>response</a> <var>response</var>: Set <var>fetchParams</var>'s
+   <a for="fetch params">preloaded response candidate</a> to <var>response</var>.
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking
    <a>consume a preloaded resource</a> for <var>req</var>'s <a for=request>window</a>,
@@ -3906,7 +3909,7 @@ the request.
    <var>onPreloadedResponseAvailable</var>.
 
    <li><p>If <var>foundPreloadedResource</var> is false, then set <var>fetchParams</var>'s
-   <a for="fetch params">preloaded response</a> to null.
+   <a for="fetch params">preloaded response candidate</a> to null.</p></li>
   </ol>
  </li>
 
@@ -3992,12 +3995,7 @@ steps:
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
- <li><p>If <var>fetchParams</var>'s <a for="fetch params">preloaded response</a> is
- "<code>pending</code>", then wait until <var>fetchParams</var>'s
- <a for="fetch params">preloaded response</a> is null or a <a for=/>response</a>.
-
- <li><p>Let <var>response</var> be <var>fetchParams</var>'s
- <a for="fetch params">preloaded response</a>.
+ <li><p>Let <var>response</var> be null.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
@@ -4049,6 +4047,17 @@ steps:
   corresponding to the first matching statement:
 
   <dl class=switch>
+   <dt><var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> is not null
+
+   <dd>
+    <ol>
+     <li><p>Wait until <var>fetchParams</var>'s
+     <a for="fetch params">preloaded response candidate</a> is not "<code>pending</code>".
+
+     <li><p>Return <var>fetchParams</var>'s
+     <a for="fetch params">preloaded response candidate</a>.
+    </ol>
+
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is
    <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, and <var>request</var>'s
    <a for=request>response tainting</a> is "<code>basic</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -4052,6 +4052,9 @@ steps:
      <li><p>Wait until <var>fetchParams</var>'s
      <a for="fetch params">preloaded response candidate</a> is not "<code>pending</code>".
 
+     <li><p>Assert: <var>fetchParams</var>'s
+     <a for="fetch params">preloaded response candidate</a> is a <a for=/>response</a>.
+
      <li><p>Return <var>fetchParams</var>'s
      <a for="fetch params">preloaded response candidate</a>.
     </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3907,7 +3907,7 @@ the request.
 
    <li><p>If <var>foundPreloadedResource</var> is true and <var>fetchParams</var>'s
    <a for="fetch params">preloaded response candidate</a> is null, then set <var>fetchParams</var>'s
-   <a for="fetch params">preloaded response candidate</a> to "<code>pending</cpde>".</p></li>
+   <a for="fetch params">preloaded response candidate</a> to "<code>pending</code>".</p></li>
   </ol>
  </li>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3894,9 +3894,6 @@ the request.
    with <var>request</var>'s <a for=request>client</a>'s
    <a for="environment settings object">origin</a>.
 
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> to
-   "<code>pending</code>".
-
    <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
    step given a <a for=/>response</a> <var>response</var>: Set <var>fetchParams</var>'s
    <a for="fetch params">preloaded response candidate</a> to <var>response</var>.
@@ -3908,8 +3905,9 @@ the request.
    <var>req</var>'s <a for=request>integrity metadata</a>, and
    <var>onPreloadedResponseAvailable</var>.
 
-   <li><p>If <var>foundPreloadedResource</var> is false, then set <var>fetchParams</var>'s
-   <a for="fetch params">preloaded response candidate</a> to null.</p></li>
+   <li><p>If <var>foundPreloadedResource</var> is true and <var>fetchParams</var>'s
+   <a for="fetch params">preloaded response candidate</a> is null, then set <var>fetchParams</var>'s
+   <a for="fetch params">preloaded response candidate</a> to "<code>pending</cpde>".</p></li>
   </ol>
  </li>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3896,7 +3896,7 @@ the request.
 
    <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
    step given a <a for=/>response</a> <var>response</var>: set <var>fetchParams</var>'s
-   <span for="fetch params">preloaded response</span> to <var>response</var>.
+   <a for="fetch params">preloaded response</a> to <var>response</var>.
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking
    <a>consume a preloaded resource</a> for <var>req</var>'s <a for=request>window</a>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3891,9 +3891,16 @@ the request.
    with <var>request</var>'s <a for=request>client</a>'s
    <a for="environment settings object">origin</a>.
 
-   <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
-   step <a>in parallel</a> given a <a for=/>response</a> <var>response</var>: run
-   <a>fetch finale</a> given <var>response</var> and <var>fetchParams</var>.
+   <li>
+    <p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
+    step <a>in parallel</a> given a <a for=/>response</a> <var>response</var>: If
+    <a lt="Should response to request be blocked by Content Security Policy?"><var>response</var>
+    to <var>request</var> should not be blocked by Content Security Policy</a>, then return; Otherwise
+    run <a>fetch finale</a> given <var>response</var> and <var>fetchParams</var>.</p>
+
+    <p class=note>An additional CSP check is necessary here as it is possible that new CSP
+    directives were hadded after the preload was initiated, e.g. by a <code>meta</code> element.</p>
+   </li>
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking
    <a>consume a preloaded resource</a> for <var>req</var>'s <a for=request>window</a>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -215,6 +215,9 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
+
+ <dt><dfn export for="fetch params">preloaded response</dfn> (default "<code>pending</code>")
+ <dd>Null, "<code>pending</code>", or a <a for=/>response</a>.
 </dl>
 
 <p>A <dfn export>fetch controller</dfn> is a <a for=/>struct</a> used to enable callers of
@@ -3891,25 +3894,9 @@ the request.
    with <var>request</var>'s <a for=request>client</a>'s
    <a for="environment settings object">origin</a>.
 
-   <li>
-    <p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
-    steps <a>in parallel</a> given a <a for=/>response</a> <var>response</var>:
-
-    <ol>
-     <li>
-      <p>If
-      <a lt="Should response to request be blocked by Content Security Policy?"><var>response</var>
-      to <var>request</var> should be blocked by Content Security Policy</a>, then set
-      <var>response</var> to a <span>network error</span>.</p>
-
-      <p class=note>An additional CSP check is necessary here as it is possible that new CSP
-      directives were added after the preload was initiated, e.g. by appending a <code>meta</code>
-      element to the document.</p>
-     </li>
-
-     <li><p>Run <a>fetch finale</a> given <var>response</var> and <var>fetchParams</var>.</p></li>
-    </ol>
-   </li>
+   <li><p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
+   step given a <a for=/>response</a> <var>response</var>: set <var>fetchParams</var>'s
+   <span for="fetch params">preloaded response</span> to <var>response</var>.
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking
    <a>consume a preloaded resource</a> for <var>req</var>'s <a for=request>window</a>,
@@ -3918,7 +3905,8 @@ the request.
    <var>req</var>'s <a for=request>integrity metadata</a>, and
    <var>onPreloadedResponseAvailable</var>.
 
-   <li><p>If <var>foundPreloadedResource</var> is true, then return.
+   <li><p>If <var>foundPreloadedResource</var> is false, then set <var>fetchParams</var>'s
+   <a for="fetch params">preloaded response</a> to null.
   </ol>
  </li>
 
@@ -4004,7 +3992,12 @@ steps:
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
- <li><p>Let <var>response</var> be null.
+ <li><p>If <var>fetchParams</var>'s <a for="fetch params">preloaded response</a> is
+ "<code>pending</code>", then wait until <var>fetchParams</var>'s
+ <a for="fetch params">preloaded response</a> is null or a <a for=/>response</a>.
+
+ <li><p>Let <var>response</var> be <var>fetchParams</var>'s
+ <a for="fetch params">preloaded response</a>.
 
  <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
  <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a

--- a/fetch.bs
+++ b/fetch.bs
@@ -3893,13 +3893,22 @@ the request.
 
    <li>
     <p>Let <var>onPreloadedResponseAvailable</var> be an algorithm that runs the following
-    step <a>in parallel</a> given a <a for=/>response</a> <var>response</var>: If
-    <a lt="Should response to request be blocked by Content Security Policy?"><var>response</var>
-    to <var>request</var> should not be blocked by Content Security Policy</a>, then return; Otherwise
-    run <a>fetch finale</a> given <var>response</var> and <var>fetchParams</var>.</p>
+    steps <a>in parallel</a> given a <a for=/>response</a> <var>response</var>:
 
-    <p class=note>An additional CSP check is necessary here as it is possible that new CSP
-    directives were hadded after the preload was initiated, e.g. by a <code>meta</code> element.</p>
+    <ol>
+     <li>
+      <p>If
+      <a lt="Should response to request be blocked by Content Security Policy?"><var>response</var>
+      to <var>request</var> should be blocked by Content Security Policy</a>, then set
+      <var>response</var> to a <span>network error</span>.</p>
+
+      <p class=note>An additional CSP check is necessary here as it is possible that new CSP
+      directives were added after the preload was initiated, e.g. by appending a <code>meta</code>
+      element to the document.</p>
+     </li>
+
+     <li><p>Run <a>fetch finale</a> given <var>response</var> and <var>fetchParams</var>.</p></li>
+    </ol>
    </li>
 
    <li><p>Let <var>foundPreloadedResource</var> be the result of invoking


### PR DESCRIPTION
Closes https://github.com/whatwg/html/issues/7686
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Implemented in WebKit & Chromiun
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/33109
   * https://github.com/web-platform-tests/wpt/pull/33205
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: N/A
   * Firefox: [1759002](https://bugzilla.mozilla.org/show_bug.cgi?id=1759002)
   * Safari: [238019](https://bugs.webkit.org/show_bug.cgi?id=238019)

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1411.html" title="Last updated on Mar 17, 2022, 1:07 PM UTC (808cb65)">Preview</a> | <a href="https://whatpr.org/fetch/1411/4561d5f...808cb65.html" title="Last updated on Mar 17, 2022, 1:07 PM UTC (808cb65)">Diff</a>