### PR TITLE
Pass in response status to mark resource timing

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4387,12 +4387,19 @@ steps:
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
 
+     <li><p>Let <var>responseStatus</var> be <var>response</var>'s <a for=response>status</a>.
+
+     <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+     <a for=request>mode</a> is "<code>navigate</code>" and <var>request</var>'s
+     <a for=request>current URL</a>'s <a for=url>origin</a> is not <a>same origin</a> with
+     <var>request</var>'s <a for=request>origin</a>, then set <var>responseStatus</var> to 0.
+
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a> is not null, then
      <a for=/>mark resource timing</a> given <var>timingInfo</var>, <var>request</var>'s
      <a for=request>URL</a>, <a for="fetch params">request</a>'s
      <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>,
-     <var>bodyInfo</var>, and <var>response</var>'s <a for=response>status</a>.
+     <var>bodyInfo</var>, and <var>responseStatus</var>.
     </ol>
 
    <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4391,8 +4391,8 @@ steps:
      <a for=request>initiator type</a> is not null, then
      <a for=/>mark resource timing</a> given <var>timingInfo</var>, <var>request</var>'s
      <a for=request>URL</a>, <a for="fetch params">request</a>'s
-     <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>, and
-     <var>bodyInfo</var>.
+     <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>,
+     <var>bodyInfo</var>, and <var>response</var>'s <a for=response>status</a>.
     </ol>
 
    <li>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4387,12 +4387,11 @@ steps:
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
 
-     <li><p>Let <var>responseStatus</var> be <var>response</var>'s <a for=response>status</a>.
-
-     <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-     <a for=request>mode</a> is "<code>navigate</code>" and <var>request</var>'s
-     <a for=request>current URL</a>'s <a for=url>origin</a> is not <a>same origin</a> with
-     <var>request</var>'s <a for=request>origin</a>, then set <var>responseStatus</var> to 0.
+     <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
+     <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and
+     <var>response</var>'s <a for=response>URL</a>'s <a for=url>origin</a> is not
+     <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, and
+     <var>response</var>'s <a for=response>status</a> otherwise.
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a> is not null, then

--- a/fetch.bs
+++ b/fetch.bs
@@ -2195,6 +2195,9 @@ this is also tracked internally using the request's <a for=request>timing allow 
 <dfn export for=response>service worker timing info</dfn> (null or a
 <a for=/>service worker timing info</a>), which is initially null.
 
+<p>A <a for=/>response</a> has an associated <dfn for=response>has-cross-origin-redirects</dfn>
+(a boolean), which is initially false.
+
 <hr>
 
 <p>A <a for=/>response</a> whose
@@ -4258,6 +4261,9 @@ steps:
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
+ <li><p>If <var>request</var> has a <a for=request>redirect-tainted origin</a>, then set
+ <var>internalResponse</var>'s <a for=response>has-cross-origin-redirects</a> to true.
+
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
 
@@ -4402,9 +4408,8 @@ steps:
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and
-     <var>response</var>'s <a for=response>URL</a>'s <a for=url>origin</a> is not
-     <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, and
-     <var>response</var>'s <a for=response>status</a> otherwise.
+     <var>response</var>'s <a for=response>has-cross-origin-redirects</a> is true; otherwise
+     <var>response</var>'s <a for=response>status</a>.
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a> is not null, then


### PR DESCRIPTION
These changes are to support addition of http response status code to Perfomance resource timing. Further details are available at https://github.com/w3c/resource-timing/pull/335

- [x] At least two implementers are interested (and none opposed):
   * Chromium : https://chromestatus.com/feature/5163838794629120
   * Firefox : https://github.com/mozilla/standards-positions/issues/665
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/3754923
   * https://chromium-review.googlesource.com/c/chromium/src/+/3958184
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1343293
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1796785
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=246857
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1468.html" title="Last updated on Oct 21, 2022, 4:24 PM UTC (08d1251)">Preview</a> | <a href="https://whatpr.org/fetch/1468/1fbc40c...08d1251.html" title="Last updated on Oct 21, 2022, 4:24 PM UTC (08d1251)">Diff</a>