### PR TITLE
Add a render-blocking boolean flag to the request concept

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1869,6 +1869,12 @@ otherwise, it is unset.
 <a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
 
+<p>A <a for=/>request</a> has an associated boolean
+<dfn export for=request id=concept-request-render-blocking>render-blocking</dfn>.
+Unless stated otherwise, it is false.
+
+<p class=note>This flag is for exclusive use by HTML's render-blocking mechanism. [[!HTML]]
+
 <hr>
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
@@ -3984,8 +3990,9 @@ the request.
 
  <li>
   <p>If <var>request</var>'s <a for=request>priority</a> is null, then use <var>request</var>'s
-  <a for=request>initiator</a> and <a for=request>destination</a> appropriately in setting
-  <var>request</var>'s <a for=request>priority</a> to a user-agent-defined object.
+  <a for=request>initiator</a>, <a for=request>destination</a> and
+  <a for=request>render-blocking</a> appropriately in setting <var>request</var>'s
+  <a for=request>priority</a> to a user-agent-defined object.
 
   <p class=note>The user-agent-defined object could encompass stream weight and dependency for
   HTTP/2, and equivalent information used to prioritize dispatch and processing of HTTP/1 fetches.

--- a/fetch.bs
+++ b/fetch.bs
@@ -1833,6 +1833,11 @@ Unless stated otherwise, it is false.
 
 <p class=note>This is for exclusive use by HTML's navigate algorithm. [[!HTML]]
 
+<p>A <a for=/>request</a> has an associated boolean <dfn export for=request>render-blocking</dfn>.
+Unless stated otherwise, it is false.
+
+<p class=note>This flag is for exclusive use by HTML's render-blocking mechanism. [[!HTML]]
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -1868,12 +1873,6 @@ otherwise, it is unset.
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
 <a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
-
-<p>A <a for=/>request</a> has an associated boolean
-<dfn export for=request id=concept-request-render-blocking>render-blocking</dfn>.
-Unless stated otherwise, it is false.
-
-<p class=note>This flag is for exclusive use by HTML's render-blocking mechanism. [[!HTML]]
 
 <hr>
 
@@ -3990,7 +3989,7 @@ the request.
 
  <li>
   <p>If <var>request</var>'s <a for=request>priority</a> is null, then use <var>request</var>'s
-  <a for=request>initiator</a>, <a for=request>destination</a> and
+  <a for=request>initiator</a>, <a for=request>destination</a>, and
   <a for=request>render-blocking</a> appropriately in setting <var>request</var>'s
   <a for=request>priority</a> to a user-agent-defined object.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Fixes #1433. The HTML-side counterpart is whatwg/html#7885.

This is also a minor follow-up of whatwg/html#7474.

- [X] At least two implementers are interested (and none opposed):
   * See whatwg/html#7474
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The render-blocking flag itself is not web-exposed and can't be tested against with WPT
   * The flag may affect [priority](https://fetch.spec.whatwg.org/#concept-request-priority), which is a UA-defined object and cannot be tested against with WPT, either.
      * Blink-specific tests are at https://chromium-review.googlesource.com/c/chromium/src/+/3627294
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * See whatwg/html#7474

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1432.html" title="Last updated on May 23, 2022, 9:12 PM UTC (96a7020)">Preview</a> | <a href="https://whatpr.org/fetch/1432/a15074d...96a7020.html" title="Last updated on May 23, 2022, 9:12 PM UTC (96a7020)">Diff</a>