### PR TITLE
Editorial: Move initiator type to other side of note

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1428,8 +1428,6 @@ false.
 <code>navigator.sendBeacon</code> and the HTML <code>img</code> element set this flag. Requests with
 this flag set are subject to additional processing requirements.
 
-<p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers mode</dfn>, that
-is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<code>all</code>".
 
 <p>A <a for=/>request</a> has an associated
 <dfn for=request export>initiator type</dfn>, which is null,
@@ -1456,6 +1454,9 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 "<code>other</code>". Unless stated otherwise it is null. [[RESOURCE-TIMING]]
 <!-- See https://github.com/whatwg/fetch/issues/1452 and
          https://github.com/w3c/resource-timing/issues/132 for future work -->
+
+<p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers mode</dfn>, that
+is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<code>all</code>".
 
 <div class=note>
  <p>This determines which service workers will receive a {{fetch!!event}} event for this fetch.


### PR DESCRIPTION
The note is about service workers.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1467.html" title="Last updated on Jul 8, 2022, 7:54 AM UTC (326250f)">Preview</a> | <a href="https://whatpr.org/fetch/1467/edf07e5...326250f.html" title="Last updated on Jul 8, 2022, 7:54 AM UTC (326250f)">Diff</a>