### PR TITLE
Editorial: Update severals biblio refs to HTTP-SEMANTICS

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -43,13 +43,13 @@ spec:websockets; type:attribute; text:bufferedAmount; for:WebSocket
 <pre class=biblio>
 {
     "HTTP": {
-        "aliasOf": "RFC7230"
-    },
-    "HTTP-SEMANTICS": {
         "aliasOf": "RFC9110"
     },
     "HTTP-CACHING": {
-        "aliasOf": "RFC7234"
+        "aliasOf": "RFC9111"
+    },
+    "HTTP1": {
+        "aliasOf": "RFC9112"
     },
     "REFERRER": {
         "aliasOf": "referrer-policy"
@@ -182,7 +182,7 @@ and RFC 7405. [[!RFC7405]]
 
 <p><dfn id=credentials export>Credentials</dfn> are HTTP cookies, TLS client certificates, and <a
 lt="authentication entry">authentication entries</a> (for HTTP authentication). [[!COOKIES]]
-[[!TLS]] [[!HTTP-SEMANTICS]]
+[[!TLS]] [[!HTTP]]
 
 <hr>
 
@@ -1301,7 +1301,7 @@ these steps:
  <li><p>If <var>codings</var> are not supported, then return <var>bytes</var>.
 
  <li><p>Return the result of decoding <var>bytes</var> with <var>codings</var> as explained in HTTP,
- if decoding does not result in an error, and failure otherwise. [[!HTTP]] [[!HTTP-SEMANTICS]]
+ if decoding does not result in an error, and failure otherwise. [[!HTTP]]
 </ol>
 <!-- XXX https://github.com/whatwg/fetch/issues/716
          https://github.com/httpwg/http-core/issues/58 -->
@@ -1732,7 +1732,7 @@ Unless stated otherwise, it is unset.
   fetch will be made to update the entry in the HTTP cache. If the HTTP cache contains a matching
   <a>stale response</a>, a conditional network fetch will be returned to update the entry in
   the HTTP cache. Otherwise, a non-conditional network fetch will be returned to update the entry
-  in the HTTP cache. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]] [[!STALE-WHILE-REVALIDATE]]
+  in the HTTP cache. [[!HTTP]] [[!HTTP-CACHING]] [[!STALE-WHILE-REVALIDATE]]
 
   <dt>"<code>no-store</code>"
   <dd>Fetch behaves as if there is no HTTP cache at all.
@@ -2285,7 +2285,7 @@ or a <a for=/>URL</a>.
   <var>location</var>'s <a for=url>fragment</a> to <var>requestFragment</var>.
 
   <p class=note>This ensures that synthetic (indeed, all) responses follow the processing model for
-  redirects defined by HTTP. [[HTTP-SEMANTICS]]
+  redirects defined by HTTP. [[HTTP]]
 
  <li><p>Return <var>location</var>.
 </ol>
@@ -2321,7 +2321,7 @@ and associated with one or more <a for=/>requests</a>.
 functionality.
 <!-- fingerprinting -->
 
-<p>Further details are defined by HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
+<p>Further details are defined by HTTP. [[!HTTP]] [[!HTTP-CACHING]]
 
 
 <h3 id=fetch-groups>Fetch groups</h3>
@@ -2574,8 +2574,7 @@ boolean <var>http3Only</var>, run these steps:
   <a for=connection>credentials</a> is <var>credentials</var>, and <a for=connection>timing info</a>
   is <var>timingInfo</var>. <a for=/>Record connection timing info</a> given <var>connection</var>
   and use <var>connection</var> to establish an HTTP connection to <var>host</var>, taking
-  <var>proxy</var> and <var>origin</var> into account. [[!HTTP]] [[!HTTP-SEMANTICS]]
-  [[!HTTP-CACHING]] [[!TLS]]
+  <var>proxy</var> and <var>origin</var> into account. [[!HTTP]] [[!HTTP1]] [[!TLS]]
 
   <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]
 
@@ -2646,7 +2645,7 @@ boolean <var>http3Only</var>, run these steps:
   <p class=example id=example-connection-end-time>Suppose the user agent establishes an HTTP/2
   connection over TLS 1.3 to send a <code>GET</code> request and a <code>POST</code> request. It
   sends the ClientHello at time <var>t1</var> and then sends the <code>GET</code> request with early
-  data. The <code>POST</code> request is not safe ([[HTTP-SEMANTICS]], section 4.2.1), so the user
+  data. The <code>POST</code> request is not safe ([[HTTP]], section 9.2.1), so the user
   agent waits to complete the handshake at time <var>t2</var> before sending it. Although both
   requests used the same connection, the <code>GET</code> request reports a connection end time of
   <var>t1</var>, while the <code>POST</code> request reports <var>t2</var>.
@@ -4868,8 +4867,8 @@ steps. They return a <a for=/>response</a>.
 <var>isNewConnectionFetch</var> (default false), run these steps:
 
 <p class=note>Some implementations might support caching of partial content, as per
-<cite>HTTP Range Requests</cite>. However, this is not widely supported by browser caches.
-[[HTTP-SEMANTICS]]
+<cite>HTTP Caching</cite>. However, this is not widely supported by browser caches.
+[[HTTP-CACHING]]
 
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
@@ -5354,7 +5353,7 @@ steps. They return a <a for=/>response</a>.
    <li>
     <p>Prompt the end user as appropriate in <var>request</var>'s
     <a for=request>window</a> and store the result as a
-    <a>proxy-authentication entry</a>. [[!HTTP-SEMANTICS]]
+    <a>proxy-authentication entry</a>. [[!HTTP]]
 
     <p class=note>Remaining details surrounding proxy authentication are defined by HTTP.
 
@@ -5463,7 +5462,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     using <var>request</var> with the following caveats:
 
     <ul>
-     <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
+     <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-CACHING]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
@@ -8115,7 +8114,7 @@ however, it is perfectly fine to do so.
 <p>If <a>CORS protocol</a> requirements are more complicated than setting
 `<a http-header><code>Access-Control-Allow-Origin</code></a>` to <code>*</code> or a static
 <a for=/>origin</a>, `<code>Vary</code>` is to be used.
-[[!HTML]] [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
+[[!HTML]] [[!HTTP]] [[!HTTP-CACHING]]
 
 <pre id=example-vary-origin class=example><code class=lang-http>
 Vary: Origin

--- a/fetch.bs
+++ b/fetch.bs
@@ -46,19 +46,10 @@ spec:websockets; type:attribute; text:bufferedAmount; for:WebSocket
         "aliasOf": "RFC7230"
     },
     "HTTP-SEMANTICS": {
-        "aliasOf": "RFC7231"
-    },
-    "HTTP-COND": {
-        "aliasOf": "RFC7232"
+        "aliasOf": "RFC9110"
     },
     "HTTP-CACHING": {
         "aliasOf": "RFC7234"
-    },
-    "HTTP-RANGE": {
-        "aliasOf": "RFC7233"
-    },
-    "HTTP-AUTH": {
-        "aliasOf": "RFC7235"
     },
     "REFERRER": {
         "aliasOf": "referrer-policy"
@@ -191,7 +182,7 @@ and RFC 7405. [[!RFC7405]]
 
 <p><dfn id=credentials export>Credentials</dfn> are HTTP cookies, TLS client certificates, and <a
 lt="authentication entry">authentication entries</a> (for HTTP authentication). [[!COOKIES]]
-[[!TLS]] [[!HTTP-AUTH]]
+[[!TLS]] [[!HTTP-SEMANTICS]]
 
 <hr>
 
@@ -1741,8 +1732,7 @@ Unless stated otherwise, it is unset.
   fetch will be made to update the entry in the HTTP cache. If the HTTP cache contains a matching
   <a>stale response</a>, a conditional network fetch will be returned to update the entry in
   the HTTP cache. Otherwise, a non-conditional network fetch will be returned to update the entry
-  in the HTTP cache. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
-  [[!STALE-WHILE-REVALIDATE]]
+  in the HTTP cache. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]] [[!STALE-WHILE-REVALIDATE]]
 
   <dt>"<code>no-store</code>"
   <dd>Fetch behaves as if there is no HTTP cache at all.
@@ -2331,7 +2321,7 @@ and associated with one or more <a for=/>requests</a>.
 functionality.
 <!-- fingerprinting -->
 
-<p>Further details are defined by HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
+<p>Further details are defined by HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
 
 
 <h3 id=fetch-groups>Fetch groups</h3>
@@ -2584,8 +2574,8 @@ boolean <var>http3Only</var>, run these steps:
   <a for=connection>credentials</a> is <var>credentials</var>, and <a for=connection>timing info</a>
   is <var>timingInfo</var>. <a for=/>Record connection timing info</a> given <var>connection</var>
   and use <var>connection</var> to establish an HTTP connection to <var>host</var>, taking
-  <var>proxy</var> and <var>origin</var> into account. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]]
-  [[!HTTP-CACHING]] [[!HTTP-AUTH]] [[!TLS]]
+  <var>proxy</var> and <var>origin</var> into account. [[!HTTP]] [[!HTTP-SEMANTICS]]
+  [[!HTTP-CACHING]] [[!TLS]]
 
   <p>If <var>http3Only</var> is true, then establish an HTTP/3 connection. [[!HTTP3]]
 
@@ -4879,7 +4869,7 @@ steps. They return a <a for=/>response</a>.
 
 <p class=note>Some implementations might support caching of partial content, as per
 <cite>HTTP Range Requests</cite>. However, this is not widely supported by browser caches.
-[[HTTP-RANGE]]
+[[HTTP-SEMANTICS]]
 
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
@@ -5364,7 +5354,7 @@ steps. They return a <a for=/>response</a>.
    <li>
     <p>Prompt the end user as appropriate in <var>request</var>'s
     <a for=request>window</a> and store the result as a
-    <a>proxy-authentication entry</a>. [[!HTTP-AUTH]]
+    <a>proxy-authentication entry</a>. [[!HTTP-SEMANTICS]]
 
     <p class=note>Remaining details surrounding proxy authentication are defined by HTTP.
 
@@ -5473,7 +5463,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
     using <var>request</var> with the following caveats:
 
     <ul>
-     <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
+     <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
@@ -8125,8 +8115,7 @@ however, it is perfectly fine to do so.
 <p>If <a>CORS protocol</a> requirements are more complicated than setting
 `<a http-header><code>Access-Control-Allow-Origin</code></a>` to <code>*</code> or a static
 <a for=/>origin</a>, `<code>Vary</code>` is to be used.
-[[!HTML]]
-[[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-COND]] [[!HTTP-CACHING]] [[!HTTP-AUTH]]
+[[!HTML]] [[!HTTP]] [[!HTTP-SEMANTICS]] [[!HTTP-CACHING]]
 
 <pre id=example-vary-origin class=example><code class=lang-http>
 Vary: Origin


### PR DESCRIPTION
The new HTTP-SEMANTICS spec (https://www.rfc-editor.org/info/rfc9110)
obsoletes several other RFCs that are referenced from the Fetch spec.

Updated all of those refs to use HTTP-SEMANTICS.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1451.html" title="Last updated on Jun 8, 2022, 1:17 PM UTC (65b28d0)">Preview</a> | <a href="https://whatpr.org/fetch/1451/82bb961...65b28d0.html" title="Last updated on Jun 8, 2022, 1:17 PM UTC (65b28d0)">Diff</a>