### PR TITLE
Specify connection timing for HTTP/3

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2644,6 +2644,11 @@ boolean <var>http3Only</var>, run these steps:
  <a for="connection timing info">secure connection start time</a> should be the result of calling
  <a for=/>unsafe shared current time</a> immmediately before starting the handshake process to
  secure <var>connection</var>. [[!TLS]]
+
+ <li><p>If <var>connection</var> is an HTTP/3 connection, <var>timingInfo</var>'s
+ <a for="connection timing info">connection start time</a> and <var>timingInfo</var>'s
+ <a for="connection timing info">secure connection start time</a> should be equal, as in HTTP/3
+ the handshake process is performed as part of the initial connection setup. [[!HTTP3]]
 </ul>
 
 <p class=note>The <a for=/>clamp and coarsen connection timing info</a> algorithm ensures that

--- a/fetch.bs
+++ b/fetch.bs
@@ -2647,8 +2647,9 @@ boolean <var>http3Only</var>, run these steps:
 
  <li><p>If <var>connection</var> is an HTTP/3 connection, <var>timingInfo</var>'s
  <a for="connection timing info">connection start time</a> and <var>timingInfo</var>'s
- <a for="connection timing info">secure connection start time</a> should be equal, as in HTTP/3
- the handshake process is performed as part of the initial connection setup. [[!HTTP3]]
+ <a for="connection timing info">secure connection start time</a> must be equal. (In HTTP/3
+ the secure transport handshake process is performed as part of the initial connection setup.)
+ [[!HTTP3]]
 </ul>
 
 <p class=note>The <a for=/>clamp and coarsen connection timing info</a> algorithm ensures that


### PR DESCRIPTION
- `secure connection start` is identical to `connection start`
  (TLS and connecting are part of the same flow in HTTP/3)

- `connection end` is right after the handshake

This corresponds to current Chromium implementation.

Closes https://github.com/w3c/navigation-timing/issues/165

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Currently WPT doesn't have support for H3 (except for `WebTransport`, TBD)
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1417.html" title="Last updated on Apr 6, 2022, 10:54 AM UTC (50514eb)">Preview</a> | <a href="https://whatpr.org/fetch/1417/92b3578...50514eb.html" title="Last updated on Apr 6, 2022, 10:54 AM UTC (50514eb)">Diff</a>