### PR TITLE
Add support for parsing a suffix byte range spec

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1122,6 +1122,9 @@ run these steps:
  <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
+ <li><p>Let <var>rangeStartValue</var> be <var>rangeStart</var>, interpreted as decimal number, if
+ <var>rangeStart</var> is not the empty string; otherwise null.
+
  <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-),
  then return failure.
 
@@ -1130,25 +1133,21 @@ run these steps:
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
+ <li><p>Let <var>rangeEndValue</var> be <var>rangeEnd</var>, interpreted as decimal number, if
+ <var>rangeEnd</var> is not the empty string; otherwise null.
+
  <li><p>If <var>position</var> is not past the end of <var>data</var>, then return failure.
 
- <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0 and <var>rangeStart</var>'s
- <a for=string>length</a> is 0, then return failure.
+ <li><p>If <var>rangeEndValue</var> and <var>rangeStartValue</var> are null, then return failure.
 
- <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return (<var>rangeStart</var>,
- null).
+ <li><p>If <var>rangeStartValue</var> and <var>rangeEndValue</var> are numbers, and
+ <var>rangeStartValue</var> is greater than <var>rangeEndValue</var>, then return failure.
 
  <li>
-  <p>If <var>rangeStart</var>'s <a for=string>length</a> is 0, then return (null,
-  <var>rangeEnd</var>).
+  <p>Return (<var>rangeStartValue</var>, <var>rangeEndValue</var>).
 
   <p class="note">The range end or start can be omitted, e.g., `<code>bytes=0-</code>` or
   `<code>bytes=-500</code>` are valid ranges.
-
- <li><p>If <var>rangeStart</var>, interpreted as decimal number, is greater than
- <var>rangeEnd</var>, interpreted as decimal number, then return failure.
-
- <li><p>Return (<var>rangeStart</var>, <var>rangeEnd</var>).
 </ol>
 
 <p class=note><a>Parse a single range header value</a> succeeds for a subset of allowed range header

--- a/fetch.bs
+++ b/fetch.bs
@@ -887,7 +887,13 @@ fetch("https://victim.example/naïve-endpoint", {
     </div>
 
    <dt>`<code>range</code>`
-   <dd><p>If <var>value</var> is not a <a>simple range header value</a>, then return false.
+   <dd>
+    <ol>
+     <li><p>Let <var>rangeResult</var> be the result of <a>parse a single range header value</a>
+     given <var>value</var>.
+
+     <li><p>If <var>rangeResult</var> is failure, then return false.
+    </ol>
 
    <dt>Otherwise
    <dd><p>Return false.
@@ -1106,14 +1112,14 @@ run these steps:
  <li><p>Return <var>values</var>.
 </ol>
 
-<p>To determine if a <a>byte sequence</a> <var>value</var> is a
-<dfn>simple range header value</dfn>, perform the following steps. They return a <a>boolean</a>.
+<p>To <dfn lt="parse a single range header value|simple range header value">parse a single range header value</dfn>
+from a <a>byte sequence</a> <var>value</var>, run these steps:
 
 <ol>
  <li><p>Let <var>data</var> be the <a>isomorphic decoding</a> of <var>value</var>.
 
  <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes=</code>", then return
- false.
+ failure.
 
  <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
  pointing at the 6th <a>code point</a> of <var>data</var>.
@@ -1122,29 +1128,36 @@ run these steps:
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
  <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-),
- then return false.
+ then return failure.
 
  <li><p>Advance <var>position</var> by 1.
 
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
 
- <li><p>If <var>position</var> is not past the end of <var>data</var>, then return false.
+ <li><p>If <var>position</var> is not past the end of <var>data</var>, then return failure.
+
+ <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0 and <var>rangeStart</var>'s
+ <a for=string>length</a> is 0, then return failure.
+
+ <li><p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return (<var>rangeStart</var>,
+ null).
 
  <li>
-  <p>If <var>rangeEnd</var>'s <a for=string>length</a> is 0, then return true.
+  <p>If <var>rangeStart</var>'s <a for=string>length</a> is 0, then return (null, <var>rangeEnd</var>).
 
-  <p class="note">The range end can be omitted, e.g., `<code>bytes=0-</code>` is valid.
+  <p class="note">The range end or start can be omitted, e.g., `<code>bytes=0-</code>` or
+  `<code>bytes=-500</code>` are valid ranges.
 
  <li><p>If <var>rangeStart</var>, interpreted as decimal number, is greater than
- <var>rangeEnd</var>, interpreted as decimal number, then return false.
+ <var>rangeEnd</var>, interpreted as decimal number, then return failure.
 
- <li><p>Return true.
+ <li><p>Return (<var>rangeStart</var>, <var>rangeEnd</var>).
 </ol>
 
-<p class="note">A <a>simple range header value</a> is a subset of allowed range header values, but
-it is the most common form used by user agents when requesting media or resuming downloads. This
-format of range header value can be set using <a>add a range header</a>.
+<p class="note"><a>parse a single range header value</a> succeeds for a subset of allowed range
+header values, but it is the most common form used by user agents when requesting media or resuming
+downloads. This format of range header value can be set using <a>add a range header</a>.
 
 <hr>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -887,13 +887,8 @@ fetch("https://victim.example/naïve-endpoint", {
     </div>
 
    <dt>`<code>range</code>`
-   <dd>
-    <ol>
-     <li><p>Let <var>rangeResult</var> be the result of <a>parse a single range header value</a>
-     given <var>value</var>.
-
-     <li><p>If <var>rangeResult</var> is failure, then return false.
-    </ol>
+   <dd><p>If the result of <a>parse a single range header value</a> given <var>value</var> is
+   failure, then return false.
 
    <dt>Otherwise
    <dd><p>Return false.
@@ -1112,8 +1107,8 @@ run these steps:
  <li><p>Return <var>values</var>.
 </ol>
 
-<p>To <dfn lt="parse a single range header value|simple range header value">parse a single range header value</dfn>
-from a <a>byte sequence</a> <var>value</var>, run these steps:
+<p>To <dfn id=simple-range-header-value>parse a single range header value</dfn> from a
+<a>byte sequence</a> <var>value</var>, run these steps:
 
 <ol>
  <li><p>Let <var>data</var> be the <a>isomorphic decoding</a> of <var>value</var>.
@@ -1144,7 +1139,8 @@ from a <a>byte sequence</a> <var>value</var>, run these steps:
  null).
 
  <li>
-  <p>If <var>rangeStart</var>'s <a for=string>length</a> is 0, then return (null, <var>rangeEnd</var>).
+  <p>If <var>rangeStart</var>'s <a for=string>length</a> is 0, then return (null,
+  <var>rangeEnd</var>).
 
   <p class="note">The range end or start can be omitted, e.g., `<code>bytes=0-</code>` or
   `<code>bytes=-500</code>` are valid ranges.
@@ -1155,8 +1151,8 @@ from a <a>byte sequence</a> <var>value</var>, run these steps:
  <li><p>Return (<var>rangeStart</var>, <var>rangeEnd</var>).
 </ol>
 
-<p class="note"><a>parse a single range header value</a> succeeds for a subset of allowed range
-header values, but it is the most common form used by user agents when requesting media or resuming
+<p class=note><a>Parse a single range header value</a> succeeds for a subset of allowed range header
+values, but it is the most common form used by user agents when requesting media or resuming
 downloads. This format of range header value can be set using <a>add a range header</a>.
 
 <hr>


### PR DESCRIPTION
Add support for parsing a range header in the suffix byte range spec
form.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Partially [here](https://github.com/web-platform-tests/wpt/pull/34384#discussion_r898469534)
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1454.html" title="Last updated on Sep 23, 2022, 4:36 PM UTC (3ebbb33)">Preview</a> | <a href="https://whatpr.org/fetch/1454/0d95632...3ebbb33.html" title="Last updated on Sep 23, 2022, 4:36 PM UTC (3ebbb33)">Diff</a>