### PR TITLE
Introduce RequestInit.duplex

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6888,7 +6888,7 @@ object), initially null.
    before starting receiving the response) fetch, and "full" for initiating a full-duplex (i.e.,
    the user agent starts receiving the response before sending all the request content) fetch.
    This needs to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The
-   semantics for "full" has not been specified yet. See
+   semantics for "full" have not been specified yet. See
    <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a>.</span>
 </dl>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6884,14 +6884,14 @@ object), initially null.
    <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
 
    <dt>{{RequestInit/duplex}}
-   <dd>"<code>half</code>" is the only valid value and it is for initiating a half-duplex (i.e.,
-   the user agent sends all the request content before starting receiving the response) fetch. We
-   reserve "<code>full</code>" for future use, for initiating a full-duplex (i.e., the user agent
-   starts receiving the response before sending all the request content) fetch. This member needs
-   to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The semantics for
-   "<code>full</code>" have not been specified yet. See
-   <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a>.</span>
-</dl>
+   <dd>"<code>half</code>" is the only valid value and it is for initiating a half-duplex fetch
+   (i.e., the user agent sends the entire request before processing the response).
+   "<code>full</code>" is reserved for future use, for initiating a full-duplex fetch (i.e., the
+   user agent can process the response before sending the entire request). This member needs to be
+   set when {{RequestInit/body}} is a {{ReadableStream}} object. <span class=note>See
+   <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a> for defining
+   "<code>full</code>".</span>
+  </dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>
  <dd>Returns <var>request</var>'s HTTP method, which is "<code>GET</code>" by default.

--- a/fetch.bs
+++ b/fetch.bs
@@ -6784,7 +6784,7 @@ dictionary RequestInit {
   DOMString integrity;
   boolean keepalive;
   AbortSignal? signal;
-  RequestDuplex? duplex;
+  RequestDuplex duplex;
   any window; // can only be set to null
 };
 
@@ -6793,7 +6793,7 @@ enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };
 enum RequestRedirect { "follow", "error", "manual" };
-enum RequestDuplex { "half", "full" };
+enum RequestDuplex { "half" };
 </pre>
 
 <p class="note no-backref">"<code>serviceworker</code>" is omitted from
@@ -6884,11 +6884,12 @@ object), initially null.
    <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
 
    <dt>{{RequestInit/duplex}}
-   <dd>"half" for initiating a half-duplex (i.e., the user agent send all the request content
-   before starting receiving the response) fetch, and "full" for initiating a full-duplex (i.e.,
-   the user agent starts receiving the response before sending all the request content) fetch.
-   This needs to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The
-   semantics for "full" have not been specified yet. See
+   <dd>"<code>half</code>" is the only valid value and it is for initiating a half-duplex (i.e.,
+   the user agent send all the request content before starting receiving the response) fetch. We
+   reserve "<code>full</code>" for future use, for initiating a full-duplex (i.e., the user agent
+   starts receiving the response before sending all the request content) fetch. This member needs
+   to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The semantics for
+   "<code>full</code>" have not been specified yet. See
    <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a>.</span>
 </dl>
 
@@ -7314,8 +7315,6 @@ constructor steps are:
 
  <li><p>Let <var>inputOrInitBody</var> be <var>initBody</var> if it is non-null; otherwise
  <var>inputBody</var>.
-
- <li><p>If <var>init</var>["{{RequestInit/duplex}}"] is "full", then throw a {{TypeError}}.
 
  <li>
   <p>If <var>inputOrInitBody</var> is non-null and <var>inputOrInitBody</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -6784,6 +6784,7 @@ dictionary RequestInit {
   DOMString integrity;
   boolean keepalive;
   AbortSignal? signal;
+  RequestDuplex? duplex;
   any window; // can only be set to null
 };
 
@@ -6792,6 +6793,7 @@ enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };
 enum RequestRedirect { "follow", "error", "manual" };
+enum RequestDuplex { "half", "full" };
 </pre>
 
 <p class="note no-backref">"<code>serviceworker</code>" is omitted from
@@ -6880,7 +6882,15 @@ object), initially null.
 
    <dt>{{RequestInit/window}}
    <dd>Can only be null. Used to disassociate <var>request</var> from any {{Window}}.
-  </dl>
+
+   <dt>{{RequestInit/duplex}}
+   <dd>"half" for initiating a half-duplex (i.e., the user agent send all the request content
+   before starting receiving the response) fetch, and "full" for initiating a full-duplex (i.e.,
+   the user agent starts receiving the response before sending all the request content) fetch.
+   This needs to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The
+   semantics for "full" has not been specified yet. See
+   <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a>.</span>
+</dl>
 
  <dt><code><var>request</var> . <a attribute for=Request>method</a></code>
  <dd>Returns <var>request</var>'s HTTP method, which is "<code>GET</code>" by default.
@@ -7305,11 +7315,15 @@ constructor steps are:
  <li><p>Let <var>inputOrInitBody</var> be <var>initBody</var> if it is non-null; otherwise
  <var>inputBody</var>.
 
+ <li><p>If <var>init</var>["{{RequestInit/duplex}}"] is "full", then throw a {{TypeError}}.
+
  <li>
   <p>If <var>inputOrInitBody</var> is non-null and <var>inputOrInitBody</var>'s
   <a for=body>source</a> is null, then:
 
   <ol>
+   <li><p>If <var>init</var>["{{RequestInit/duplex}}"] is null, then throw a {{TypeError}}.
+
    <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is neither
    "<code>same-origin</code>" nor "<code>cors</code>", then throw a {{TypeError}}.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -7322,8 +7322,8 @@ constructor steps are:
   <a for=body>source</a> is null, then:
 
   <ol>
-   <li><p>If <var>initBody</var> is non-null and <var>init</var>["{{RequestInit/duplex}}"] is null,
-   then throw a {{TypeError}}.
+   <li><p>If <var>initBody</var> is non-null and <var>init</var>["{{RequestInit/duplex}}"] does
+   not <a for=map>exist</a>, then throw a {{TypeError}}.
 
    <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is neither
    "<code>same-origin</code>" nor "<code>cors</code>", then throw a {{TypeError}}.

--- a/fetch.bs
+++ b/fetch.bs
@@ -7322,7 +7322,8 @@ constructor steps are:
   <a for=body>source</a> is null, then:
 
   <ol>
-   <li><p>If <var>init</var>["{{RequestInit/duplex}}"] is null, then throw a {{TypeError}}.
+   <li><p>If <var>initBody</var> is non-null and <var>init</var>["{{RequestInit/duplex}}"] is null,
+   then throw a {{TypeError}}.
 
    <li><p>If <a>this</a>'s <a for=Request>request</a>'s <a for=request>mode</a> is neither
    "<code>same-origin</code>" nor "<code>cors</code>", then throw a {{TypeError}}.

--- a/fetch.bs
+++ b/fetch.bs
@@ -6885,7 +6885,7 @@ object), initially null.
 
    <dt>{{RequestInit/duplex}}
    <dd>"<code>half</code>" is the only valid value and it is for initiating a half-duplex (i.e.,
-   the user agent send all the request content before starting receiving the response) fetch. We
+   the user agent sends all the request content before starting receiving the response) fetch. We
    reserve "<code>full</code>" for future use, for initiating a full-duplex (i.e., the user agent
    starts receiving the response before sending all the request content) fetch. This member needs
    to be set when {{RequestInit/body}} is a {{ReadableStream}}. <span class=note>The semantics for


### PR DESCRIPTION
Introduce the member, and throw if init.duplex is not set in the
Request constructor, as discussed at #1438.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Mozilla
   * Deno
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/34496
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1337696
   * Firefox: This is a part of the streaming upload feature.
   * Safari: This is a part of the streaming upload feature.
   * Deno (not for CORS changes): This is a part of the streaming upload feature.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1457.html" title="Last updated on Jul 1, 2022, 8:09 AM UTC (557f24d)">Preview</a> | <a href="https://whatpr.org/fetch/1457/4c93f89...557f24d.html" title="Last updated on Jul 1, 2022, 8:09 AM UTC (557f24d)">Diff</a>