### PR TITLE
Add algorithm to extract an encoding from a MIME type

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3492,18 +3492,18 @@ Content-Type:
 </div>
 
 <p>To <dfn export>legacy extract an encoding</dfn> given failure or a <a for=/>MIME type</a>
-<var>mimeType</var> and an <a for=/>encoding</a> <var>encoding</var>, run these steps:
+<var>mimeType</var> and an <a for=/>encoding</a> <var>fallbackEncoding</var>, run these steps:
 
 <ol>
- <li><p>If <var>mimeType</var> is failure, then return <var>encoding</var>.
+ <li><p>If <var>mimeType</var> is failure, then return <var>fallbackEncoding</var>.
 
  <li><p>If <var>mimeType</var>["<code>charset</code>"] does not <a for=map>exist</a>, then return
- <var>encoding</var>.
+ <var>fallbackEncoding</var>.
 
  <li><p>Let <var>tentativeEncoding</var> be the result of <a for=/>getting an encoding</a> from
  <var>mimeType</var>["<code>charset</code>"].
 
- <li><p>If <var>tentativeEncoding</var> is failure, then return <var>encoding</var>.
+ <li><p>If <var>tentativeEncoding</var> is failure, then return <var>fallbackEncoding</var>.
 
  <li><p>Return <var>tentativeEncoding</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -3491,6 +3491,30 @@ Content-Type:
  </table>
 </div>
 
+<p>To <dfn export>legacy extract an encoding</dfn> given failure or a <a for=/>MIME type</a>
+<var>mimeType</var> and an <a for=/>encoding</a> <var>encoding</var>, run these steps:
+
+<ol>
+ <li><p>If <var>mimeType</var> is failure, then return <var>encoding</var>.
+
+ <li><p>If <var>mimeType</var>["<code>charset</code>"] does not <a for=map>exist</a>, then return
+ <var>encoding</var>.
+
+ <li><p>Let <var>tentativeEncoding</var> be the result of <a for=/>getting an encoding</a> from
+ <var>mimeType</var>["<code>charset</code>"].
+
+ <li><p>If <var>tentativeEncoding</var> is failure, then return <var>encoding</var>.
+
+ <li><p>Return <var>tentativeEncoding</var>.
+</ol>
+
+<div class=note>
+ <p>This algorithm allows <var>mimeType</var> to be failure so it can be more easily combined with
+ <a>extract a MIME type</a>.
+
+ <p>It is denoted as legacy as modern formats are to exclusively use <a for=/>UTF-8</a>.
+</div>
+
 
 <h3 id=x-content-type-options-header>`<code>X-Content-Type-Options</code>` header</h3>
 


### PR DESCRIPTION
This is useful for HTML's fetch a classic script and Fetch's upcoming opaque-response blocking. It will also be useful to more tightly define equivalent legacy setups elsewhere.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1447.html" title="Last updated on Jun 1, 2022, 4:31 PM UTC (5d92f26)">Preview</a> | <a href="https://whatpr.org/fetch/1447/4128e96...5d92f26.html" title="Last updated on Jun 1, 2022, 4:31 PM UTC (5d92f26)">Diff</a>