### PR TITLE
Only allow blob: URLs that have a backing blob

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4503,12 +4503,14 @@ steps:
     <a for="fetch params">canceled</a>:
 
     <ol>
-     <li><p>Let <var>blob</var> be <var>request</var>'s <a for=request>current URL</a>'s
-     <a for=url>blob URL entry</a>'s <a for="blob URL entry">object</a>.
+     <li><p>Let <var>blobURLEntry</var> be <var>request</var>'s <a for=request>current URL</a>'s
+     <a for=url>blob URL entry</a>.
 
      <li>
-      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>` or
-      <var>blob</var> is not a {{Blob}} object, then return a <a>network error</a>. [[!FILEAPI]]
+      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>`,
+      <var>blobURLEntry</var> is null, or <var>blobURLEntry</var>'s
+      <a for="blob URL entry">object</a> is not a {{Blob}} object, then return a
+      <a>network error</a>. [[!FILEAPI]]
 
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
       other than being interoperable.


### PR DESCRIPTION
Document the need to return a network error on fetch if the blob URL has
no backing blob.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/33941
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

Fixes: https://github.com/whatwg/fetch/issues/1077

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1435.html" title="Last updated on May 13, 2022, 1:13 PM UTC (3fccfa7)">Preview</a> | <a href="https://whatpr.org/fetch/1435/3ab5102...3fccfa7.html" title="Last updated on May 13, 2022, 1:13 PM UTC (3fccfa7)">Diff</a>