### PR TITLE
Expose decoded/encoded size for constructed responses

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4426,8 +4426,30 @@ steps:
   <ol>
    <li><p>Let <var>transformStream</var> be a new {{TransformStream}}.
 
-   <li><p>Let <var>identityTransformAlgorithm</var> be an algorithm which, given <var>chunk</var>,
-   <a for=TransformStream lt=enqueue>enqueues</a> <var>chunk</var> in <var>transformStream</var>.
+   <li>
+    <p>Let <var>identityTransformAlgorithm</var> be the following steps given
+    <a>byte sequence</a> <var>chunk</var>:
+
+    <ol>
+     <li><p><a for=TransformStream lt=enqueue>Enqueue</a> <var>chunk</var> in
+     <var>transformStream</var>.
+
+     <li>
+      <p>If <var>response</var>'s <a for=response>URL</a> is null, then:
+
+      <ol>
+       <li><p>Increment <var>response</var>'s <a for=response>body info</a>'s
+       <a for="response body info">encoded size</a> by <var>chunk</var>'s
+       <a for="byte sequence">length</a>.
+
+       <li><p>Set <var>response</var>'s <a for=response>body info</a>'s
+       <a for="response body info">decoded size</a> to <var>response</var>'s
+       <a for=response>body info</a>'s <a for="response body info">encoded size</a>
+      </ol>
+
+      <p class=note>This exposes the encoded/decoded size for responses created programmatically
+      using the {{Response}} object in a service worker. [[SW]]
+    </ol>
 
    <li><p><a for=TransformStream>Set up</a> <var>transformStream</var> with
    <a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to

--- a/fetch.bs
+++ b/fetch.bs
@@ -7558,6 +7558,9 @@ these steps:
  <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
  <var>init</var>["{{ResponseInit/status}}"].
 
+ <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>cache state</a> to
+ "<code>local</code>".
+
  <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status message</a>
  to <var>init</var>["{{ResponseInit/statusText}}"].
 


### PR DESCRIPTION
Keep track of chunk sizes as the response stream is being read.

Closes https://github.com/w3c/navigation-timing/issues/124

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/33283
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=925239
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1456.html" title="Last updated on Jul 5, 2022, 11:43 AM UTC (dbe8c93)">Preview</a> | <a href="https://whatpr.org/fetch/1456/4c93f89...dbe8c93.html" title="Last updated on Jul 5, 2022, 11:43 AM UTC (dbe8c93)">Diff</a>