### PR TITLE
Editorial: Use controller for navigation redirect

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8307,10 +8307,18 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
  <cite>HTML</cite>. [[HTML]]
 
  <dt><a for=fetch><i>processResponse</i></a>
- <dd><p>Takes an algorithm that will be passed a <a for=/>response</a>. Indicates
- <a for=/>response</a>'s <a for=response>header list</a> has been received and initialized. This
- is primarily useful for standards that want to operate on <a for=/>response</a>'s
- <a for=response>body</a>'s <a for=body>stream</a> directly.
+ <dd>
+  <p>Takes an algorithm that will be passed a <a for=/>response</a>. Indicates
+  <a for=/>response</a>'s <a for=response>header list</a> has been received and initialized. This
+  is primarily useful for standards that want to operate on <a for=/>response</a>'s
+  <a for=response>body</a>'s <a for=body>stream</a> directly.
+
+  <p>If the <a for=/>request</a>'s <a for=request>redirect mode</a> was "<code>manual</code>", then
+  callers need to follow a very specific flow with this algorithm to get the intended behavior.
+  They should compute the appropriate <a for=response>location URL</a>, and if it is not null or a
+  failure, then they should call <a for="fetch controller">process the next manual redirect</a>.
+  This will result in <a for=fetch><i>processResponse</i></a> being called again, with the next
+  <a for=/>response</a> in the redirect chain.
 
  <dt><a for=fetch><i>processResponseEndOfBody</i></a>
  <dd><p>Takes an algorithm that will be passed a <a for=/>response</a>. Indicates the network is

--- a/fetch.bs
+++ b/fetch.bs
@@ -8313,12 +8313,13 @@ in a <a for=/>parallel queue</a> if <a for=fetch><i>useParallelQueue</i></a> is 
   is primarily useful for standards that want to operate on <a for=/>response</a>'s
   <a for=response>body</a>'s <a for=body>stream</a> directly.
 
-  <p>If the <a for=/>request</a>'s <a for=request>redirect mode</a> was "<code>manual</code>", then
-  callers need to follow a very specific flow with this algorithm to get the intended behavior.
-  They should compute the appropriate <a for=response>location URL</a>, and if it is not null or a
-  failure, then they should call <a for="fetch controller">process the next manual redirect</a>.
-  This will result in <a for=fetch><i>processResponse</i></a> being called again, with the next
-  <a for=/>response</a> in the redirect chain.
+  <p>If the <a for=/>request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and its
+  <a for=request>redirect mode</a> is "<code>manual</code>", then callers need to follow a very
+  specific flow with this algorithm to get the intended behavior. They should compute the
+  appropriate <a for=response>location URL</a>, and if it is not null or a failure, then they
+  should call <a for="fetch controller">process the next manual redirect</a>. This will result in
+  <a for=fetch><i>processResponse</i></a> being called again, with the next <a for=/>response</a>
+  in the redirect chain.
 
  <dt><a for=fetch><i>processResponseEndOfBody</i></a>
  <dd><p>Takes an algorithm that will be passed a <a for=/>response</a>. Indicates the network is

--- a/fetch.bs
+++ b/fetch.bs
@@ -238,6 +238,9 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
 
  <dt><dfn for="fetch controller">serialized abort reason</dfn> (default null)
  <dd>Null or a <a>Record</a> (result of [$StructuredSerialize$]).
+
+ <dt><dfn for="fetch controller">next manual redirect steps</dfn> (default null)
+ <dd>Null or an algorithm accepting nothing.
 </dl>
 
 <p>To <dfn export for="fetch controller" id="finalize-and-report-timing">report timing</dfn> for a
@@ -248,6 +251,16 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  null.
 
  <li><p>Call <a>this</a>'s <a for="fetch controller">report timing steps</a> with <var>global</var>.
+</ol>
+
+<p>To <dfn export for="fetch controller">process the next manual redirect</dfn> for a
+<a>fetch controller</a> <var>controller</var>:
+
+<ol>
+ <li><p><a for=/>Assert</a>: <var>controller</var>'s
+ <a for="fetch controller">next manual redirect steps</a> are not null.
+
+ <li><p>Call <var>controller</var>'s <a for="fetch controller">next manual redirect steps</a>.
 </ol>
 
 <p>To <dfn export for="fetch controller" id="extract-full-timing-info">extract full timing info</a>
@@ -4823,7 +4836,11 @@ these steps:
 
      <dt>"<code>manual</code>"
      <dd><p>Set <var>response</var> to an <a>opaque-redirect filtered response</a> whose
-     <a for="filtered response">internal response</a> is <var>actualResponse</var>.
+     <a for="filtered response">internal response</a> is <var>actualResponse</var>. If
+     <var>request</var>'s <a for=request>mode</a> is "<code>navigate</code>", then set
+     <var>fetchParams</var>'s <a for="fetch params">controller</a>'s <a
+     for="fetch controller">next manual redirect steps</a> to run <a>HTTP-redirect fetch</a> given
+     <var>fetchParams</var> and <var>response</var>.
 
      <dt>"<code>follow</code>"
      <dd><p>Set <var>response</var> to the result of running <a>HTTP-redirect fetch</a> given
@@ -4934,26 +4951,6 @@ run these steps:
 
   <p class=note>This has to invoke <a>main fetch</a> to get <var>request</var>'s
   <a for=request>response tainting</a> correct.
-</ol>
-
-
-<h3 id=navigate-redirect-fetch>Navigate-redirect fetch</h3>
-
-<p class=note>This algorithm is used by <cite>HTML</cite>'s navigate algorithm. It is expected to be
-invoked while <a>in parallel</a>. [[!HTML]]
-
-<p>To <dfn export id=concept-navigate-redirect-fetch>navigate-redirect fetch</dfn>, given a
-<a for=/>request</a> <var>request</var> and <a for=/>response</a> <var>response</var>, run these
-steps. They return a <a for=/>response</a>.
-
-<ol>
- <li><p>Assert: <var>request</var>'s <a for=request>redirect mode</a> is "<code>manual</code>".
-
- <li><p>Let <var>fetchParams</var> be a new <a for=/>fetch params</a> whose
- <a for="fetch params">request</a> is <var>request</var>.
-
- <li><p>Return the result of running <a>HTTP-redirect fetch</a> given <var>fetchParams</var> and
- <var>response</var>.
 </ol>
 
 


### PR DESCRIPTION
Remove the existing navigation redirect, and allow the caller
to use the controller to continue to the next redirect.

This simplifies the navigation HTML<->FETCH flow, as now there is
a single `fetch params` struct for the course of the entire navigation.
Up until now some data from fetch params would be lost, like timing info
and task desination, because navigation fetches create a brand new
`fetch params` struct. Now that data is retained, and the only thing that
HTML needs to do is call `process the next redirect` on the fetch controller.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1469.html" title="Last updated on Oct 13, 2022, 7:21 AM UTC (05ef536)">Preview</a> | <a href="https://whatpr.org/fetch/1469/283c2ae...05ef536.html" title="Last updated on Oct 13, 2022, 7:21 AM UTC (05ef536)">Diff</a>