### PR TITLE
Accept header for prefetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4189,6 +4189,12 @@ the request.
   <ol>
    <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
+   <li><p>Let <var>documentAccept</var> be
+   `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
+
+   <li><p>If <var>request</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then set
+   <var>value</var> to <var>documentAccept</var>.
+
    <li>
     <p>A user agent should set <var>value</var> to the first matching statement, if any, switching
     on <var>request</var>'s <a for=request>destination</a>:
@@ -4198,7 +4204,7 @@ the request.
      <dt>"<code>document</code>"
      <dt>"<code>frame</code>"
      <dt>"<code>iframe</code>"
-     <dd>`<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`
+     <dd><var>documentAccept</var>
 
      <dt>"<code>image</code>"
      <dd>`<code>image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5</code>`

--- a/fetch.bs
+++ b/fetch.bs
@@ -2571,6 +2571,9 @@ manually. [[!HTML]]
  <li><p>Return <var>potentialDestination</var>.
 </ol>
 
+<p>The <dfn lt="document Accept header value">Document `Accept` header value</dfn> is
+`<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
+
 
 <h3 id=authentication-entries>Authentication entries</h3>
 
@@ -4189,11 +4192,9 @@ the request.
   <ol>
    <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
-   <li><p>Let <var>documentAccept</var> be
-   `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 
    <li><p>If <var>request</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then set
-   <var>value</var> to <var>documentAccept</var>.
+   <var>value</var> to <a lt="document Accept header value">document `Accept` header value</a>.
 
    <li>
     <p>A user agent should set <var>value</var> to the first matching statement, if any, switching
@@ -4204,7 +4205,7 @@ the request.
      <dt>"<code>document</code>"
      <dt>"<code>frame</code>"
      <dt>"<code>iframe</code>"
-     <dd><var>documentAccept</var>
+     <dd><a lt="document Accept header value">document `Accept` header value</a>
 
      <dt>"<code>image</code>"
      <dd>`<code>image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5</code>`

--- a/fetch.bs
+++ b/fetch.bs
@@ -4197,8 +4197,8 @@ the request.
    <var>value</var> to <a>document `Accept` header value</a>.
 
    <li>
-    <p>Otherwise, user agent should set <var>value</var> to the first matching statement, if any,
-    switching on <var>request</var>'s <a for=request>destination</a>:
+    <p>Otherwise, the user agent should set <var>value</var> to the first matching statement, if
+    any, switching on <var>request</var>'s <a for=request>destination</a>:
     <!-- https://github.com/whatwg/fetch/issues/43#issuecomment-97909717 -->
 
     <dl class=switch>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1296,6 +1296,8 @@ downloads. This format of range header value can be set using <a>add a range hea
 <a>implementation-defined</a> <a for=/>header value</a> for the `<code>User-Agent</code>`
 <a for=/>header</a>.
 
+<p>The <dfn>Document `Accept` header value</dfn> is
+`<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 
 <h4 id=statuses>Statuses</h4>
 
@@ -2570,9 +2572,6 @@ manually. [[!HTML]]
 
  <li><p>Return <var>potentialDestination</var>.
 </ol>
-
-<p>The <dfn lt="document Accept header value">Document `Accept` header value</dfn> is
-`<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 
 
 <h3 id=authentication-entries>Authentication entries</h3>
@@ -4194,18 +4193,18 @@ the request.
 
 
    <li><p>If <var>request</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then set
-   <var>value</var> to <a lt="document Accept header value">document `Accept` header value</a>.
+   <var>value</var> to <a>document `Accept` header value</a>.
 
    <li>
-    <p>A user agent should set <var>value</var> to the first matching statement, if any, switching
-    on <var>request</var>'s <a for=request>destination</a>:
+    <p>Otherwise, user agent should set <var>value</var> to the first matching statement, if any,
+    switching on <var>request</var>'s <a for=request>destination</a>:
     <!-- https://github.com/whatwg/fetch/issues/43#issuecomment-97909717 -->
 
     <dl class=switch>
      <dt>"<code>document</code>"
      <dt>"<code>frame</code>"
      <dt>"<code>iframe</code>"
-     <dd><a lt="document Accept header value">document `Accept` header value</a>
+     <dd><a>document `Accept` header value</a>
 
      <dt>"<code>image</code>"
      <dd>`<code>image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5</code>`

--- a/fetch.bs
+++ b/fetch.bs
@@ -981,9 +981,6 @@ fetch("https://victim.example/naïve-endpoint", {
       <p class=note>As web browsers have historically not emitted ranges such as
       `<code>bytes=-500</code>` this algorithm does not safelist them.
     </ol>
-   <dt>`<code>sec-purpose</code>`
-   <dd>
-     <p>If <var>value</var> is `<code>prefetch</code>`, return true. Otherwise return false.
 
    <dt>Otherwise
    <dd><p>Return false.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4192,7 +4192,6 @@ the request.
   <ol>
    <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
-
    <li><p>If <var>request</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then set
    <var>value</var> to <a>document `Accept` header value</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1296,7 +1296,7 @@ downloads. This format of range header value can be set using <a>add a range hea
 <a>implementation-defined</a> <a for=/>header value</a> for the `<code>User-Agent</code>`
 <a for=/>header</a>.
 
-<p>The <dfn>Document `Accept` header value</dfn> is
+<p>The <dfn>document `<code>Accept</code>` header value</dfn> is
 `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 
 <h4 id=statuses>Statuses</h4>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4193,7 +4193,7 @@ the request.
    <li><p>Let <var>value</var> be `<code>*/*</code>`.
 
    <li><p>If <var>request</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then set
-   <var>value</var> to <a>document `Accept` header value</a>.
+   <var>value</var> to the <a>document `<code>Accept</code>` header value</a>.
 
    <li>
     <p>Otherwise, the user agent should set <var>value</var> to the first matching statement, if
@@ -4204,7 +4204,7 @@ the request.
      <dt>"<code>document</code>"
      <dt>"<code>frame</code>"
      <dt>"<code>iframe</code>"
-     <dd><a>document `Accept` header value</a>
+     <dd>the <a>document `<code>Accept</code>` header value</a>
 
      <dt>"<code>image</code>"
      <dd>`<code>image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5</code>`

--- a/fetch.bs
+++ b/fetch.bs
@@ -1299,6 +1299,7 @@ downloads. This format of range header value can be set using <a>add a range hea
 <p>The <dfn>document `<code>Accept</code>` header value</dfn> is
 `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 
+
 <h4 id=statuses>Statuses</h4>
 
 <p>A <dfn export id=concept-status>status</dfn> is an integer in the range 0 to 999, inclusive.

--- a/fetch.bs
+++ b/fetch.bs
@@ -981,6 +981,9 @@ fetch("https://victim.example/naïve-endpoint", {
       <p class=note>As web browsers have historically not emitted ranges such as
       `<code>bytes=-500</code>` this algorithm does not safelist them.
     </ol>
+   <dt>`<code>sec-purpose</code>`
+   <dd>
+     <p>If <var>value</var> is `<code>prefetch</code>`, return true. Otherwise return false.
 
    <dt>Otherwise
    <dd><p>Return false.


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Together with https://github.com/whatwg/html/pull/8111
- [x] At least two implementers are interested (and none opposed):
   * Deferring to dicussion at https://github.com/whatwg/html/pull/8111
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/35707
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=626081
   * Firefox: [1788167: Align prefetch with spec](https://bugzilla.mozilla.org/show_bug.cgi?id=1788167)
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=49238
   * Deno (not for CORS changes): N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1485.html" title="Last updated on Jan 16, 2023, 1:20 PM UTC (02e6fe0)">Preview</a> | <a href="https://whatpr.org/fetch/1485/62e5d0b...02e6fe0.html" title="Last updated on Jan 16, 2023, 1:20 PM UTC (02e6fe0)">Diff</a>