### PR TITLE
Integrity-metadata should not be a preload key

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3902,8 +3902,7 @@ the request.
    <a>consume a preloaded resource</a> for <var>request</var>'s <a for=request>window</a>, given
    <var>request</var>'s <a for=request>URL</a>, <var>request</var>'s <a for=request>destination</a>,
    <var>request</var>'s <a for=request>mode</a>, <var>request</var>'s
-   <a for=request>credentials mode</a>, <var>request</var>'s <a for=request>integrity metadata</a>,
-   and <var>onPreloadedResponseAvailable</var>.
+   <a for=request>credentials mode</a>, and <var>onPreloadedResponseAvailable</var>.
 
    <li><p>If <var>foundPreloadedResource</var> is true and <var>fetchParams</var>'s
    <a for="fetch params">preloaded response candidate</a> is null, then set <var>fetchParams</var>'s


### PR DESCRIPTION
In conjunction with https://github.com/whatwg/html/pull/7738

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Covered thoroughly by https://wpt.live/preload/subresource-integrity.html
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
