### PR TITLE
Add `Set-Cookie` as a forbidden header name

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -997,6 +997,7 @@ is a <a>byte-case-insensitive</a> match for one of
  <li>`<code>Keep-Alive</code>`
  <li>`<a http-header><code>Origin</code></a>`
  <li>`<code>Referer</code>`
+ <li>`<code>Set-Cookie</code>`
  <li>`<code>TE</code>`
  <li>`<code>Trailer</code>`
  <li>`<code>Transfer-Encoding</code>`


### PR DESCRIPTION
Following a suggestion from @annevk in #973, this adds `set-cookie` as a
forbidden request header name. The rationale here is to prevent complication of
internal data structures for internal header lists that are attached to
`Request` objects, in light of #1346.

I added a UseCounter to Chromium in January to check that this is a web
compatible change. The analysis uncovered no issues, and as such I consider that
this change is web compatible. See
https://github.com/whatwg/fetch/issues/973#issuecomment-1154958094 for more
elaboration.

- [ ] At least two implementers are interested (and none opposed):
   * Deno
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
