### PR TITLE
Separate DNS  timing info from proxy resolution

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2515,11 +2515,12 @@ steps:
    <li><p>If <var>proxy</var> is "<code>DIRECT</code>", then set <var>hosts</var> to the result of
    running <a>resolve an origin</a> given <var>key</var> and <var>url</var>'s <a for=url>origin</a>.
 
-   <li><p>If <var>hosts</var> is failure, then <a for=iteration>continue</a>.
-
    <li><p>Let <var>timingInfo</var> be a new <a for=/>connection timing info</a> whose
    <a for="connection timing info">domain lookup start time</a> is
-   <var>domainLookupStartTime</var>.
+   <var>domainLookupStartTime</var> and <a for="connection timing info">domain lookup end time</a>
+   is the <a for=/>unsafe shared current time</a>.
+
+   <li><p>If <var>hosts</var> is failure, then <a for=iteration>continue</a>.
 
    <li>
     <p>Let <var>connection</var> be the result of running this step: run <a>create a connection</a>
@@ -2617,9 +2618,6 @@ boolean <var>http3Only</var>, run these steps:
 <a for=connection>timing info</a> and observe these requirements:
 
 <ul>
- <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> should be
- the time after resolving the IP address of the server or proxy. [[SVCB]]
-
  <li>
   <p><var>timingInfo</var>'s <a for="connection timing info">connection end time</a> should be the
   <a for=/>unsafe shared current time</a> immediately after establishing the connection to the

--- a/fetch.bs
+++ b/fetch.bs
@@ -2493,6 +2493,8 @@ steps:
    <a>connection</a>.
   </ol>
 
+ <li><p>Let <var>domainLookupStartTime</var> be the <a for=/>unsafe shared current time</a>.
+
  <li>
   <p>Let <var>proxies</var> be the result of finding proxies for <var>url</var> in an
   <a>implementation-defined</a> manner. If there are no proxies, let <var>proxies</var> be
@@ -2504,15 +2506,10 @@ steps:
   into play. The "<code>DIRECT</code>" value means to not use a proxy for this particular
   <var>url</var>.
 
- <li><p>Let <var>timingInfo</var> be a new <a for=/>connection timing info</a>.
-
  <li>
   <p><a for=list>For each</a> <var>proxy</var> of <var>proxies</var>:
 
   <ol>
-   <li><p>Set <var>timingInfo</var>'s <a for="connection timing info">domain lookup start time</a>
-   to the <a for=/>unsafe shared current time</a>.
-
    <li><p>Let <var>hosts</var> be « <var>origin</var>'s <a for=origin>host</a> ».
 
    <li><p>If <var>proxy</var> is "<code>DIRECT</code>", then set <var>hosts</var> to the result of
@@ -2524,6 +2521,10 @@ steps:
    the <a for=/>unsafe shared current time</a>.
 
    <li>
+    <li><p>Let <var>timingInfo</var> be a new <a for=/>connection timing info</a> whose
+    <a for="connection timing info">domain lookup start time</a> is
+    <var>domainLookupStartTime</var>.
+
     <p>Let <var>connection</var> be the result of running this step: run <a>create a connection</a>
     given <var>key</var>, <var>url</var>'s <a for=url>origin</a>, <var>credentials</var>,
     <var>proxy</var>, an <a>implementation-defined</a> <a for=/>host</a> from <var>hosts</var>,
@@ -2619,6 +2620,9 @@ boolean <var>http3Only</var>, run these steps:
 <a for=connection>timing info</a> and observe these requirements:
 
 <ul>
+ <li><p><var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> should be
+ the time after resolving the IP address of the server or proxy. [[SVCB]]
+
  <li>
   <p><var>timingInfo</var>'s <a for="connection timing info">connection end time</a> should be the
   <a for=/>unsafe shared current time</a> immediately after establishing the connection to the

--- a/fetch.bs
+++ b/fetch.bs
@@ -2517,14 +2517,11 @@ steps:
 
    <li><p>If <var>hosts</var> is failure, then <a for=iteration>continue</a>.
 
-   <li><p>Set <var>timingInfo</var>'s <a for="connection timing info">domain lookup end time</a> to
-   the <a for=/>unsafe shared current time</a>.
+   <li><p>Let <var>timingInfo</var> be a new <a for=/>connection timing info</a> whose
+   <a for="connection timing info">domain lookup start time</a> is
+   <var>domainLookupStartTime</var>.
 
    <li>
-    <li><p>Let <var>timingInfo</var> be a new <a for=/>connection timing info</a> whose
-    <a for="connection timing info">domain lookup start time</a> is
-    <var>domainLookupStartTime</var>.
-
     <p>Let <var>connection</var> be the result of running this step: run <a>create a connection</a>
     given <var>key</var>, <var>url</var>'s <a for=url>origin</a>, <var>credentials</var>,
     <var>proxy</var>, an <a>implementation-defined</a> <a for=/>host</a> from <var>hosts</var>,


### PR DESCRIPTION
Creating a connection info for each potential connection in proxy, all with the same `domain lookup start time`. The selected connection attaches its timing info to the response.

This ensures that resource timing doesn't expose timing related to proxy selection, which should remain private and not be web exposed.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Still unable to test this stuff in WPT, but moving towards it, see https://github.com/web-platform-tests/rfcs/pull/112
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1429.html" title="Last updated on Apr 26, 2022, 1:34 PM UTC (7a2f4a2)">Preview</a> | <a href="https://whatpr.org/fetch/1429/14898c0...7a2f4a2.html" title="Last updated on Apr 26, 2022, 1:34 PM UTC (7a2f4a2)">Diff</a>