### PR TITLE
Add render-blocking boolean to fetch timing info

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -289,6 +289,8 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 
  <dt><dfn export for="fetch timing info">server-timing headers</dfn> (default « »)
  <dd>A <a for=/>list</a> of strings.
+ <dt><dfn export for="fetch timing info">render-blocking</dfn> (default false)
+ <dd>A boolean.
 </dl>
 
 <p>A <dfn export>response body info</dfn> is a <a for=/>struct</a> used to maintain
@@ -3878,7 +3880,9 @@ the request.
  <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
  <a for="fetch timing info">start time</a> and
  <a for="fetch timing info">post-redirect start time</a> are the
- <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>.
+ <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>
+ and <a for="fetch timing info">render-blocking</a> is set to <var>request</var>'s
+ <a for=request>render-blocking</a>.
 
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
  <a for="fetch params">request</a> is <var>request</var>,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3880,8 +3880,8 @@ the request.
  <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
  <a for="fetch timing info">start time</a> and
  <a for="fetch timing info">post-redirect start time</a> are the
- <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>
- and <a for="fetch timing info">render-blocking</a> is set to <var>request</var>'s
+ <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>, and
+ <a for="fetch timing info">render-blocking</a> is set to <var>request</var>'s
  <a for=request>render-blocking</a>.
 
  <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
These changes are to support addition of a render blocking status field to Perfomance resource timing. Further details are available at https://github.com/w3c/resource-timing/pull/327

~~For HTML side changes see https://github.com/whatwg/html/pull/7979~~

- [x] At least two implementers are interested (and none opposed):
   * Chromium : https://chromestatus.com/feature/5166965277589504
   * Firefox : https://github.com/mozilla/standards-positions/issues/662#issuecomment-1171568555
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/3709521
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1337256
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1449.html" title="Last updated on Jul 28, 2022, 3:12 PM UTC (ff45bb8)">Preview</a> | <a href="https://whatpr.org/fetch/1449/4c93f89...ff45bb8.html" title="Last updated on Jul 28, 2022, 3:12 PM UTC (ff45bb8)">Diff</a>