### PR TITLE
Disallow streaming upload on HTTP/1.1 connections

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5434,8 +5434,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch timing info">post-redirect start time</a>, and <var>fetchParams</var>'s
    <a for="fetch params">cross-origin isolated capability</a>.
 
-   <li><p>If <var>connection</var> is neither an HTTP/2 nor an HTTP/3 connection,
-   <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
+   <li><p>If <var>connection</var> is an HTTP/1.x connection, <var>request</var>'s
+   <a for=request>body</a> is non-null, and <var>request</var>'s
    <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
 
    <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final network-request start time</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -5435,8 +5435,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch params">cross-origin isolated capability</a>.
 
    <li><p>If <var>connection</var> is an HTTP/1.x connection, <var>request</var>'s
-   <a for=request>body</a> is non-null, and <var>request</var>'s
-   <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
+   <a for=request>body</a> is non-null, and <var>request</var>'s <a for=request>body</a>'s
+   <a for=body>source</a> is null, then return a <a>network error</a>.
 
    <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final network-request start time</a>
    to the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
@@ -5509,10 +5509,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and
     therefore <var>response</var> represents both a <a for=/>response</a> and
     an HTTP response here.
-
-    <p>If <var>request</var>'s <a for=request>header list</a> contains
-    (`<code>Transfer-Encoding</code>`, `<code>chunked</code>`) and <var>response</var> is
-    transferred via HTTP/1.0 or older, then return a <a>network error</a>.
 
     <p>If the HTTP request results in a TLS client certificate dialog, then:
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5434,11 +5434,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch timing info">post-redirect start time</a>, and <var>fetchParams</var>'s
    <a for="fetch params">cross-origin isolated capability</a>.
 
-   <li><p>If <var>connection</var> is not an HTTP/2 connection, <var>request</var>'s
-   <a for=request>body</a> is non-null, and <var>request</var>'s <a for=request>body</a>'s
-   <a for=body>source</a> is null, then <a for="header list">append</a>
-   (`<code>Transfer-Encoding</code>`, `<code>chunked</code>`) to <var>request</var>'s
-   <a for=request>header list</a>.
+   <li><p>If <var>connection</var> is neither an HTTP/2 nor an HTTP/3 connection,
+   <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
+   <a for=request>body</a>'s <a for=body>source</a> is null, then return a <a>network error</a>.
 
    <li>Set <var>timingInfo</var>'s <a for="fetch timing info">final network-request start time</a>
    to the <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s


### PR DESCRIPTION
This is to reduce the risk to break existing HTTP/1.1 servers.

See #966, #1438.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1444.html" title="Last updated on Jun 16, 2022, 8:12 AM UTC (829c52e)">Preview</a> | <a href="https://whatpr.org/fetch/1444/78f9bdd...829c52e.html" title="Last updated on Jun 16, 2022, 8:12 AM UTC (829c52e)">Diff</a>