### PR TITLE
Add more timing information about (interim) responses

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -342,7 +342,10 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dt><dfn export for="fetch timing info">post-redirect start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final service worker start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final network-request start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">first interim network-response start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final network-response start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">final network-response headers end time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">response body start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">end time</dfn> (default 0)
  <dd>A {{DOMHighResTimeStamp}}.
 
@@ -5994,15 +5997,19 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
       <p>While true:
 
       <ol>
-       <li><p>If <var>timingInfo</var>'s
-       <a for="fetch timing info">final network-response start time</a> is 0, then set
-       <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a> to
+       <li><p>Set <var>timingInfo</var>'s
+       <a for="fetch timing info">final network-response start time</a> to the
        <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
        <a for="fetch params">cross-origin isolated capability</a>, immediately after the user
        agent's HTTP parser receives the first byte of the response (e.g., frame header bytes for
        HTTP/2 or response status line for HTTP/1.x).
 
        <li><p>Wait until all the HTTP response headers are transmitted.
+
+       <li><p>Set <var>timingInfo</var>'s
+       <a for="fetch timing info">final network-response headers end time</a> to
+       <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+       <a for="fetch params">cross-origin isolated capability</a>.
 
        <li><p>Let <var>status</var> be the HTTP response's status code.
 
@@ -6016,6 +6023,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <ol>
          <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>" and
          <var>status</var> is 101, then <a for=iteration>break</a>.
+
+         <li><p>If <var>timingInfo</var>'s
+         <a for="fetch timing info">first interim network-response start time</a> is 0, then set
+         <var>timingInfo</var>'s
+         <a for="fetch timing info">first interim network-response start time</a> to
+         <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a>.
+
+         <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
 
          <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
          <a for="fetch params">process early hints response</a> is non-null, then
@@ -6197,6 +6212,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>If one or more bytes have been transmitted from <var>response</var>'s message body, then:
 
         <ol>
+         <li><p>If <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+         <a for="fetch timing info">response body start time</a> is 0, then set
+         <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
+         <a for="fetch timing info">response body start time</a> to the
+         <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
+         <a for="fetch params">cross-origin isolated capability</a>.
+
          <li><p>Let <var>bytes</var> be the transmitted bytes.
 
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given

--- a/fetch.bs
+++ b/fetch.bs
@@ -345,7 +345,7 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dt><dfn export for="fetch timing info">first interim network-response start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final network-response start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final network-response headers end time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">response body start time</dfn> (default 0)
+ <dt><dfn export for="fetch timing info">final network-response body start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">end time</dfn> (default 0)
  <dd>A {{DOMHighResTimeStamp}}.
 
@@ -6213,9 +6213,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
         <ol>
          <li><p>If <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-         <a for="fetch timing info">response body start time</a> is 0, then set
+         <a for="fetch timing info">final network-response body start time</a> is 0, then set
          <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-         <a for="fetch timing info">response body start time</a> to the
+         <a for="fetch timing info">final network-response body start time</a> to the
          <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
          <a for="fetch params">cross-origin isolated capability</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6014,14 +6014,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         processing we now perform here inline. -->
 
         <ol>
-         <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>" and
-         <var>status</var> is 101, then <a for=iteration>break</a>.
-
          <li><p>If <var>timingInfo</var>'s
          <a for="fetch timing info">first interim network-response start time</a> is 0, then set
          <var>timingInfo</var>'s
          <a for="fetch timing info">first interim network-response start time</a> to
          <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a>.
+
+         <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>" and
+         <var>status</var> is 101, then <a for=iteration>break</a>.
 
          <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
          <a for="fetch params">process early hints response</a> is non-null, then

--- a/fetch.bs
+++ b/fetch.bs
@@ -6030,8 +6030,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <a for="fetch timing info">first interim network-response start time</a> to
          <var>timingInfo</var>'s <a for="fetch timing info">final network-response start time</a>.
 
-         <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
-
          <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
          <a for="fetch params">process early hints response</a> is non-null, then
          <a>queue a fetch task</a> to run <var>fetchParams</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -344,8 +344,6 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dt><dfn export for="fetch timing info">final network-request start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">first interim network-response start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">final network-response start time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">final network-response headers end time</dfn> (default 0)
- <dt><dfn export for="fetch timing info">final network-response body start time</dfn> (default 0)
  <dt><dfn export for="fetch timing info">end time</dfn> (default 0)
  <dd>A {{DOMHighResTimeStamp}}.
 
@@ -6006,11 +6004,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Wait until all the HTTP response headers are transmitted.
 
-       <li><p>Set <var>timingInfo</var>'s
-       <a for="fetch timing info">final network-response headers end time</a> to
-       <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
-       <a for="fetch params">cross-origin isolated capability</a>.
-
        <li><p>Let <var>status</var> be the HTTP response's status code.
 
        <li>
@@ -6210,13 +6203,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
         <p>If one or more bytes have been transmitted from <var>response</var>'s message body, then:
 
         <ol>
-         <li><p>If <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-         <a for="fetch timing info">final network-response body start time</a> is 0, then set
-         <var>fetchParams</var>'s <a for="fetch params">timing info</a>'s
-         <a for="fetch timing info">final network-response body start time</a> to the
-         <a for=/>coarsened shared current time</a> given <var>fetchParams</var>'s
-         <a for="fetch params">cross-origin isolated capability</a>.
-
          <li><p>Let <var>bytes</var> be the transmitted bytes.
 
          <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given


### PR DESCRIPTION
See https://github.com/w3c/resource-timing/issues/345

Since early hints have landed, there are additional useful timestamp
that's currently not exposed:

- First interim response start (e.g. when we received a 103)
  as a different timestamp from the final response start
  (e.g. when we received the 200)

Note that https://github.com/w3c/resource-timing/issues/345 also mentions two additional
timestamps, which would be added incrementally when tests are authored for them.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome: yes
   * Firefox: [positive](https://github.com/mozilla/standards-positions/issues/722)
   * Safari: [positive](https://github.com/WebKit/standards-positions/issues/109)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at https://github.com/web-platform-tests/wpt/pull/37984
https://github.com/web-platform-tests/wpt/pull/39881
 - [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: [1402089](https://bugs.chromium.org/p/chromium/issues/detail?id=1402089)
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1811291
   * Safari: https://github.com/WebKit/standards-positions/issues/109
   * Deno (not for CORS changes): N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1483.html" title="Last updated on May 4, 2023, 10:01 AM UTC (38428cc)">Preview</a> | <a href="https://whatpr.org/fetch/1483/4502481...38428cc.html" title="Last updated on May 4, 2023, 10:01 AM UTC (38428cc)">Diff</a>