### PR TITLE
Editorial: Add 103 to note about null body Response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7560,7 +7560,7 @@ these steps:
     <a>throw</a> a {{TypeError}}.
 
     <p class="note no-backref">101 and 103 are included in <a>null body status</a> due to their
-    use elsewhere. It does not affect this step.
+    use elsewhere. They do not affect this step.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>body</var>'s
    <a for="body with type">body</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -7559,8 +7559,8 @@ these steps:
     <p>If <var>response</var>'s <a for=response>status</a> is a <a>null body status</a>, then
     <a>throw</a> a {{TypeError}}.
 
-    <p class="note no-backref">101 is included in <a>null body status</a> due to its use elsewhere.
-    It does not affect this step.
+    <p class="note no-backref">101 and 103 are included in <a>null body status</a> due to their
+    use elsewhere. It does not affect this step.
 
    <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>body</var>'s
    <a for="body with type">body</a>.


### PR DESCRIPTION
Currently, 103 code is a [`null body status`](https://fetch.spec.whatwg.org/#null-body-status).
A note in Step 6 of [`initialize a response`](https://fetch.spec.whatwg.org/#initialize-a-response) mentions only 101.
103 is also an exception ∵ it's filtered out by Step 1.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg-fetch/1465.html" title="Last updated on Jul 28, 2022, 6:36 AM UTC (7cb9898)">Preview</a> | <a href="https://whatpr.org/fetch/1465/50d77e6...7cb9898.html" title="Last updated on Jul 28, 2022, 6:36 AM UTC (7cb9898)">Diff</a>