### PR TITLE
Define opaque-response blocking 

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -33,6 +33,11 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
         url:dfn-coarsened-shared-current-time;text:coarsened shared current time
         url:dfn-unsafe-shared-current-time;text:unsafe shared current time
     type:typedef;url:dom-domhighrestimestamp;text:DOMHighResTimeStamp
+
+urlPrefix: https://tc39.es/ecma262/;type:dfn;spec:ecma-262
+    url:sec-parsetext;text:ParseText
+    url:prod-Script;text:Script
+    url:script-record;text:Script Record
 </pre>
 
 <pre class=link-defaults>
@@ -1839,6 +1844,16 @@ Unless stated otherwise, it is false.
 
 <p class=note>This is for exclusive use by HTML's navigate algorithm. [[!HTML]]
 
+<p class=XXX>A <a for=/>request</a> has an associated
+<dfn export for=request>no-cors media request state</dfn> ...
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
+<p>A <a for=/>request</a> has an associated <a>no-cors JavaScript fallback encoding</a> (an
+<a for=/>encoding</a>). Unless stated otherwise, it is <a for=/>UTF-8</a>.
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -2869,6 +2884,198 @@ run these steps:
 
  <li><p>Return <b>allowed</b>.
 </ol>
+
+
+<h3 id=orb>Opaque-response blocking</h3>
+
+<div class=note>
+ <p>Opaque-response blocking, also known as <abbr>ORB</abbr>, is a network filter that blocks access
+ to <a>opaque filtered responses</a>. These responses would likely would not have been useful to the
+ fetching party. Blocking them reduces information leakage to potential attackers.
+
+ <p>Essentially, CSS, JavaScript, images, and media (audio and video) can be requested across
+ origins without the <a>CORS protocol</a>. And unfortunately except for CSS there is no MIME type
+ enforcement. This algorithm aims to block as many responses as possible that are not one of these
+ types (or are newer variants of those types) to avoid leaking their contents through side channels.
+
+ <p>The network filter combines pro-active blocking based on response headers, sniffing a limited
+ set of bytes, and ultimately falls back to a full parse due to unfortunate (lack of) design
+ decisions in the early days of the web platform. As a result there are still quite a few responses
+ whose secrets can end up being revealed to attackers. Web developers are strongly encouraged to use
+ the `<code http-header>Cross-Origin-Resource-Policy</code>` response header to defend them.
+</div>
+
+
+<h4 id=orb-algorithm>The opaque-response-safelist check</h4>
+
+<p>The <dfn>opaque-response-safelist check</dfn>, given a <a for=/>request</a> <var>request</var>
+and a <a for=/>response</a> <var>response</var>, is to run these steps:
+
+<ol>
+ <li><p>Let <var>mimeType</var> be the result of <a>extracting a MIME type</a> from
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>Let <var>nosniff</var> be the result of <a>determining nosniff</a> given
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li>
+  <p>If <var>mimeType</var> is not failure, then:
+
+  <ol>
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-safelisted MIME type</a>, then return
+   true.
+
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-blocklisted-never-sniffed MIME type</a>,
+   then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is an
+   <a>opaque-response-blocklisted MIME type</a>, then return false.
+
+   <li><p>If <var>nosniff</var> is true and <var>mimeType</var> is an
+   <a>opaque-response-blocklisted MIME type</a> or its <a for="MIME type">essence</a> is
+   "<code>text/plain</code>", then return false.
+  </ol>
+
+ <li><p>If <var>request</var>'s <a for=request>no-cors media request state</a> is
+ "<code>subsequent</code>", then return true.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and
+ <a>validate a partial response</a> given 0 and <var>response</var> returns invalid, then return
+ false.
+ <!-- TODO Integrate https://wicg.github.io/background-fetch/#validate-a-partial-response into Fetch -->
+
+ <li><p>Wait for 1024 bytes of <var>response</var>'s <a for=response>body</a> or end-of-file,
+ whichever comes first and let <var>bytes</var> be those bytes.
+ <!-- TODO Obtaining these bytes needs to be defined in terms of a transform stream. -->
+
+ <li>
+  <p>If the <a>audio or video type pattern matching algorithm</a> given <var>bytes</var> does not
+  return undefined, then:
+
+  <ol>
+   <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+   "<code>initial</code>", then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is not 200 or 206, then return false.
+
+   <li><p>Return true.
+  </ol>
+
+ <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+ "<code>N/A</code>", then return false.
+
+ <li><p>If the <a>image type pattern matching algorithm</a> given <var>bytes</var> does not return
+ undefined, then return true.
+
+ <li>
+  <p>If <var>nosniff</var> is true, then return false.
+
+  <p class=note>This check is made late as unfortunately images and media are always sniffed.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is not an <a>ok status</a>, then return
+ false.
+
+ <li>
+  <p>If <var>mimeType</var> is failure, then return true.
+
+  <p class=note>This could be improved at somewhat significant cost. See
+  <a href=https://github.com/annevk/orb/issues/28>annevk/orb #28</a>.
+
+ <li><p>If <var>mimeType</var>'s <a for="MIME type">essence</a> <a for=string>starts with</a>
+ "<code>audio/</code>", "<code>image/</code>", or "<code>video/</code>", then return false.
+
+ <li><p>Let <var>responseBodyBytes</var> be null.
+
+ <li>
+  <p>Let <var>processBody</var> given a <a for=/>byte sequence</a> <var>bytes</var> be these steps:
+
+  <ol>
+   <li><p>Set <var>responseBodyBytes</var> to <var>bytes</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the <a for="body with type">body</a>
+   of the result of <a for=BodyInit>safely extracting</a> <var>bytes</var>.
+  </ol>
+
+ <li><p>Let <var>processBodyError</var> be this step: set <var>responseBodyBytes</var> to failure.
+
+ <li><p><a>Fully read</a> <var>response</var>'s <a for=response>body</a> given <a>processBody</a>
+ and <var>processBodyError</var>.
+
+ <li><p>Wait for <var>responseBodyBytes</var> to be non-null.
+
+ <li><p>If <var>responseBodyBytes</var> is failure, then return false.
+
+ <li><p><a for=/>Assert</a>: <var>responseBodyBytes</var> is a <a for=/>byte sequence</a>.
+
+ <li><p>If <a>parse JSON bytes to a JavaScript value</a> given <var>responseBodyBytes</var> does not
+ throw, then return false. If it throws, catch the exception and ignore it.
+
+ <li><p>Let <var>sourceText</var> be the result of <a for=/>decoding</a>
+ <var>responseBodyBytes</var> given <var>request</var>'s
+ <a for=request>no-cors JavaScript fallback encoding</a>.
+
+ <li><p>If <a>ParseText</a>(<var>sourceText</var>, <a>Script</a>) returns a <a>Script Record</a>,
+ then return true.
+ <!-- Ideally HTML owns this so ECMAScript changes don't end up impacting Fetch. We could
+      potentially make this use "create a classic script" instead with some mock data. Maybe that is
+      better? -->
+
+ <li><p>Return false.
+</ol>
+
+
+<h4 id=orb-mime-type-sets>New MIME type sets</h4>
+
+<p class=note>The definitions in this section are solely for the purpose of abstracting parts of the
+<a>opaque-response-safelist check</a>. They are not suited for usage elsewhere.
+
+<p>An <dfn>opaque-response-safelisted MIME type</dfn> is a <a>JavaScript MIME type</a> or a
+<a for=/>MIME type</a> whose <a for="MIME type">essence</a> is "<code>text/css</code>" or
+"<code>image/svg+xml</code>".
+
+<p>An <dfn>opaque-response-blocklisted MIME type</dfn> is an <a>HTML MIME type</a>,
+<a>JSON MIME type</a>, or <a>XML MIME type</a>.
+
+<p>An <dfn>opaque-response-blocklisted-never-sniffed MIME type</dfn> is a <a for=/>MIME type</a>
+whose <a for="MIME type">essence</a> is one of:
+
+<ul class=brief>
+ <li>"<code>application/gzip</code>"
+ <li>"<code>application/msexcel</code>"
+ <li>"<code>application/mspowerpoint</code>"
+ <li>"<code>application/msword</code>"
+ <li>"<code>application/msword-template</code>"
+ <li>"<code>application/pdf</code>"
+ <li>"<code>application/vnd.ces-quickpoint</code>"
+ <li>"<code>application/vnd.ces-quicksheet</code>"
+ <li>"<code>application/vnd.ces-quickword</code>"
+ <li>"<code>application/vnd.ms-excel</code>"
+ <li>"<code>application/vnd.ms-excel.sheet.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-powerpoint</code>"
+ <li>"<code>application/vnd.ms-powerpoint.presentation.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-word</code>"
+ <li>"<code>application/vnd.ms-word.document.12</code>"
+ <li>"<code>application/vnd.ms-word.document.macroenabled.12</code>"
+ <li>"<code>application/vnd.msword</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.presentation</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.document</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.template</code>"
+ <li>"<code>application/vnd.presentation-openxml</code>"
+ <li>"<code>application/vnd.presentation-openxmlm</code>"
+ <li>"<code>application/vnd.spreadsheet-openxml</code>"
+ <li>"<code>application/vnd.wordprocessing-openxml</code>"
+ <li>"<code>application/x-gzip</code>"
+ <li>"<code>application/x-protobuf</code>"
+ <li>"<code>application/x-protobuffer</code>"
+ <li>"<code>application/zip</code>"
+ <li>"<code>multipart/byteranges</code>"
+ <li>"<code>multipart/signed</code>"
+ <li>"<code>text/event-stream</code>"
+ <li>"<code>text/csv</code>"
+</ul>
 
 
 
@@ -4075,8 +4282,14 @@ steps:
 
      <li><p>Set <var>request</var>'s <a for=request>response tainting</a> to "<code>opaque</code>".
 
-     <li><p>Return the result of running <a>scheme fetch</a> given <var>fetchParams</var>.
+     <li><p>Let <var>opaqueResponse</var> be the result of running <a>scheme fetch</a> given
+     <var>fetchParams</var>.
      <!-- file URLs end up here as they are not same-origin typically. -->
+
+     <li><p>If the <a>opaque-response-safelist check</a> given <var>request</var> and
+     <var>opaqueResponse</var> returns true, then return <var>opaqueResponse</var>.
+
+     <li><p>Return a <a>network error</a>.
     </ol>
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is not an
@@ -8305,6 +8518,7 @@ Mohamed Zergaoui,
 Mohammed Zubair Ahmed<!-- M-ZubairAhmed; GitHub -->,
 Moritz Kneilmann,
 Ms2ger,
+Nathan Froyd,
 Nico Schlömer,
 Nicolás Peña Moreno,
 Nikhil Marathe,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3547,61 +3547,6 @@ X-Content-Type-Options           = "nosniff" ; case-insensitive
 pertain to them. Also, considering "<code>image</code>" was not compatible with deployed content.
 
 
-<h3 id=corb>CORB</h3>
-
-<p class="note">Cross-origin read blocking, better known as CORB, is an algorithm which identifies
-dubious cross-origin resource fetches (e.g., fetches that would fail anyway like attempts to render
-JSON inside an <code>img</code> element) and blocks them before they reach a web page. CORB reduces
-the risk of leaking sensitive data by keeping it further from cross-origin web pages.
-
-<p>A <dfn>CORB-protected MIME type</dfn> is an <a>HTML MIME type</a>, a <a>JSON MIME type</a>, or an
-<a>XML MIME type</a> excluding <code>image/svg+xml</code>.
-
-<p class="note no-backref">Even without CORB, accessing the content of cross-origin resources with
-<a>CORB-protected MIME types</a> is either managed by the <a>CORS protocol</a> (e.g., in case of
-{{XMLHttpRequest}}), not observable (e.g., in case of pings or CSP reports which ignore the
-response), or would result in an error (e.g., when failing to decode an HTML document embedded in an
-<code>img</code> element as an image). This means that CORB can block
-<a>CORB-protected MIME types</a> resources without being disruptive to web pages.
-
-<p>To perform a <dfn noexport>CORB check</dfn>, given a <var>request</var> and <var>response</var>,
-run these steps:</p>
-
-<ol>
- <li>
-  <p>If <var>request</var>'s <a for=request>initiator</a> is "<code>download</code>", then return
-  <b>allowed</b>.
-
-  <p class=XXX>If we recast downloading as navigation this step can be removed.
-
- <li><p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is not an
- <a>HTTP(S) scheme</a>, then return <b>allowed</b>.
-
- <li><p>Let <var>mimeType</var> be the result of <a for="header list">extracting a MIME type</a>
- from <var>response</var>'s <a for=response>header list</a>.
-
- <li><p>If <var>mimeType</var> is failure, then return <b>allowed</b>.
-
- <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is a
- <a>CORB-protected MIME type</a>, then return <b>blocked</b>.
-
- <li>
-  <p>If <a>determine nosniff</a> with <var>response</var>'s <a for=response>header list</a> is true
-  and <var>mimeType</var> is a <a>CORB-protected MIME type</a> or its <a for="MIME type">essence</a>
-  is "<code>text/plain</code>", then return <b>blocked</b>.
-
-  <p class="note no-backref">CORB only protects <code>text/plain</code> responses with a
-  `<code>X-Content-Type-Options: nosniff</code>` header. Unfortunately, protecting such responses
-  without that header when their <a for=response>status</a> is 206 would break too many existing
-  video responses that have a <code>text/plain</code> <a for=/>MIME type</a>.
-
- <!-- TODO: MIME type confirmation sniffing -->
- <!-- TODO: JSON security prefix sniffing -->
-
- <li><p>Return <b>allowed</b>.
-</ol>
-
-
 <h3 id=cross-origin-resource-policy-header>`<code>Cross-Origin-Resource-Policy</code>` header</h3>
 
 <p>The
@@ -4119,35 +4064,19 @@ steps:
     <a>HTTP(S) scheme</a>.
     [[!HTML]] [[!SW]]
 
-   <dt><var>request</var>'s <a for=request>mode</a> is
-   "<code>same-origin</code>"
+   <dt><var>request</var>'s <a for=request>mode</a> is "<code>same-origin</code>"
    <dd><p>Return a <a>network error</a>.
 
-   <dt><var>request</var>'s <a for=request>mode</a> is
-   "<code>no-cors</code>"
+   <dt><var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>"
    <dd>
     <ol>
      <li><p>If <var>request</var>'s <a for=request>redirect mode</a> is not "<code>follow</code>",
      then return a <a>network error</a>.
 
-     <li><p>Set <var>request</var>'s
-     <a for=request>response tainting</a> to
-     "<code>opaque</code>".
+     <li><p>Set <var>request</var>'s <a for=request>response tainting</a> to "<code>opaque</code>".
 
-     <li><p>Let <var>noCorsResponse</var> be the result of running <a>scheme fetch</a> given
-     <var>fetchParams</var>.
+     <li><p>Return the result of running <a>scheme fetch</a> given <var>fetchParams</var>.
      <!-- file URLs end up here as they are not same-origin typically. -->
-
-     <li><p>If <var>noCorsResponse</var> is a <a>filtered response</a> or the <a>CORB check</a> with
-     <var>request</var> and <var>noCorsResponse</var> returns <b>allowed</b>, then return
-     <var>noCorsResponse</var>.
-
-     <li>
-      <p>Return a new <a for=/>response</a> whose <a for=response>status</a> is
-      <var>noCorsResponse</var>'s <a for=response>status</a>.
-
-      <p class="warning">This is only an effective defense against side channel attacks if
-      <var>noCorsResponse</var> is kept isolated from the process that initiated the request.
     </ol>
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> is not an


### PR DESCRIPTION
This is good enough for early review, but there are a number of issues that still need resolving: https://github.com/annevk/orb/labels/mvp.

There are also some inline TODO comments.

A PR against HTML is needed to ensure it passes the appropriate metadata for media element and classic script requests. We might also want to depend on HTML for parsing JavaScript.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
