### PR TITLE
Call `finalize and report timing` automatically on end-of-body

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3803,8 +3803,8 @@ an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (def
 optional null or string <dfn export for=fetch><var>initiatorType</var></dfn> (default null),
 and an optional "<code>client</code>" or a <a for=/>global object</a>
 <dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
-below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm acceptin an integer
-representing the number of bytes transmitted. If given <var>processRequestEndOfBody</var> must be an
+below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting an integer
+representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be an
 algorithm accepting no arguments. If given, <var>processEarlyHintsResponse</var> must be an
 algorithm accepting a <a for=/>response</a>. If given, <var>processResponse</var> must be an
 algorithm accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be

--- a/fetch.bs
+++ b/fetch.bs
@@ -237,7 +237,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a>fetch controller</a> <var>controller</var> given a <a for=/>global object</a> <var>global</var>:
 
 <ol>
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">report timing steps</a> is not null.
+ <li><p><a for=/>Assert</a>: <a>this</a>'s <a for="fetch controller">report timing steps</a> is not
+ null.
 
  <li><p>Call <a>this</a>'s <a for="fetch controller">report timing steps</a> with <var>global</var>.
 </ol>
@@ -246,7 +247,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 given a <a>fetch controller</a> <var>controller</var>:
 
 <ol>
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">full timing info</a> is not null.
+ <li><p><a for=/>Assert</a>: <a>this</a>'s <a for="fetch controller">full timing info</a> is not
+ null.
 
  <li><p>Return <a>this</a>'s <a for="fetch controller">full timing info</a>.
 </ol>
@@ -1443,6 +1445,8 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 "<code>video</code>",
 "<code>xmlhttprequest</code>", or
 "<code>other</code>". Unless stated otherwise it is null. [[RESOURCE-TIMING]]
+<!-- See https://github.com/whatwg/fetch/issues/1452 and
+         https://github.com/w3c/resource-timing/issues/132 for future work -->
 
 <div class=note>
  <p>This determines which service workers will receive a {{fetch!!event}} event for this fetch.
@@ -4369,7 +4373,7 @@ steps:
      <li>
       <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
       then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-      <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
+      <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>, and
       set <var>cacheState</var> to the empty string.
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
@@ -4386,21 +4390,21 @@ steps:
     <p>Let <var>processResponseEndOfBodyTask</var> be the following steps:
 
     <ol>
+     <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+     <a for=request>done flag</a>.
+
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is
-     not null, then call <var>fetchParams</var>'s
+     non-null, then run <var>fetchParams</var>'s
      <a for="fetch params">process response end-of-body</a> given <var>response</var>.
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-     <a for="request">initiator type</a> is not null and <var>fetchParams</var>'s
-     <a for="fetch params">request</a>'s <a for=request>client</a> is not null, then
-     run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+     <a for="request">initiator type</a> is non-null and <var>fetchParams</var>'s
+     <a for="fetch params">request</a>'s <a for=request>client</a> is non-null, then run
+     <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
      <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>client</a>'s
      <a for="environment settings object">global object</a> and <a for="fetch params">request</a>'s
      <a for="request">initiator type</a>.
-
-     <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-     <a for=request>done flag</a>.
     </ol>
 
    <li><p><a>Queue a fetch task</a> to run <var>processResponseEndOfBodyTask</var> with

--- a/fetch.bs
+++ b/fetch.bs
@@ -3845,7 +3845,12 @@ the request.
    <li><p>Set <var>crossOriginIsolatedCapability</var> to <var>request</var>'s
    <a for=request>client</a>'s
    <a for="environment settings object">cross-origin isolated capability</a>.
+
+   <li><p>Set <var>timingGlobal</var> to <var>request</var>'s <a for=request>client</a>'s
+   <a for="environment settings object">global object</a>.
   </ol>
+
+ <li><p>Assert: <var>timingGlobal</var> is null or a <a for=/>global object</a>.
 
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
@@ -3854,10 +3859,6 @@ the request.
       works for all callers. Fetch itself calls main fetch while taskDestination is null. Anyone
       wanting to do a ping without request body might do so as well, but if you do have a request
       body you definitely need this as otherwise transmit-request-body loop breaks down. -->
-
- <li><p>If <var>timingGlobal</var> is "<code>client</code>", then set <var>timingGlobal</var> to
- <var>request</var>'s <a for=request>client</a>'s <a
- for="environment settings object">global object</a>.
 
  <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
  <a for="fetch timing info">start time</a> and
@@ -4343,9 +4344,9 @@ steps:
     <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
     <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
-    <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s <a
-    for="fetch controller">report timing steps</a> to the following steps given a <a
-    for=/>global object</a> <var>global</var>:
+    <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+    <a for="fetch controller">report timing steps</a> to the following steps given a
+    <a for=/>global object</a> <var>global</var>:
 
     <ol>
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -246,6 +246,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a for=/>response</a> <var>finalResponse</var> (default "<code>original</code>"):</p>
 
 <ol>
+ <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
+
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>responding</code>".
 
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
@@ -4330,8 +4332,8 @@ steps:
 
    <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
 
-   <li><p>If <var>request</var>'s <a for=request>URL</a>'s <a for=url>scheme</a> is not an
-   <a>HTTP(S) scheme</a>, then return.
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
+   <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
 
    <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
    <a for="fetch params">timing info</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -300,9 +300,9 @@ information needed by <cite>Resource Timing</cite> and <cite>Navigation Timing</
 following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
 <dl>
- <dt><dfn export for="response body info" id="fetch-timing-info-encoded-body-size">encoded body
+ <dt><dfn export for="response body info" id="fetch-timing-info-encoded-body-size">encoded
  size</dfn> (default 0)
- <dt><dfn export for="response body info" id="fetch-timing-info-decoded-body-size">decoded body
+ <dt><dfn export for="response body info" id="fetch-timing-info-decoded-body-size">decoded
  size</dfn> (default 0)
  <dd>A number.
 </dl>
@@ -3801,7 +3801,7 @@ algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an op
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
 an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), an
 optional null or string <dfn export for=fetch><var>initiatorType</var></dfn> (default null),
-and an optional "<code>client</code>" or a <a for=/>global object</a>
+and an optional "<code>client</code>", "<code>none</code>",  or a <a for=/>global object</a>
 <dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
 below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting an integer
 representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be an
@@ -3850,7 +3850,7 @@ the request.
    <a for="environment settings object">global object</a>.
   </ol>
 
- <li><p>Assert: <var>timingGlobal</var> is null or a <a for=/>global object</a>.
+ <li><p>Assert: <var>timingGlobal</var> is "<code>none</code>" or a <a for=/>global object</a>.
 
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
@@ -4354,7 +4354,7 @@ steps:
 
      <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
      <a>relative high resolution time</a> given <var>unsafeEndTime</var> and
-     <var>global</var>.</p></li>
+     <var>global</var>.
 
      <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
@@ -4367,7 +4367,6 @@ steps:
       set <var>cacheState</var> to the empty string.
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
-     </li>
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null, then
      <a for=/>mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
@@ -4379,10 +4378,10 @@ steps:
 
    <li>
     <p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null and
-    <var>fetchParams</var>'s <a for="fetch params">timing global</a> is not null, then
-    <a>queue a fetch task</a> to run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-    <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
-    <a for="fetch params">timing global</a> and <var>fetchParams</var>'s
+    <var>fetchParams</var>'s <a for="fetch params">timing global</a> is not "<code>none</code>",
+    then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
+    <a for="fetch params">controller</a>'s <a for="fetch controller">report timing steps</a> given
+    <var>fetchParams</var>'s <a for="fetch params">timing global</a> and <var>fetchParams</var>'s
     <a for="fetch params">initiator type</a>, with<var>fetchParams</var>'s
     <a for="fetch params">timing global</a>.
    </li>
@@ -5704,7 +5703,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
          <li><p>Increase <var>response</var>'s <a for=response>body info</a>'s
-         <a for="response body info">encoded body size</a> by <var>bytes</var>'s
+         <a for="response body info">encoded size</a> by <var>bytes</var>'s
          <a for="byte sequence">length</a>.
 
          <li>
@@ -5715,7 +5714,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
           unreliable to the extent that it was reliable to begin with.
 
          <li><p>Increase <var>response</var>'s <a for=response>body info</a>'s
-         <a for="response body info">decoded body size</a> by
+         <a for="response body info">decoded size</a> by
          <var>bytes</var>'s <a for="byte sequence">length</a>.
 
          <li><p>If <var>bytes</var> is failure, then <a for="fetch controller">terminate</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4344,9 +4344,6 @@ steps:
   <ol>
    <li><p>Let <var>unsafeEndTime</var> be the <a>unsafe shared current time</a>.
 
-   <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-   <a for=request>done flag</a>.
-
    <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
    <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
    <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
@@ -4385,20 +4382,28 @@ steps:
      <var>bodyInfo</var>.
     </ol>
 
-   <li><p>Let <var>client</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-   <a for=request>client</a>.
+   <li>
+    <p>Let <var>processResponseEndOfBodyTask</var> be the following steps:
 
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-   <a for="request">initiator type</a> is not null and <var>client</var> is not null, then
-   <a>queue a fetch task</a> to run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-   <a for="fetch controller">report timing steps</a> given <var>client</var>'s
-   <a for="environment settings object">global object</a> and <a for="fetch params">request</a>'s
-   <a for="request">initiator type</a>, with <var>client</var>'s
-   <a for="environment settings object">global object</a>.
+    <ol>
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is
+     not null, then call <var>fetchParams</var>'s
+     <a for="fetch params">process response end-of-body</a> given <var>response</var>.
 
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is not
-   null, then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
-   <a for="fetch params">process response end-of-body</a> given <var>response</var> with
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+     <a for="request">initiator type</a> is not null and <var>fetchParams</var>'s
+     <a for="fetch params">request</a>'s <a for=request>client</a> is not null, then
+     run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+     <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
+     <a for="fetch params">request</a>'s <a for=request>client</a>'s
+     <a for="environment settings object">global object</a> and <a for="fetch params">request</a>'s
+     <a for="request">initiator type</a>.
+
+     <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+     <a for=request>done flag</a>.
+    </ol>
+
+   <li><p><a>Queue a fetch task</a> to run <var>processResponseEndOfBodyTask</var> with
    <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
   </ol>
  </li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5285,7 +5285,7 @@ steps. They return a <a for=/>response</a>.
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
 
-      <p class=note><var>forwardResponse</var>'s <a for=response>body info</a> should be stored
+      <p><var>The user agent should store <var>forwardResponse</var>'s <a for=response>body info</a>
       as part of the response.
     </ol>
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -205,6 +205,12 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
+ <dt><dfn for="fetch params">initiator type</dfn> (default "<code>other</code>")
+ <dd>A string.
+
+ <dt><dfn for="fetch params">timing global</dfn> (default null)
+ <dd>Null or a <a for=/>global object</a>.
+
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
@@ -225,9 +231,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <dl>
  <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
  <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
-
- <dt><dfn for="fetch controller">report timing steps</dfn> (default null)
- <dd>Null or an algorithm responsible for reporting timing information.
 </dl>
 
 <p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
@@ -237,27 +240,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <p>To <dfn export for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
 <var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
 "<code>terminated</code>".
-
-<p>To <dfn export for="fetch controller" id="finalize-and-report-timing">report timing</dfn> for a
-<a for=/>fetch controller</a> <var>controller</var>, perform the following steps given an optional
-string <var>initiatorType</var> (default "<code>other</code>"), an optional "<code>client</code>" or
-<a for=/>global object</a> <var>global</var> (default "<code>client</code>"), an optional
-"<code>original</code>" or <a for=/>response</a> <var>finalResponse</var> (default
-"<code>original</code>"), and an optional "<code>now</code>" or {{DOMHighResTimeStamp}}
-<var>unsafeResponseEndTime</var> (default "<code>now</code>"):</p>
-
-<ol>
- <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
-
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">report timing steps</a> is not null.
-
- <li><p>If <var>unsafeResponseEndTime</var> is "<code>now</code>", then set
- <var>unsafeResponseEndTime</var> to the <a>unsafe shared current time</a>.
-
- <li><p>Invoke <a>this</a>'s <a for="fetch controller">report timing steps</a> with
- <var>initiatorType</var>, <var>global</var>, <var>finalResponse</var>, and
- <var>unsafeResponseEndTime</var>.
-</ol>
 
 <p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">aborted</dfn> if
 its <a for="fetch params">controller</a>'s <a for="fetch controller">state</a> is
@@ -3793,15 +3775,18 @@ an optional algorithm <dfn export for=fetch><var>processEarlyHintsResponse</var>
 algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an optional
 algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
-and an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run
-the steps below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting
-an integer representing the number of bytes transmitted. If given,
-<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments. If given,
-<var>processEarlyHintsResponse</var> must be an algorithm accepting a <a for=/>response</a>. If
-given, <var>processResponse</var> must be an algorithm accepting a <a for=/>response</a>. If given,
-<var>processResponseEndOfBody</var> must be an algorithm accepting a <a for=/>response</a>. If
-given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
-and null, failure, or a <a for=/>byte sequence</a>.
+an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), an
+optional string <dfn export for=fetch><var>initiatorType</var></dfn> (default "<code>other</code>"),
+and an optional "<code>client</code>", "<code>none</code>" or a <a for=/>global object</a>
+<dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
+below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm acceptin an integer
+representing the number of bytes transmitted. If given <var>processRequestEndOfBody</var> must be an
+algorithm accepting no arguments. If given, <var>processEarlyHintsResponse</var> must be an
+algorithm accepting a <a for=/>response</a>. If given, <var>processResponse</var> must be an
+algorithm accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be
+an algorithm accepting a <a for=/>response</a>. If given, <var>processResponseConsumeBody</var> must
+be an algorithm accepting a <a for=/>response</a> and null, failure, or a
+<a for=/>byte sequence</a>.
 
 <p>The user agent may be asked to
 <dfn export for=fetch id=concept-fetch-suspend>suspend</dfn> the ongoing fetch.
@@ -3842,6 +3827,10 @@ the request.
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
 
+ <li><p>If <var>timingGlobal</var> is "<code>client</code>", then set <var>timingGlobal</var>
+ to <var>request</var>'s <a for=request>client</a>'s
+ <a for="environment settings object">global object</a>.
+
  <!-- It would be nice to assert that taskDestination is non-null here, but it's not clear if this
       works for all callers. Fetch itself calls main fetch while taskDestination is null. Anyone
       wanting to do a ping without request body might do so as well, but if you do have a request
@@ -3856,6 +3845,8 @@ the request.
  <a for="fetch params">request</a> is <var>request</var>,
  <a for="fetch params">timing info</a> is <var>timingInfo</var>,
  <a for="fetch params">controller</a> is <var>controller</var>,
+ <a for="fetch params">initiator type</a> is <var>initiatorType</var>,
+ <a for="fetch params">timing global</a> is <var>timingGlobal</var>,
  <a for="fetch params">process request body chunk length</a> is
  <var>processRequestBodyChunkLength</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
@@ -4318,52 +4309,41 @@ steps:
   <p>Let <var>processResponseEndOfBody</var> be the following steps:
 
   <ol>
+   <li><p>Let <var>unsafeEndTime</var> be the <a>unsafe shared current time</a>.
+
    <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
    <a for=request>done flag</a>.
 
+   <li><p>Let <var>global</var> be <var>fetchParams</var>'s <a for="fetch params">timing global</a>.
+
    <li>
-    <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-    <a for="fetch controller">report timing steps</a> to the following steps given a string
-    <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
-    <var>global</var>, an "<code>original</code>" or <a for=/>response</a>
-    <var>finalResponse</var>, and a {{DOMHighResTimeStamp}} <var>unsafeResponseEndTime</var>:
+    <p>If <var>global</var> is not null, then <a>queue a fetch task</a> given
+    <var>fetchParams</var>'s <a for="fetch params">timing global</a> to run the following steps:
 
     <ol>
-     <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
-     <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
-     <a for="environment settings object">global object</a>.
-
-     <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
-     to <var>response</var>.
-
-     <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
-
-     <li><p>Assert: <var>finalResponse</var> is <var>response</var> or a <a>network error</a>.
-
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
      <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
+
+     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
+     <a>relative high resolution time</a> given <var>unsafeEndTime</var> and
+     <var>global</var>.</p></li>
 
      <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
      <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
 
      <li>
-      <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
+      <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
       then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
       <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
       set <var>cacheState</var> to the empty string.
 
-      <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
+      <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
      </li>
 
-     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
-     <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
-     <a>relevant settings object</a>'s
-     <a for="environment settings object">cross-origin isolated capability</a>.
-
      <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-     <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
-     and <var>bodyInfo</var>.
+     <a for=request>URL</a>, <var>fetchParams</var>'s <a for="fetch params">initiator type</a>,
+     <var>global</var>, <var>cacheState</var>, and <var>bodyInfo</var>.
     </ol>
    </li>
 
@@ -7714,14 +7694,10 @@ method steps are:
    <var>controller</var>.
   </ol>
 
- <li><p>Let <var>handleFetchDone</var> be to
- <a for="fetch controller">report timing</a> for <var>controller</var> given "<code>fetch</code>".
-
  <li>
   <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given
-  <var>request</var>, with <a for=fetch><i>processResponseEndOfBody</i></a> set to
-  <var>handleFetchDone</var>, and <a for=fetch><i>processResponse</i></a> given <var>response</var>
-  being these substeps:
+  <var>request</var>, with <a for=fetch><i>initiatorType</i></a> set to "<code>fetch</code>, and
+  <a for=fetch><i>processResponse</i></a> given <var>response</var> being these substeps:
 
   <ol>
    <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
@@ -8206,6 +8182,16 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  <dt><a for=fetch><i>useParallelQueue</i></a>
  <dd><p>Takes a <a for=/>boolean</a> that defaults to false. Indicates where the algorithms passed
  as arguments will be invoked. Hopefully most standards will not need this.
+
+ <dt><a for=fetch><i>initiatorType</i></a>
+ <dd><p>Takes a string that defaults to "<code>other</code>", to indicate the
+ {{PerformanceResourceTiming/initiatorType}} for <cite>Resource Timing</cite>. [[RESOURCE-TIMING]]
+
+ <dt><a for=fetch><i>timingGlobal</i></a>
+ <dd><p>Takes "<code>client</code>", "<code>none</code>" or a <a for=/>global object</a> (default
+ "<code>client</code>"). Indicates which <a for=/>global object</a> is used for enqueuing the
+ {{PerformanceResourceTiming}} entry. If "<code>none</code>" is passed, the entry is not reported.
+ [[RESOURCE-TIMING]]
 </dl>
 
 <p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>. The

--- a/fetch.bs
+++ b/fetch.bs
@@ -4338,12 +4338,12 @@ steps:
    <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
    <a for=request>done flag</a>.
 
-   <li>
-    <p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-    <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
-    <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
-    <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+   <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
+   <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
+   <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
+   <li>
     <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
     <a for="fetch controller">report timing steps</a> to the following steps given a
     <a for=/>global object</a> <var>global</var>:

--- a/fetch.bs
+++ b/fetch.bs
@@ -208,11 +208,11 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">controller</dfn> (default a new <a for=/>fetch controller</a>)
- <dd>A <a for=/>fetch controller</a>.
-
  <dt><dfn for="fetch params">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
+
+ <dt><dfn for="fetch params">controller</dfn>
+ <dd>A <a for=/>fetch controller</a>.
 
  <dt><dfn export for="fetch params">preloaded response candidate</dfn> (default null)
  <dd>Null, "<code>pending</code>", or a <a for=/>response</a>.
@@ -227,6 +227,9 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dd>"<code>requesting</code>", "<code>responding</code>", "<code>concluded</code>",
  "<code>terminated</code>", or "<code>aborted</code>"
 
+ <dt><dfn for="fetch controller">timing info</dfn>
+ <dd>A <a for=/>fetch timing info</a>
+
  <dt><dfn for="fetch controller">conclude steps</dfn> (default null)
  <dd>Null or an algorithm responsible for finalizing the fetch and reporting timing information
 </dl>
@@ -240,10 +243,11 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 "<code>terminated</code>".
 
 <p>To <dfn export for="fetch controller" id="finalize-and-report-timing">conclude</dfn> a
-<a for=/>fetch controller</a> <var>controller</var>, perform the following steps given a string
-<var>initiatorType</var>, an optional "<code>client</code>" or <a for=/>global object</a>
-<var>global</var> (default "<code>client</code>"), and an optional "<code>original</code>" or
-<a for=/>response</a> <var>finalResponse</var> (default "<code>original</code>"):</p>
+<a for=/>fetch controller</a> <var>controller</var>, perform the following steps given an optional
+string <var>initiatorType</var> (default "<code>other</code>"), an optional "<code>client</code>" or
+<a for=/>global object</a> <var>global</var> (default "<code>client</code>"), and an optional
+"<code>original</code>" or <a for=/>response</a> <var>finalResponse</var> (default
+"<code>original</code>"):</p>
 
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
@@ -282,15 +286,21 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dt><dfn export for="fetch timing info">end time</dfn> (default 0)
  <dd>A {{DOMHighResTimeStamp}}.
 
- <dt><dfn export for="fetch timing info">encoded body size</dfn> (default 0)
- <dt><dfn export for="fetch timing info">decoded body size</dfn> (default 0)
- <dd>A number.
-
  <dt><dfn export for="fetch timing info">final connection timing info</dfn> (default null)
  <dd>Null or a <a for=/>connection timing info</a>.
 
  <dt><dfn export for="fetch timing info">server-timing headers</dfn> (default « »)
  <dd>A <a for=/>list</a> of strings.
+</dl>
+
+<p>A <dfn export>fetch resource info</dfn> is a <a for=/>struct</a> used to maintain
+information needed by <cite>Resource Timing</cite> and <cite>Navigation Timing</cite>. It has the
+following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
+
+<dl>
+ <dt><dfn export for="fetch resource info">encoded body size</dfn> (default 0)
+ <dt><dfn export for="fetch resource info">decoded body size</dfn> (default 0)
+ <dd>A number.
 </dl>
 
 <p>To
@@ -299,22 +309,6 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
 <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
 <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
 <a for="fetch timing info">start time</a>.
-
-<p>To <dfn>update timing info from stored response</dfn>, given a
-<a for=/>connection timing info</a> <var>timingInfo</var> and a <a for=/>response</a>
-<var>response</var>, perform the following steps:
-
-<ol>
- <li><p>Let <var>storedTimingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
-
- <li><p>If <var>storedTimingInfo</var> is null, then return.
-
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a> to
- <var>storedTimingInfo</var>'s <a for="fetch timing info">encoded body size</a>.
-
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> to
- <var>storedTimingInfo</var>'s <a for="fetch timing info">decoded body size</a>.
-</ol>
 
 <p>To <dfn>queue a fetch task</dfn>, given an algorithm <var>algorithm</var>, a
 <a for=/>global object</a> or a <a for=/>parallel queue</a> <var>taskDestination</var>, run these
@@ -2111,6 +2105,11 @@ message as HTTP/2 does not support them.
 "<code>local</code>", or "<code>validated</code>"). Unlesss stated otherwise, it is the empty
 string.
 
+<p>A <a for=/>response</a> has an associated
+<dfn export for=response id=concept-response-resource-info>resource info</dfn>
+(a <a for=/>fetch resource info</a>). Unlesss stated otherwise, it is a new
+<a for=/>fetch resource info</a>.
+
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
 <cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]
 <!-- If we ever expand the utility of this we need to carefully consider whether filtered responses
@@ -2145,10 +2144,6 @@ initially unset.
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
 the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
-
-<p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-info>timing info</dfn> (null or a
-<a for=/>fetch timing info</a>), which is initially null.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response>service worker timing info</dfn> (null or a
@@ -3859,9 +3854,13 @@ the request.
  <a for="fetch timing info">post-redirect start time</a> are the
  <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>.
 
+ <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> whose
+ <a for="fetch controller">timing info</a> is <var>timingInfo</var>.
+
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
  <a for="fetch params">request</a> is <var>request</var>,
  <a for="fetch params">timing info</a> is <var>timingInfo</var>,
+ <a for="fetch params">controller</a> is <var>controller</var>,
  <a for="fetch params">process request body chunk length</a> is
  <var>processRequestBodyChunkLength</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
@@ -4310,8 +4309,6 @@ steps:
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
  <a for="fetch params">timing info</a>.</p></li>
 
- <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.</p></li>
-
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
   <a for="fetch controller">state</a> to "<code>responding</code>".
 
@@ -4340,10 +4337,13 @@ steps:
 
    <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
+   <li><p>Let <var>resourceInfo</var> be <var>response</var>'s <a for=response>resource info</a>.
+
    <li>
     <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
     then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-    <var>timingInfo</var> and set <var>cacheState</var> to the empty string.
+    <var>timingInfo</var>, set <var>resourceInfo</var> to a new <a for=/>fetch resource info</a> and
+    set <var>cacheState</var> to the empty string.
 
     <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
    </li>
@@ -4354,7 +4354,8 @@ steps:
    <a for="environment settings object">cross-origin isolated capability</a>.
 
    <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-   <a for=request>URL</a> <var>initiatorType</var>, <var>global</var>, and <var>cacheState</var>.
+   <a for=request>URL</a> <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
+   and <var>resourceInfo</var>.
   </ol>
 
  <li>
@@ -4433,49 +4434,6 @@ steps:
    <a for="fetch params">task destination</a>.
   </ol>
 </ol>
-
-<p>To <dfn export>finalize and report timing</dfn> given a <a for=/>response</a>
-<var>response</var>, a <a for=/>global object</a> <var>global</var>, and a <a for=/>string</a>
-<var>initiatorType</var> (default "<code>other</code>"), run these steps:
-
-<ol>
- <li><p>If <var>response</var> is an <a>aborted network error</a>, then return.
-
- <li><p>If <var>response</var>'s <a for=response>URL list</a> is null or
- <a for=list lt="is empty">empty</a>, then return.
-
- <li><p>Let <var>originalURL</var> be <var>response</var>'s <a for=response>URL list</a>[0].
-
- <li><p>Let <var>timingInfo</var> be <var>response</var>'s <a for=response>timing info</a>.
-
- <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
-
- <li><p>If <var>originalURL</var>'s <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then
- return.
-
- <li><p>If <var>timingInfo</var> is null, then return.
-
- <li>
-  <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set, then:
-
-  <ol>
-   <li><p>Set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-   <var>timingInfo</var>.
-
-   <li><p>Set <var>cacheState</var> to the empty string.
-  </ol>
-
- <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
- <a for=/>coarsened shared current time</a> given <var>global</var>'s
- <a>relevant settings object</a>'s
- <a for="environment settings object">cross-origin isolated capability</a>.
-
- <li><p>Set <var>response</var>'s <a for="response">timing info</a> to <var>timingInfo</var>.
-
- <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>originalURL</var>,
- <var>initiatorType</var>, <var>global</var>, and <var>cacheState</var>.
-</ol>
-
 
 <h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
@@ -4646,9 +4604,6 @@ these steps:
      <a for="fetch timing info">final service worker start time</a> to
      <var>serviceWorkerStartTime</var>.
 
-     <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
-     <a for="fetch params">timing info</a> and <var>response</var>.
-
      <li>If <var>request</var>'s <a for=request>body</a> is non-null, then
      <a for=ReadableStream>cancel</a> <var>request</var>'s <a for=request>body</a> with undefined.
 
@@ -4780,15 +4735,7 @@ these steps:
     </dl>
     <!-- not resetting actualResponse since it's no longer used anyway -->
   </ol>
-
- <li>
-  <p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.
-
-  <p class=note>Attaching the timing info to a response is what makes it exposed to the web as a
-  Resource Timing entry later. This step is done here, as resource-timing entries are available only
-  for HTTP fetches, including ones that are handled by service-workers or HTTP cache, and not for,
-  e.g., <code>data:</code>, <code>blob:</code> URL fetches, and are only available after all the
-  relevant security checks have succeeded.
+ </li>
 
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s
@@ -5315,9 +5262,6 @@ steps. They return a <a for=/>response</a>.
      <li><p>Set <var>response</var> to <var>storedResponse</var>.
 
      <li><p>Set <var>response</var>'s <a for=response>cache state</a> to "<code>validated</code>".
-
-     <li><p><a for=/>Update timing info from stored response</a> given <var>fetchParams</var>'s
-     <a for="fetch params">timing info</a> and <var>response</var>.
     </ol>
 
    <li>
@@ -5333,9 +5277,6 @@ steps. They return a <a for=/>response</a>.
 
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
-
-      <p class=note>The associated <a for=response>timing info</a> is stored in the cache
-      alongside the response.
     </ol>
   </ol>
 
@@ -5748,8 +5689,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
          `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
-         <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">encoded body size</a>
-         by <var>bytes</var>'s <a for="byte sequence">length</a>.
+         <li><p>Increase <var>response</var>'s <a for=response>resource info</a>'s
+         <a for="fetch resource info">encoded body size</a> by <var>bytes</var>'s
+         <a for="byte sequence">length</a>.
 
          <li>
           <p>Set <var>bytes</var> to the result of <a lt="handle content codings">handling content
@@ -5758,7 +5700,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
           <p class="note no-backref">This makes the `<code>Content-Length</code>` <a for=/>header</a>
           unreliable to the extent that it was reliable to begin with.
 
-         <li><p>Increase <var>timingInfo</var>'s <a for="fetch timing info">decoded body size</a> by
+         <li><p>Increase <var>response</var>'s <a for=response>resource info</a>'s
+         <a for="fetch resource info">decoded body size</a> by
          <var>bytes</var>'s <a for="byte sequence">length</a>.
 
          <li><p>If <var>bytes</var> is failure, then <a for="fetch controller">terminate</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4319,6 +4319,9 @@ steps:
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
  <a for="fetch controller">state</a> to "<code>transmitting</code>".
 
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
+ <a for="fetch params">timing info</a>.
+
  <li>
   <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
   <a for="fetch controller">conclude steps</a> to the following steps given a string
@@ -4338,9 +4341,6 @@ steps:
 
    <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
    <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
-
-   <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
-   <a for="fetch params">timing info</a>.
 
    <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
@@ -4367,8 +4367,8 @@ steps:
 
  <li>
   <p>Otherwise, if <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-  <a for=request>client</a> is a <a>secure context</a>, set <var>response</var>'s
-  <a for=response>timing info</a>'s <a for="fetch timing info">server-timing headers</a> to the
+  <a for=request>client</a> is a <a>secure context</a>, set <var>timingInfo</var>'s
+  <a for="fetch timing info">server-timing headers</a> to the
   result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
   from <var>response</var>'s <a for=response>header list</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -208,11 +208,11 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">timing info</dfn>
- <dd>A <a for=/>fetch timing info</a>.
-
  <dt><dfn for="fetch params">controller</dfn>
  <dd>A <a for=/>fetch controller</a>.
+
+ <dt><dfn for="fetch params">timing info</dfn>
+ <dd>A <a for=/>fetch timing info</a>.
 
  <dt><dfn export for="fetch params">preloaded response candidate</dfn> (default null)
  <dd>Null, "<code>pending</code>", or a <a for=/>response</a>.
@@ -234,10 +234,10 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
   contexts.</p>
 
  <dt><dfn for="fetch controller">timing info</dfn>
- <dd>A <a for=/>fetch timing info</a>
+ <dd>A <a for=/>fetch timing info</a>.
 
  <dt><dfn for="fetch controller">conclude steps</dfn> (default null)
- <dd>Null or an algorithm responsible for finalizing the fetch and reporting timing information
+ <dd>Null or an algorithm responsible for finalizing the fetch and reporting timing information.
 </dl>
 
 <p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
@@ -4367,7 +4367,7 @@ steps:
    <a for="environment settings object">cross-origin isolated capability</a>.
 
    <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-   <a for=request>URL</a> <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
+   <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
    and <var>bodyInfo</var>.
   </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4403,8 +4403,7 @@ steps:
      <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
      <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>client</a>'s
-     <a for="environment settings object">global object</a> and <a for="fetch params">request</a>'s
-     <a for="request">initiator type</a>.
+     <a for="environment settings object">global object</a>.
     </ol>
 
    <li><p><a>Queue a fetch task</a> to run <var>processResponseEndOfBodyTask</var> with

--- a/fetch.bs
+++ b/fetch.bs
@@ -245,9 +245,10 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <p>To <dfn export for="fetch controller" id="finalize-and-report-timing">conclude</dfn> a
 <a for=/>fetch controller</a> <var>controller</var>, perform the following steps given an optional
 string <var>initiatorType</var> (default "<code>other</code>"), an optional "<code>client</code>" or
-<a for=/>global object</a> <var>global</var> (default "<code>client</code>"), and an optional
+<a for=/>global object</a> <var>global</var> (default "<code>client</code>"), an optional
 "<code>original</code>" or <a for=/>response</a> <var>finalResponse</var> (default
-"<code>original</code>"):</p>
+"<code>original</code>"), and an optional "<code>now</code>" or {{DOMHighResTimeStamp}}
+<var>unsafeResponseEndTime</var>:</p>
 
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
@@ -256,8 +257,12 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
 
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
 
+ <li><p>If <var>unsafeResponseEndTime</var> is "<code>now</code>", then set
+ <var>unsafeResponseEndTime</var> to the <a>unsafe shared current time</a>.
+
  <li><p>Invoke <a>this</a>'s <a for="fetch controller">conclude steps</a> with
- <var>initiatorType</var> and <var>global</var>.
+ <var>initiatorType</var>, <var>global</var>, <var>finalResponse</var>, and
+ <var>unsafeResponseEndTime</var>.
 
  <li><p>Set <var>controller</var>'s <a for="fetch controller">state</a> to
  "<code>concluded</code>".
@@ -4316,8 +4321,8 @@ steps:
   <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
   <a for="fetch controller">conclude steps</a> to the following steps given a string
   <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
-  <var>global</var>, and an "<code>original</code>" or <a for=/>response</a>
-  <var>finalResponse</var>:
+  <var>global</var>, an "<code>original</code>" or <a for=/>response</a>
+  <var>finalResponse</var>, and a {{DOMHighResTimeStamp}} <var>unsafeResponseEndTime</var>:
 
   <ol>
    <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
@@ -4348,8 +4353,8 @@ steps:
     <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
    </li>
 
-   <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
-   <a for=/>coarsened shared current time</a> given <var>global</var>'s
+   <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
+   <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
    <a>relevant settings object</a>'s
    <a for="environment settings object">cross-origin isolated capability</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -223,8 +223,12 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a for=struct>items</a>:
 
 <dl>
- <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
- <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
+ <dt><dfn for="fetch controller">state</dfn> (default "<code>requesting</code>")
+ <dd>"<code>requesting</code>", "<code>responding</code>", "<code>concluded</code>",
+ "<code>terminated</code>", or "<code>aborted</code>"
+
+ <dt><dfn for="fetch controller">conclude steps</dfn> (default null)
+ <dd>Null or an algorithm responsible for finalizing the fetch and reporting timing information
 </dl>
 
 <p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
@@ -234,6 +238,24 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <p>To <dfn export for="fetch controller">terminate</dfn> a <a for=/>fetch controller</a>
 <var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
 "<code>terminated</code>".
+
+<p>To <dfn export for="fetch controller">conclude</dfn> a <a for=/>fetch controller</a>
+<var>controller</var>, perform the following steps given a string
+<var>initiatorType</var>, an optional "<code>client</code>" or <a for=/>global object</a>
+<var>global</var> (default "<code>client</code>"), and an optional "<code>original</code>" or
+<a for=/>response</a> <var>finalResponse</var> (default "<code>original</code>"):</p>
+
+<ol>
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>responding</code>".
+
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
+
+ <li><p>Invoke <a>this</a>'s <a for="fetch controller">conclude steps</a> with
+ <var>initiatorType</var> and <var>global</var>.
+
+ <li><p>Set <var>controller</var>'s <a for="fetch controller">state</a> to
+ "<code>concluded</code>".
+</ol>
 
 <p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">aborted</dfn> if
 its <a for="fetch params">controller</a>'s <a for="fetch controller">state</a> is
@@ -4283,22 +4305,54 @@ steps:
 <var>fetchParams</var> and a <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
+ <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
+ <a for="fetch params">timing info</a>.</p></li>
+
+ <li><p>Set <var>response</var>'s <a for=response>timing info</a> to <var>timingInfo</var>.</p></li>
+
+ <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+  <a for="fetch controller">state</a> to "<code>responding</code>".
+
  <li>
-  <p>If <var>response</var> is a <a>network error</a>, then:
+  <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+  <a for="fetch controller">conclude steps</a> to the following steps given a string
+  <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
+  <var>global</var>, and an "<code>original</code>" or <a for=/>response</a>
+  <var>finalResponse</var>:
 
   <ol>
-   <li>
-    <p>Set <var>response</var>'s <a for=response>URL list</a> to « <var>fetchParams</var>'s
-    <a for="fetch params">request</a>'s <a for=request>URL list</a>[0] ».
+   <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
+   <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
+   <a for="environment settings object">global object</a>.
 
-    <p class=note>This is needed as after <a for=list>cloning</a> <var>fetchParams</var>'s
-    <a for="fetch params">request</a>'s <a for=request>URL list</a> earlier, <var>response</var>
-    might have been set to a <a>network error</a>.</p>
+   <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
+   to <var>response</var>.
+
+   <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
+
+   <li><p>If <var>request</var>'s <a for=request>URL</a>'s <a for=url>scheme</a> is not an
+   <a>HTTP(S) scheme</a>, then return.
+
+   <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
+   <a for="fetch params">timing info</a>.
+
+   <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
+
+   <li>
+    <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
+    then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
+    <var>timingInfo</var> and set <var>cacheState</var> to the empty string.
+
+    <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
    </li>
 
-   <li><p>Set <var>response</var>'s <a for=response>timing info</a> to the result of
-   <a>creating an opaque timing info</a> for <var>fetchParams</var>'s
-   <a for="fetch params">timing info</a>.</p></li>
+   <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the
+   <a for=/>coarsened shared current time</a> given <var>global</var>'s
+   <a>relevant settings object</a>'s
+   <a for="environment settings object">cross-origin isolated capability</a>.
+
+   <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
+   <a for=request>URL</a> <var>initiatorType</var>, <var>global</var>, and <var>cacheState</var>.
   </ol>
 
  <li>
@@ -7721,9 +7775,8 @@ method steps are:
    <var>controller</var>.
   </ol>
 
- <li><p>Let <var>handleFetchDone</var> given <a for=/>response</a> <var>response</var> be to
- <a>finalize and report timing</a> with <var>response</var>, <var>globalObject</var>, and
- "<code>fetch</code>".
+ <li><p>Let <var>handleFetchDone</var> be to
+ <a for="fetch controller">conclude</a> <var>controller</var> given "<code>fetch</code>".
 
  <li>
   <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given

--- a/fetch.bs
+++ b/fetch.bs
@@ -5298,8 +5298,8 @@ steps. They return a <a for=/>response</a>.
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
 
-      <p>The user agent should store <var>forwardResponse</var>'s <a for=response>body info</a>
-      as part of the response.
+      <p class=note>The associated <a for=response>body info</a> is stored in the cache
+      alongside the response.
     </ol>
   </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4399,10 +4399,11 @@ steps:
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for="request">initiator type</a> is non-null and <var>fetchParams</var>'s
-     <a for="fetch params">request</a>'s <a for=request>client</a> is non-null, then run
-     <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-     <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>client</a>'s
+     <a for="environment settings object">global object</a> is <var>fetchParams</var>'s
+     <a for="fetch params">task destination</a>, then run <var>fetchParams</var>'s
+     <a for="fetch params">controller</a>'s <a for="fetch controller">report timing steps</a> given
+     <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
      <a for="environment settings object">global object</a>.
     </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3777,16 +3777,15 @@ algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an op
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
 an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), an
 optional string <dfn export for=fetch><var>initiatorType</var></dfn> (default "<code>other</code>"),
-and an optional "<code>client</code>", "<code>none</code>" or a <a for=/>global object</a>
-<dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
+and an optional "<code>client</code>", null, or a <a for=/>global object</a>
+<dfn export for=fetch><var>timingGlobal</var></dfn> (default null), run the steps
 below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm acceptin an integer
 representing the number of bytes transmitted. If given <var>processRequestEndOfBody</var> must be an
 algorithm accepting no arguments. If given, <var>processEarlyHintsResponse</var> must be an
 algorithm accepting a <a for=/>response</a>. If given, <var>processResponse</var> must be an
 algorithm accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be
 an algorithm accepting a <a for=/>response</a>. If given, <var>processResponseConsumeBody</var> must
-be an algorithm accepting a <a for=/>response</a> and null, failure, or a
-<a for=/>byte sequence</a>.
+be an algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>.
 
 <p>The user agent may be asked to
 <dfn export for=fetch id=concept-fetch-suspend>suspend</dfn> the ongoing fetch.
@@ -4318,7 +4317,7 @@ steps:
 
    <li>
     <p>If <var>global</var> is not null, then <a>queue a fetch task</a> given
-    <var>fetchParams</var>'s <a for="fetch params">timing global</a> to run the following steps:
+    <var>global</var> to run the following steps:
 
     <ol>
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -208,7 +208,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
- <dt><dfn for="fetch params">controller</dfn>
+ <dt><dfn for="fetch params">controller</dfn> (default a new <a for=/>fetch controller</a>)
  <dd>A <a for=/>fetch controller</a>.
 
  <dt><dfn for="fetch params">timing info</dfn>
@@ -226,10 +226,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
  <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
 
- <dt><dfn for="fetch controller">timing info</dfn>
- <dd>A <a for=/>fetch timing info</a>.
-
- <dt><dfn for="fetch controller">conclude steps</dfn> (default null)
+ <dt><dfn for="fetch controller">report timing steps</dfn> (default null)
  <dd>Null or an algorithm responsible for reporting timing information.
 </dl>
 
@@ -241,7 +238,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
 "<code>terminated</code>".
 
-<p>To <dfn export for="fetch controller" id="finalize-and-report-timing">conclude</dfn> a
+<p>To <dfn export for="fetch controller" id="finalize-and-report-timing">report timing</dfn> for a
 <a for=/>fetch controller</a> <var>controller</var>, perform the following steps given an optional
 string <var>initiatorType</var> (default "<code>other</code>"), an optional "<code>client</code>" or
 <a for=/>global object</a> <var>global</var> (default "<code>client</code>"), an optional
@@ -252,12 +249,12 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
 
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">report timing steps</a> is not null.
 
  <li><p>If <var>unsafeResponseEndTime</var> is "<code>now</code>", then set
  <var>unsafeResponseEndTime</var> to the <a>unsafe shared current time</a>.
 
- <li><p>Invoke <a>this</a>'s <a for="fetch controller">conclude steps</a> with
+ <li><p>Invoke <a>this</a>'s <a for="fetch controller">report timing steps</a> with
  <var>initiatorType</var>, <var>global</var>, <var>finalResponse</var>, and
  <var>unsafeResponseEndTime</var>.
 </ol>
@@ -3855,9 +3852,6 @@ the request.
  <a for="fetch timing info">post-redirect start time</a> are the
  <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>.
 
- <li><p>Let <var>controller</var> be a new <a for=/>fetch controller</a> whose
- <a for="fetch controller">timing info</a> is <var>timingInfo</var>.
-
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
  <a for="fetch params">request</a> is <var>request</var>,
  <a for="fetch params">timing info</a> is <var>timingInfo</var>,
@@ -4329,47 +4323,47 @@ steps:
 
    <li>
     <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-    <a for="fetch controller">conclude steps</a> to the following steps given a string
+    <a for="fetch controller">report timing steps</a> to the following steps given a string
     <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
     <var>global</var>, an "<code>original</code>" or <a for=/>response</a>
     <var>finalResponse</var>, and a {{DOMHighResTimeStamp}} <var>unsafeResponseEndTime</var>:
 
     <ol>
-    <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
-    <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
-    <a for="environment settings object">global object</a>.
+     <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
+     <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
+     <a for="environment settings object">global object</a>.
 
-    <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
-    to <var>response</var>.
+     <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
+     to <var>response</var>.
 
-    <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
+     <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
 
-    <li><p>Assert: <var>finalResponse</var> is <var>response</var> or a <a>network error</a>.
+     <li><p>Assert: <var>finalResponse</var> is <var>response</var> or a <a>network error</a>.
 
-    <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
-    <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
+     <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
 
-    <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
+     <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
-    <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
+     <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
 
-    <li>
-     <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
-     then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-     <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
-     set <var>cacheState</var> to the empty string.
+     <li>
+      <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
+      then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
+      <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
+      set <var>cacheState</var> to the empty string.
 
-     <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
-    </li>
+      <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
+     </li>
 
-    <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
-    <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
-    <a>relevant settings object</a>'s
-    <a for="environment settings object">cross-origin isolated capability</a>.
+     <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
+     <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
+     <a>relevant settings object</a>'s
+     <a for="environment settings object">cross-origin isolated capability</a>.
 
-    <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-    <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
-    and <var>bodyInfo</var>.
+     <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
+     <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
+     and <var>bodyInfo</var>.
     </ol>
    </li>
 
@@ -7721,7 +7715,7 @@ method steps are:
   </ol>
 
  <li><p>Let <var>handleFetchDone</var> be to
- <a for="fetch controller">conclude</a> <var>controller</var> given "<code>fetch</code>".
+ <a for="fetch controller">report timing</a> for <var>controller</var> given "<code>fetch</code>".
 
  <li>
   <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given

--- a/fetch.bs
+++ b/fetch.bs
@@ -205,12 +205,6 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
- <dt><dfn for="fetch params">initiator type</dfn> (default null)
- <dd>Null or a string.
-
- <dt><dfn for="fetch params">timing global</dfn> (default null)
- <dd>Null or a <a for=/>global object</a>.
-
  <dt><dfn for="fetch params">cross-origin isolated capability</dfn> (default false)
  <dd>A boolean.
 
@@ -1426,6 +1420,10 @@ this flag set are subject to additional processing requirements.
 <p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers mode</dfn>, that
 is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<code>all</code>".
 
+<p>A <a for=/>request</a> has an associated null or string
+<dfn for=request export>initiator type</dfn>. Unless stated otherwise it is null.
+[[RESOURCE-TIMING]]
+
 <div class=note>
  <p>This determines which service workers will receive a {{fetch!!event}} event for this fetch.
 
@@ -2115,11 +2113,6 @@ string.
      need to mask it, whether the cache API needs to store it, etc. -->
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response id=concept-response-body-info>body info</dfn>
-(a <a for=/>response body info</a>). Unless stated otherwise, it is a new
-<a for=/>response body info</a>.
-
-<p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</dfn>
 (a list of zero or more <a for=/>header</a>
 <a lt=name for=header>names</a>). The list is empty unless otherwise specified.
@@ -2148,6 +2141,11 @@ initially unset.
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
 the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
+
+<p>A <a for=/>response</a> has an associated
+<dfn export for=response id=concept-response-body-info>body info</dfn>
+(a <a for=/>response body info</a>). Unless stated otherwise, it is a new
+<a for=/>response body info</a>.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response>service worker timing info</dfn> (null or a
@@ -3799,17 +3797,15 @@ an optional algorithm <dfn export for=fetch><var>processEarlyHintsResponse</var>
 algorithm <dfn export for=fetch id=process-response><var>processResponse</var></dfn>, an optional
 algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
-an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), an
-optional null or string <dfn export for=fetch><var>initiatorType</var></dfn> (default null),
-and an optional "<code>client</code>", "<code>none</code>",  or a <a for=/>global object</a>
-<dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
-below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting an integer
-representing the number of bytes transmitted. If given, <var>processRequestEndOfBody</var> must be an
-algorithm accepting no arguments. If given, <var>processEarlyHintsResponse</var> must be an
-algorithm accepting a <a for=/>response</a>. If given, <var>processResponse</var> must be an
-algorithm accepting a <a for=/>response</a>. If given, <var>processResponseEndOfBody</var> must be
-an algorithm accepting a <a for=/>response</a>. If given, <var>processResponseConsumeBody</var> must
-be an algorithm accepting a <a for=/>response</a> and null, failure, or a <a for=/>byte sequence</a>.
+and an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), run
+the steps below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm accepting
+an integer representing the number of bytes transmitted. If given,
+<var>processRequestEndOfBody</var> must be an algorithm accepting no arguments. If given,
+<var>processEarlyHintsResponse</var> must be an algorithm accepting a <a for=/>response</a>. If
+given, <var>processResponse</var> must be an algorithm accepting a <a for=/>response</a>. If given,
+<var>processResponseEndOfBody</var> must be an algorithm accepting a <a for=/>response</a>. If
+given, <var>processResponseConsumeBody</var> must be an algorithm accepting a <a for=/>response</a>
+and null, failure, or a <a for=/>byte sequence</a>.
 
 <p>The user agent may be asked to
 <dfn export for=fetch id=concept-fetch-suspend>suspend</dfn> the ongoing fetch.
@@ -3845,12 +3841,7 @@ the request.
    <li><p>Set <var>crossOriginIsolatedCapability</var> to <var>request</var>'s
    <a for=request>client</a>'s
    <a for="environment settings object">cross-origin isolated capability</a>.
-
-   <li><p>Set <var>timingGlobal</var> to <var>request</var>'s <a for=request>client</a>'s
-   <a for="environment settings object">global object</a>.
   </ol>
-
- <li><p>Assert: <var>timingGlobal</var> is "<code>none</code>" or a <a for=/>global object</a>.
 
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
@@ -3869,8 +3860,6 @@ the request.
  <a for="fetch params">request</a> is <var>request</var>,
  <a for="fetch params">timing info</a> is <var>timingInfo</var>,
  <a for="fetch params">controller</a> is <var>controller</var>,
- <a for="fetch params">initiator type</a> is <var>initiatorType</var>,
- <a for="fetch params">timing global</a> is <var>timingGlobal</var>,
  <a for="fetch params">process request body chunk length</a> is
  <var>processRequestBodyChunkLength</var>,
  <a for="fetch params">process request end-of-body</a> is <var>processRequestEndOfBody</var>,
@@ -4368,23 +4357,24 @@ steps:
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
 
-     <li><p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null, then
-     <a for=/>mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-     <a for=request>URL</a>, <var>fetchParams</var>'s <a for="fetch params">initiator type</a>,
-     <var>global</var>, <var>cacheState</var>, and <var>bodyInfo</var>.
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+     <a for=request>initiator type</a> is not null, then
+     <a for=/>mark resource timing</a> given <var>timingInfo</var>, <var>request</var>'s
+     <a for=request>URL</a>, <a for="fetch params">request</a>'s
+     <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>, and
+     <var>bodyInfo</var>.
     </ol>
 
-   <li><p>Let <var>global</var> be <var>fetchParams</var>'s <a for="fetch params">timing global</a>.
+   <li><p>Let <var>client</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+   <a for=request>client</a>.
 
-   <li>
-    <p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null and
-    <var>fetchParams</var>'s <a for="fetch params">timing global</a> is not "<code>none</code>",
-    then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
-    <a for="fetch params">controller</a>'s <a for="fetch controller">report timing steps</a> given
-    <var>fetchParams</var>'s <a for="fetch params">timing global</a> and <var>fetchParams</var>'s
-    <a for="fetch params">initiator type</a>, with<var>fetchParams</var>'s
-    <a for="fetch params">timing global</a>.
-   </li>
+   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+   <a for="request">initiator type</a> is not null and <var>client</var> is not null, then
+   <a>queue a fetch task</a> to run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+   <a for="fetch controller">report timing steps</a> given <var>client</var>'s
+   <a for="environment settings object">global object</a> and <a for="fetch params">request</a>'s
+   <a for="request">initiator type</a>, with <var>client</var>'s
+   <a for="environment settings object">global object</a>.
 
    <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is not
    null, then <a>queue a fetch task</a> to run <var>fetchParams</var>'s
@@ -7084,6 +7074,9 @@ constructor steps are:
 
    <dt><a for=request>URL list</a>
    <dd>A <a for=list>clone</a> of <var>request</var>'s <a for=request>URL list</a>.
+
+   <dt><a for=request>initiator type</a>
+   <dd>"<code>fetch</code>".
   </dl>
 
  <li>
@@ -7735,8 +7728,8 @@ method steps are:
 
  <li>
   <p><p>Set <var>controller</var> to the result of calling <a for=/>fetch</a> given
-  <var>request</var>, with <a for=fetch><i>initiatorType</i></a> set to "<code>fetch</code>, and
-  <a for=fetch><i>processResponse</i></a> given <var>response</var> being these substeps:
+  <var>request</var> and <a for=fetch><i>processResponse</i></a> given <var>response</var> being
+  these substeps:
 
   <ol>
    <li><p>If <var>locallyAborted</var> is true, terminate these substeps.
@@ -8221,16 +8214,6 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  <dt><a for=fetch><i>useParallelQueue</i></a>
  <dd><p>Takes a <a for=/>boolean</a> that defaults to false. Indicates where the algorithms passed
  as arguments will be invoked. Hopefully most standards will not need this.
-
- <dt><a for=fetch><i>initiatorType</i></a>
- <dd><p>Takes null or a string, to indicate the {{PerformanceResourceTiming/initiatorType}} for
- <cite>Resource Timing</cite>. If not given, the entry is not reported. [[RESOURCE-TIMING]]
-
- <dt><a for=fetch><i>timingGlobal</i></a>
- <dd><p>Takes "<code>client</code>", "<code>none</code>" or a <a for=/>global object</a> (default
- "<code>client</code>"). Indicates which <a for=/>global object</a> is used for enqueuing the
- {{PerformanceResourceTiming}} entry. If "<code>none</code>" is passed, the entry is not reported.
- [[RESOURCE-TIMING]]
 </dl>
 
 <p>When invoked, the <a for=/>fetch</a> operation returns a <a for=/>fetch controller</a>. The

--- a/fetch.bs
+++ b/fetch.bs
@@ -223,8 +223,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a for=struct>items</a>:
 
 <dl>
- <dt><dfn for="fetch controller">state</dfn> (default "<code>requesting</code>")
- <dd>"<code>requesting</code>", "<code>responding</code>", "<code>concluded</code>",
+ <dt><dfn for="fetch controller">state</dfn> (default "<code>fetching</code>")
+ <dd>"<code>fetching</code>", "<code>transmitting</code>", "<code>concluded</code>",
  "<code>terminated</code>", or "<code>aborted</code>"
 
  <dt><dfn for="fetch controller">timing info</dfn>
@@ -248,12 +248,12 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
 <a for=/>global object</a> <var>global</var> (default "<code>client</code>"), an optional
 "<code>original</code>" or <a for=/>response</a> <var>finalResponse</var> (default
 "<code>original</code>"), and an optional "<code>now</code>" or {{DOMHighResTimeStamp}}
-<var>unsafeResponseEndTime</var>:</p>
+<var>unsafeResponseEndTime</var> (default "<code>now</code>"):</p>
 
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
 
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>responding</code>".
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>transmitting</code>".
 
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
 
@@ -298,13 +298,15 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dd>A <a for=/>list</a> of strings.
 </dl>
 
-<p>A <dfn export>fetch resource info</dfn> is a <a for=/>struct</a> used to maintain
+<p>A <dfn export>response body info</dfn> is a <a for=/>struct</a> used to maintain
 information needed by <cite>Resource Timing</cite> and <cite>Navigation Timing</cite>. It has the
 following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
 <dl>
- <dt><dfn export for="fetch resource info">encoded body size</dfn> (default 0)
- <dt><dfn export for="fetch resource info">decoded body size</dfn> (default 0)
+ <dt><dfn export for="response body info" id="fetch-timing-info-encoded-body-size">encoded body
+ size</dfn> (default 0)
+ <dt><dfn export for="response body info" id="fetch-timing-info-decoded-body-size">decoded body
+ size</dfn> (default 0)
  <dd>A number.
 </dl>
 
@@ -2107,18 +2109,18 @@ message as HTTP/2 does not support them.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string,
-"<code>local</code>", or "<code>validated</code>"). Unlesss stated otherwise, it is the empty
+"<code>local</code>", or "<code>validated</code>"). Unless stated otherwise, it is the empty
 string.
-
-<p>A <a for=/>response</a> has an associated
-<dfn export for=response id=concept-response-resource-info>resource info</dfn>
-(a <a for=/>fetch resource info</a>). Unlesss stated otherwise, it is a new
-<a for=/>fetch resource info</a>.
 
 <p class=note>This is intended for usage by <cite>Service Workers</cite> and
 <cite>Resource Timing</cite>.  [[SW]] [[RESOURCE-TIMING]]
 <!-- If we ever expand the utility of this we need to carefully consider whether filtered responses
      need to mask it, whether the cache API needs to store it, etc. -->
+
+<p>A <a for=/>response</a> has an associated
+<dfn export for=response id=concept-response-body-info>body info</dfn>
+(a <a for=/>response body info</a>). Unless stated otherwise, it is a new
+<a for=/>response body info</a>.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cors-exposed-header-name-list>CORS-exposed header-name list</dfn>
@@ -4312,10 +4314,10 @@ steps:
 
 <ol>
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
- <a for="fetch params">timing info</a>.</p></li>
+ <a for="fetch params">timing info</a>.
 
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-  <a for="fetch controller">state</a> to "<code>responding</code>".
+ <a for="fetch controller">state</a> to "<code>transmitting</code>".
 
  <li>
   <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
@@ -4342,12 +4344,12 @@ steps:
 
    <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
 
-   <li><p>Let <var>resourceInfo</var> be <var>response</var>'s <a for=response>resource info</a>.
+   <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
 
    <li>
     <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
     then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-    <var>timingInfo</var>, set <var>resourceInfo</var> to a new <a for=/>fetch resource info</a> and
+    <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
     set <var>cacheState</var> to the empty string.
 
     <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
@@ -4360,7 +4362,7 @@ steps:
 
    <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
    <a for=request>URL</a> <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
-   and <var>resourceInfo</var>.
+   and <var>bodyInfo</var>.
   </ol>
 
  <li>
@@ -5694,8 +5696,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
          `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
-         <li><p>Increase <var>response</var>'s <a for=response>resource info</a>'s
-         <a for="fetch resource info">encoded body size</a> by <var>bytes</var>'s
+         <li><p>Increase <var>response</var>'s <a for=response>body info</a>'s
+         <a for="response body info">encoded body size</a> by <var>bytes</var>'s
          <a for="byte sequence">length</a>.
 
          <li>
@@ -5705,8 +5707,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
           <p class="note no-backref">This makes the `<code>Content-Length</code>` <a for=/>header</a>
           unreliable to the extent that it was reliable to begin with.
 
-         <li><p>Increase <var>response</var>'s <a for=response>resource info</a>'s
-         <a for="fetch resource info">decoded body size</a> by
+         <li><p>Increase <var>response</var>'s <a for=response>body info</a>'s
+         <a for="response body info">decoded body size</a> by
          <var>bytes</var>'s <a for="byte sequence">length</a>.
 
          <li><p>If <var>bytes</var> is failure, then <a for="fetch controller">terminate</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5284,6 +5284,9 @@ steps. They return a <a for=/>response</a>.
 
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
+
+      <p class=note><var>forwardResponse</var>'s <a for=response>body info</a> should be stored
+      as part of the response.
     </ol>
   </ol>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4310,13 +4310,10 @@ steps:
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
  <a for="fetch params">timing info</a>.
 
- <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
- <a for="fetch params">timing info</a>.
-
  <li>
-  <p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-  <a for=request>client</a> is a <a>secure context</a>, set <var>timingInfo</var>'s
-  <a for="fetch timing info">server-timing headers</a> to the
+  <p>If <var>response</var> is not a <a>network error</a>  and <var>fetchParams</var>'s
+  <a for="fetch params">request</a>'s <a for=request>client</a> is a <a>secure context</a>, then set
+  <var>timingInfo</var>'s <a for="fetch timing info">server-timing headers</a> to the
   result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
   from <var>response</var>'s <a for=response>header list</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -239,8 +239,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
 "<code>terminated</code>".
 
-<p>To <dfn export for="fetch controller">conclude</dfn> a <a for=/>fetch controller</a>
-<var>controller</var>, perform the following steps given a string
+<p>To <dfn export for="fetch controller" id="finalize-and-report-timing">conclude</dfn> a
+<a for=/>fetch controller</a> <var>controller</var>, perform the following steps given a string
 <var>initiatorType</var>, an optional "<code>client</code>" or <a for=/>global object</a>
 <var>global</var> (default "<code>client</code>"), and an optional "<code>original</code>" or
 <a for=/>response</a> <var>finalResponse</var> (default "<code>original</code>"):</p>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1420,9 +1420,29 @@ this flag set are subject to additional processing requirements.
 <p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers mode</dfn>, that
 is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<code>all</code>".
 
-<p>A <a for=/>request</a> has an associated null or string
-<dfn for=request export>initiator type</dfn>. Unless stated otherwise it is null.
-[[RESOURCE-TIMING]]
+<p>A <a for=/>request</a> has an associated
+<dfn for=request export>initiator type</dfn>, which is null,
+"<code>audio</code>",
+"<code>beacon</code>",
+"<code>body</code>",
+"<code>css</code>",
+"<code>early-hint</code>",
+"<code>embed</code>",
+"<code>fetch</code>",
+"<code>font</code>",
+"<code>frame</code>",
+"<code>iframe</code>",
+"<code>image</code>",
+"<code>img</code>",
+"<code>input</code>",
+"<code>link</code>",
+"<code>object</code>",
+"<code>ping</code>",
+"<code>script</code>",
+"<code>track</code>",
+"<code>video</code>",
+"<code>xmlhttprequest</code>", or
+"<code>other</code>". Unless stated otherwise it is null. [[RESOURCE-TIMING]]
 
 <div class=note>
  <p>This determines which service workers will receive a {{fetch!!event}} event for this fetch.

--- a/fetch.bs
+++ b/fetch.bs
@@ -248,8 +248,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <li><p>Call <a>this</a>'s <a for="fetch controller">report timing steps</a> with <var>global</var>.
 </ol>
 
-<p>To <dfn export for="fetch controller">extract full timing info</a> given a
-<a>fetch controller</a> <var>controller</var>:
+<p>To <dfn export for="fetch controller" id="extract-full-timing-info">extract full timing info</a>
+given a <a>fetch controller</a> <var>controller</var>:
 
 <ol>
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">full timing info</a> is not null.

--- a/fetch.bs
+++ b/fetch.bs
@@ -205,8 +205,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch params">task destination</dfn> (default null)
  <dd>Null, a <a for=/>global object</a>, or a <a for=/>parallel queue</a>.
 
- <dt><dfn for="fetch params">initiator type</dfn> (default "<code>other</code>")
- <dd>A string.
+ <dt><dfn for="fetch params">initiator type</dfn> (default null)
+ <dd>Null or a string.
 
  <dt><dfn for="fetch params">timing global</dfn> (default null)
  <dd>Null or a <a for=/>global object</a>.
@@ -231,7 +231,31 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <dl>
  <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
  <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
+
+ <dt><dfn for="fetch controller">full timing info</dfn> (default null)
+ <dd>Null or a <a for=/>fetch timing info</a>.
+
+ <dt><dfn for="fetch controller">report timing steps</dfn> (default null)
+ <dd>Null or an algorithm accepting a <a for=/>global object</a>.
 </dl>
+
+<p>To <dfn export for="fetch controller" id="finalize-and-report-timing">report timing</a> for a
+<a>fetch controller</a> <var>controller</var> given a <a for=/>global object</a> <var>global</var>:
+
+<ol>
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">report timing steps</a> is not null.
+
+ <li><p>Call <a>this</a>'s <a for="fetch controller">report timing steps</a> with <var>global</var>.
+</ol>
+
+<p>To <dfn export for="fetch controller">extract full timing info</a> given a
+<a>fetch controller</a> <var>controller</var>:
+
+<ol>
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">full timing info</a> is not null.
+
+ <li><p>Return <a>this</a>'s <a for="fetch controller">full timing info</a>.
+</ol>
 
 <p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
 <var>controller</var>, set <var>controller</var>'s <a for="fetch controller">state</a> to
@@ -3776,9 +3800,9 @@ algorithm <dfn export for=fetch id=process-response><var>processResponse</var></
 algorithm <dfn export for=fetch><var>processResponseEndOfBody</var></dfn>, an optional algorithm
 <dfn export for=fetch id=process-response-end-of-body oldids=process-response-end-of-file><var>processResponseConsumeBody</var></dfn>,
 an optional boolean <dfn export for=fetch><var>useParallelQueue</var></dfn> (default false), an
-optional string <dfn export for=fetch><var>initiatorType</var></dfn> (default "<code>other</code>"),
-and an optional "<code>client</code>", null, or a <a for=/>global object</a>
-<dfn export for=fetch><var>timingGlobal</var></dfn> (default null), run the steps
+optional null or string <dfn export for=fetch><var>initiatorType</var></dfn> (default null),
+and an optional "<code>client</code>" or a <a for=/>global object</a>
+<dfn export for=fetch><var>timingGlobal</var></dfn> (default "<code>client</code>"), run the steps
 below. If given, <var>processRequestBodyChunkLength</var> must be an algorithm acceptin an integer
 representing the number of bytes transmitted. If given <var>processRequestEndOfBody</var> must be an
 algorithm accepting no arguments. If given, <var>processEarlyHintsResponse</var> must be an
@@ -3826,14 +3850,14 @@ the request.
  <li><p>If <var>useParallelQueue</var> is true, then set <var>taskDestination</var> to the result of
  <a>starting a new parallel queue</a>.
 
- <li><p>If <var>timingGlobal</var> is "<code>client</code>", then set <var>timingGlobal</var>
- to <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a>.
-
  <!-- It would be nice to assert that taskDestination is non-null here, but it's not clear if this
       works for all callers. Fetch itself calls main fetch while taskDestination is null. Anyone
       wanting to do a ping without request body might do so as well, but if you do have a request
       body you definitely need this as otherwise transmit-request-body loop breaks down. -->
+
+ <li><p>If <var>timingGlobal</var> is "<code>client</code>", then set <var>timingGlobal</var> to
+ <var>request</var>'s <a for=request>client</a>'s <a
+ for="environment settings object">global object</a>.
 
  <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
  <a for="fetch timing info">start time</a> and
@@ -4313,11 +4337,15 @@ steps:
    <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
    <a for=request>done flag</a>.
 
-   <li><p>Let <var>global</var> be <var>fetchParams</var>'s <a for="fetch params">timing global</a>.
-
    <li>
-    <p>If <var>global</var> is not null, then <a>queue a fetch task</a> given
-    <var>global</var> to run the following steps:
+    <p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+    <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
+    <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
+    <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
+    <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s <a
+    for="fetch controller">report timing steps</a> to the following steps given a <a
+    for=/>global object</a> <var>global</var>:
 
     <ol>
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
@@ -4340,10 +4368,22 @@ steps:
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
      </li>
 
-     <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null, then
+     <a for=/>mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
      <a for=request>URL</a>, <var>fetchParams</var>'s <a for="fetch params">initiator type</a>,
      <var>global</var>, <var>cacheState</var>, and <var>bodyInfo</var>.
     </ol>
+
+   <li><p>Let <var>global</var> be <var>fetchParams</var>'s <a for="fetch params">timing global</a>.
+
+   <li>
+    <p>If <var>fetchParams</var>'s <a for="fetch params">initiator type</a> is not null and
+    <var>fetchParams</var>'s <a for="fetch params">timing global</a> is not null, then
+    <a>queue a fetch task</a> to run <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+    <a for="fetch controller">report timing steps</a> given <var>fetchParams</var>'s
+    <a for="fetch params">timing global</a> and <var>fetchParams</var>'s
+    <a for="fetch params">initiator type</a>, with<var>fetchParams</var>'s
+    <a for="fetch params">timing global</a>.
    </li>
 
    <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is not
@@ -8183,8 +8223,8 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  as arguments will be invoked. Hopefully most standards will not need this.
 
  <dt><a for=fetch><i>initiatorType</i></a>
- <dd><p>Takes a string that defaults to "<code>other</code>", to indicate the
- {{PerformanceResourceTiming/initiatorType}} for <cite>Resource Timing</cite>. [[RESOURCE-TIMING]]
+ <dd><p>Takes null or a string, to indicate the {{PerformanceResourceTiming/initiatorType}} for
+ <cite>Resource Timing</cite>. If not given, the entry is not reported. [[RESOURCE-TIMING]]
 
  <dt><a for=fetch><i>timingGlobal</i></a>
  <dd><p>Takes "<code>client</code>", "<code>none</code>" or a <a for=/>global object</a> (default

--- a/fetch.bs
+++ b/fetch.bs
@@ -230,8 +230,8 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
   <p class="note">The <a for="fetch controller" lt="state">states</a> of the <a>fetch controller</a>
   only make sense in the context of half-duplex HTTP fetches (where the <a for=/>request</a> is
-  complete before the <a for=/>response</a> starts). Using them in other contexts should be handled
-  with care.</p>
+  complete before the <a for=/>response</a> starts). Handle with care when using them in other
+  contexts.</p>
 
  <dt><dfn for="fetch controller">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -223,21 +223,14 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a for=struct>items</a>:
 
 <dl>
- <dt><dfn for="fetch controller">state</dfn> (default "<code>requesting</code>")
- <dd>
-  "<code>requesting</code>", "<code>responding</code>", "<code>concluded</code>",
-  "<code>terminated</code>", or "<code>aborted</code>"
-
-  <p class="note">The <a for="fetch controller" lt="state">states</a> of the <a>fetch controller</a>
-  only make sense in the context of half-duplex HTTP fetches (where the <a for=/>request</a> is
-  complete before the <a for=/>response</a> starts). Handle with care when using them in other
-  contexts.</p>
+ <dt><dfn for="fetch controller">state</dfn> (default "<code>ongoing</code>")
+ <dd>"<code>ongoing</code>", "<code>terminated</code>", or "<code>aborted</code>"
 
  <dt><dfn for="fetch controller">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>.
 
  <dt><dfn for="fetch controller">conclude steps</dfn> (default null)
- <dd>Null or an algorithm responsible for finalizing the fetch and reporting timing information.
+ <dd>Null or an algorithm responsible for reporting timing information.
 </dl>
 
 <p>To <dfn export for="fetch controller">abort</dfn> a <a for=/>fetch controller</a>
@@ -259,8 +252,6 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
 
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>responding</code>".
-
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
 
  <li><p>If <var>unsafeResponseEndTime</var> is "<code>now</code>", then set
@@ -269,9 +260,6 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
  <li><p>Invoke <a>this</a>'s <a for="fetch controller">conclude steps</a> with
  <var>initiatorType</var>, <var>global</var>, <var>finalResponse</var>, and
  <var>unsafeResponseEndTime</var>.
-
- <li><p>Set <var>controller</var>'s <a for="fetch controller">state</a> to
- "<code>concluded</code>".
 </ol>
 
 <p>A <a for=/>fetch params</a> <var>fetchParams</var> is <dfn for="fetch params">aborted</dfn> if
@@ -4322,57 +4310,11 @@ steps:
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
  <a for="fetch params">timing info</a>.
 
- <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
- <a for="fetch controller">state</a> to "<code>responding</code>".
-
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
  <a for="fetch params">timing info</a>.
 
  <li>
-  <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
-  <a for="fetch controller">conclude steps</a> to the following steps given a string
-  <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
-  <var>global</var>, an "<code>original</code>" or <a for=/>response</a>
-  <var>finalResponse</var>, and a {{DOMHighResTimeStamp}} <var>unsafeResponseEndTime</var>:
-
-  <ol>
-   <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
-   <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
-   <a for="environment settings object">global object</a>.
-
-   <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
-   to <var>response</var>.
-
-   <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
-
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
-   <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
-
-   <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
-
-   <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
-
-   <li>
-    <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
-    then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
-    <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
-    set <var>cacheState</var> to the empty string.
-
-    <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
-   </li>
-
-   <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
-   <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
-   <a>relevant settings object</a>'s
-   <a for="environment settings object">cross-origin isolated capability</a>.
-
-   <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
-   <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
-   and <var>bodyInfo</var>.
-  </ol>
-
- <li>
-  <p>Otherwise, if <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+  <p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
   <a for=request>client</a> is a <a>secure context</a>, set <var>timingInfo</var>'s
   <a for="fetch timing info">server-timing headers</a> to the
   result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
@@ -4387,6 +4329,52 @@ steps:
   <ol>
    <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
    <a for=request>done flag</a>.
+
+   <li>
+    <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
+    <a for="fetch controller">conclude steps</a> to the following steps given a string
+    <var>initiatorType</var>, a "<code>client</code>" or <a for=/>global object</a>
+    <var>global</var>, an "<code>original</code>" or <a for=/>response</a>
+    <var>finalResponse</var>, and a {{DOMHighResTimeStamp}} <var>unsafeResponseEndTime</var>:
+
+    <ol>
+    <li><p>If <var>global</var> is "<code>client</code>", then set <var>global</var> to
+    <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>client</a>'s
+    <a for="environment settings object">global object</a>.
+
+    <li><p>If <var>finalResponse</var> is "<code>original</code>", then set <var>finalResponse</var>
+    to <var>response</var>.
+
+    <li><p>If <var>finalResponse</var> is an <a>aborted network error</a>, then return.
+
+    <li><p>Assert: <var>finalResponse</var> is <var>response</var> or a <a>network error</a>.
+
+    <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s <a for=request>URL</a>'s
+    <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then return.
+
+    <li><p>Let <var>cacheState</var> be <var>response</var>'s <a for=response>cache state</a>.
+
+    <li><p>Let <var>bodyInfo</var> be <var>response</var>'s <a for=response>body info</a>.
+
+    <li>
+     <p>If <var>finalResponse</var>'s <a for=response>timing allow passed flag</a> is not set,
+     then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
+     <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a> and
+     set <var>cacheState</var> to the empty string.
+
+     <p class=note>This covers the case of <var>finalResponse</var> being a <a>network error</a>.
+    </li>
+
+    <li><p>Set <var>timingInfo</var>'s <a for="fetch timing info">end time</a> to the result of
+    <a lt="coarsen time">coarsening</a> <var>unsafeResponseEndTime</var> given <var>global</var>'s
+    <a>relevant settings object</a>'s
+    <a for="environment settings object">cross-origin isolated capability</a>.
+
+    <li><p><a for=/>Mark resource timing</a> for <var>timingInfo</var>, <var>request</var>'s
+    <a for=request>URL</a>, <var>initiatorType</var>, <var>global</var>, <var>cacheState</var>,
+    and <var>bodyInfo</var>.
+    </ol>
+   </li>
 
    <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is not
    null, then <a>queue a fetch task</a> to run <var>fetchParams</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -5285,7 +5285,7 @@ steps. They return a <a for=/>response</a>.
       <p class=note>If <var>forwardResponse</var> is a <a>network error</a>, this effectively caches
       the network error, which is sometimes known as "negative caching".
 
-      <p><var>The user agent should store <var>forwardResponse</var>'s <a for=response>body info</a>
+      <p>The user agent should store <var>forwardResponse</var>'s <a for=response>body info</a>
       as part of the response.
     </ol>
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -223,9 +223,15 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 <a for=struct>items</a>:
 
 <dl>
- <dt><dfn for="fetch controller">state</dfn> (default "<code>fetching</code>")
- <dd>"<code>fetching</code>", "<code>transmitting</code>", "<code>concluded</code>",
- "<code>terminated</code>", or "<code>aborted</code>"
+ <dt><dfn for="fetch controller">state</dfn> (default "<code>requesting</code>")
+ <dd>
+  "<code>requesting</code>", "<code>responding</code>", "<code>concluded</code>",
+  "<code>terminated</code>", or "<code>aborted</code>"
+
+  <p class="note">The <a for="fetch controller" lt="state">states</a> of the <a>fetch controller</a>
+  only make sense in the context of half-duplex HTTP fetches (where the <a for=/>request</a> is
+  complete before the <a for=/>response</a> starts). Using them in other contexts should be handled
+  with care.</p>
 
  <dt><dfn for="fetch controller">timing info</dfn>
  <dd>A <a for=/>fetch timing info</a>
@@ -253,7 +259,7 @@ string <var>initiatorType</var> (default "<code>other</code>"), an optional "<co
 <ol>
  <li><p>If <a>this</a>'s <a for="fetch controller">state</a> is "<code>aborted</code>", then return.
 
- <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>transmitting</code>".
+ <li><p>Assert: <a>this</a>'s <a for="fetch controller">state</a> is "<code>responding</code>".
 
  <li><p>Assert: <a>this</a>'s <a for="fetch controller">conclude steps</a> is not null.
 
@@ -4317,7 +4323,7 @@ steps:
  <a for="fetch params">timing info</a>.
 
  <li><p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s
- <a for="fetch controller">state</a> to "<code>transmitting</code>".
+ <a for="fetch controller">state</a> to "<code>responding</code>".
 
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s
  <a for="fetch params">timing info</a>.
@@ -4742,7 +4748,6 @@ these steps:
     </dl>
     <!-- not resetting actualResponse since it's no longer used anyway -->
   </ol>
- </li>
 
  <li><p>Return <var>response</var>. <span class="note no-backref">Typically
  <var>actualResponse</var>'s <a for=response>body</a>'s


### PR DESCRIPTION
Closes https://github.com/whatwg/fetch/issues/1208
Closes https://github.com/w3c/navigation-timing/pull/131

A new method called `conclude` reports the timing for the resource.
The timing info used is the one attached to the fetch rather than
one attached to a response.

This is done to reduce ambiguities when timing info is attached to
the `response`, as it's unclear what happens to that timing info
when a response is cloned, reused, serialized or stored & restored
from cache.

Call-site patches:

Update resource/navigation to use `conclude` / `resource-info`: https://github.com/whatwg/html/pull/7722
Update XHR to use `conclude`: https://github.com/whatwg/xhr/pull/347
Update CSS to use `conclude`: https://github.com/w3c/csswg-drafts/pull/7355
Update beacon to use `conclude`: https://github.com/w3c/beacon/pull/75
Update resource timing to use `resource info`: https://github.com/w3c/resource-timing/pull/321
Update navigation timing to use `resource info`: https://github.com/w3c/navigation-timing/pull/1760


(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1413.html" title="Last updated on Jun 15, 2022, 9:18 AM UTC (9f0745a)">Preview</a> | <a href="https://whatpr.org/fetch/1413/f725059...9f0745a.html" title="Last updated on Jun 15, 2022, 9:18 AM UTC (9f0745a)">Diff</a>