### PR TITLE
Always send Origin header for (non HEAD/GET) CORS requests

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3016,7 +3016,8 @@ given a <a for=/>request</a> <var>request</var>, run these steps:
 
   <ol>
    <li>
-    <p>Switch on <var>request</var>'s <a for=request>referrer policy</a>:
+    <p>If <var>request</var>'s <a for=request>mode</a> is not "<code>cors</code>",
+    then switch on <var>request</var>'s <a for=request>referrer policy</a>:
 
     <dl class=switch>
      <dt>"<code>no-referrer</code>"


### PR DESCRIPTION
#1022 We need to send the Origin header for same-origin CORS requests even with no-referrer. This is the current behavior of all browsers (https://wpt.fyi/results/fetch/origin/assorted.window.html?label=master&label=experimental&aligned) and not doing so [breaks the web](https://bugzilla.mozilla.org/show_bug.cgi?id=1775235).

- [x] At least two implementers are interested (and none opposed):
   * Firefox is interested
   * Existing behavior in Safari and Chrome (which diverges further)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * fetch/origin/assorted.window.html needs to be updated ("Origin header and POST same-origin fetch cors mode with Referrer-Policy no-referrer")
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: Existing behavior
   * Firefox: (Re)-Implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1775235
   * Safari: Existing behavior
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1463.html" title="Last updated on Oct 7, 2022, 3:05 PM UTC (f6d18aa)">Preview</a> | <a href="https://whatpr.org/fetch/1463/7487a97...f6d18aa.html" title="Last updated on Oct 7, 2022, 3:05 PM UTC (f6d18aa)">Diff</a>