### PR TITLE
Editorial: Rename 'fetch finale' to 'fetch response handover'

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4258,7 +4258,7 @@ steps:
   <p>If <var>request</var>'s <a for=request>integrity metadata</a> is not the empty string, then:
 
   <ol>
-   <li><p>Let <var>processBodyError</var> be this step: run <a>fetch finale</a> given
+   <li><p>Let <var>processBodyError</var> be this step: run <a>fetch response handover</a> given
    <var>fetchParams</var> and a <a>network error</a>.
 
    <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" or
@@ -4276,20 +4276,20 @@ steps:
      <li><p>Set <var>response</var>'s <a for=response>body</a> to the first return value of
      <a for=BodyInit>safely extracting</a> <var>bytes</var>.
 
-     <li><p>Run <a>fetch finale</a> given <var>fetchParams</var> and <var>response</var>.
+     <li><p>Run <a>fetch response handover</a> given <var>fetchParams</var> and <var>response</var>.
     </ol>
 
    <li><p><a for=body>Fully read</a> <var>response</var>'s <a for=response>body</a> given
    <var>processBody</var> and <var>processBodyError</var>.
   </ol>
 
- <li><p>Otherwise, run <a>fetch finale</a> given <var>fetchParams</var> and <var>response</var>.
+ <li><p>Otherwise, run <a>fetch response handover</a> given <var>fetchParams</var> and <var>response</var>.
 </ol>
 
 <hr>
 
-<p>The <dfn>fetch finale</dfn>, given a <a for=/>fetch params</a> <var>fetchParams</var> and a
-<a for=/>response</a> <var>response</var>, run these steps:
+<p>The <dfn id=fetch-finale>fetch response handover</dfn>, given a <a for=/>fetch params</a>
+<var>fetchParams</var> and a <a for=/>response</a> <var>response</var>, run these steps:
 
 <ol>
  <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4283,7 +4283,8 @@ steps:
    <var>processBody</var> and <var>processBodyError</var>.
   </ol>
 
- <li><p>Otherwise, run <a>fetch response handover</a> given <var>fetchParams</var> and <var>response</var>.
+ <li><p>Otherwise, run <a>fetch response handover</a> given <var>fetchParams</var> and
+ <var>response</var>.
 </ol>
 
 <hr>


### PR DESCRIPTION
Closes #1419

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1423.html" title="Last updated on Apr 5, 2022, 2:45 PM UTC (32e15f3)">Preview</a> | <a href="https://whatpr.org/fetch/1423/92b3578...32e15f3.html" title="Last updated on Apr 5, 2022, 2:45 PM UTC (32e15f3)">Diff</a>