### PR TITLE
Anonymous iframe (WIP)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2652,8 +2652,12 @@ details of reused connections are not exposed and time values are coarsened.
 
 <h3 id=network-partition-keys>Network partition keys</h3>
 
-<p>A <dfn>network partition key</dfn> is a tuple consisting of a <a for=/>site</a> and null or
-an <a>implementation-defined</a> value.
+<p>A <dfn>network partition key</dfn> is a tuple consisting of:</p>
+<ul class="brief">
+  <li><p>a <a for=/>site</a>.</p>
+  <li><p>null or an <a>implementation-defined</a> value.</p>
+  <li><p>null or a nonce.</p>
+</ul>
 
 <p>To
 <dfn export lt="determine the network partition key|determining the network partition key">determine the network partition key</dfn>,
@@ -2671,13 +2675,14 @@ given an <a for=/>environment</a> <var>environment</var>, run these steps:
  <li><p>Let <var>topLevelSite</var> be the result of <a lt="obtain a site">obtaining a site</a>,
  given <var>topLevelOrigin</var>.
 
- <li>
-  <p>Let <var>secondKey</var> be null or an <a>implementation-defined</a> value.
+ <li><p>Let <var>secondKey</var> be null or an <a>implementation-defined</a> value.
 
-  <p class=XXX>The second key is intentionally a little vague as the finer points are still
-  evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
+ <p class=XXX>The second key is intentionally a little vague as the finer points are still
+ evolving. See <a href=https://github.com/whatwg/fetch/issues/1035>issue #1035</a>.
 
- <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>).
+ <li><p>Let <var>nonce</var> be <var>environment</var>'s <a for="environment">partition-nonce</a></p>
+
+ <li><p>Return (<var>topLevelSite</var>, <var>secondKey</var>, <var>nonce</var>).
 </ol>
 
 <p>To


### PR DESCRIPTION
Explainer & specs (WIP)
https://arthursonzogni.github.io/anonymous-iframe/#explainer

Summary:
- Plumb environment's`partition-nonce` in the `network-partition-key`. The value is filled
  from the HTML specification.

Anonymous iframe require updating several specifications:
- HTML => https://github.com/whatwg/html/pull/7695
- Fetch => (this)
- CHIPS (cookie-having-independent-partition-state) => XXX
- Storage-partitioning => XXX

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome: https://chromestatus.com/feature/5729461725036544
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/html/cross-origin-embedder-policy/anonymous-iframe
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1226469
   * Firefox: …
   * Safari: …
   * Deno: N/A
   * Node.js: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
