### PR TITLE
Fix the reference to "generate and queue a report".

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3812,8 +3812,8 @@ run these steps:
   </table>
 
  <li><p><a>Generate and queue a report</a> for <var>settingsObject</var>'s
- <a for="environment settings object">global object</a> given
- the <a>"<code>coep</code>" report type</a>, <var>endpoint</var>, and <var>body</var>. [[!REPORTING]]
+ <a for="environment settings object">global object</a> given the
+ <a>"<code>coep</code>" report type</a>, <var>endpoint</var>, and <var>body</var>. [[!REPORTING]]
 </ol>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3811,8 +3811,9 @@ run these steps:
    </tbody>
   </table>
 
- <li><p><a for="reporting">Queue</a> <var>body</var> as the <a>"<code>coep</code>" report type</a> for
- <var>endpoint</var> on <var>settingsObject</var>. [[!REPORTING]]
+ <li><p><a>Generate and queue a report</a> for <var>settingsObject</var>'s
+ <a for="environment settings object">global object</a> given
+ the <a>"<code>coep</code>" report type</a>, <var>endpoint</var>, and <var>body</var>. [[!REPORTING]]
 </ol>
 
 


### PR DESCRIPTION
w3c/reporting#253 changed which algorithm is exported. The build will get fixed once Shepherd picks up that change.

I'm pretty sure this is the right algorithm to call, but please double check
that these should actually be sent to the network.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] Editorial
- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1487.html" title="Last updated on Sep 22, 2022, 9:56 AM UTC (81bec05)">Preview</a> | <a href="https://whatpr.org/fetch/1487/9bb2ded...81bec05.html" title="Last updated on Sep 22, 2022, 9:56 AM UTC (81bec05)">Diff</a>