### PR TITLE
Only break for 101 in "websocket" mode

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5543,9 +5543,14 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li>
         <p>If <var>status</var> is in the range 100 to 199, inclusive:
+        <!-- If there comes a time when there is another code besides 101 and 103 that needs special
+        processing we should generalize the "process early hints response" callback and invoke it
+        for each 1xx response and as such require callers like WebSockets to do the filtering and
+        processing we now perform here inline. -->
 
         <ol>
-         <li><p>If <var>status</var> is 101, <a for=iteration>break</a>.
+         <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>websocket</code>" and
+         <var>status</var> is 101, then <a for=iteration>break</a>.
 
          <li><p>If <var>status</var> is 103 and <var>fetchParams</var>'s
          <a for="fetch params">process early hints response</a> is non-null, then


### PR DESCRIPTION
Also document how we should refactor this in the future.

Tests: https://wpt.fyi/fetch/security/1xx-response.any.html.

Fixes #1397.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Checkboxes are not applicable as this is already implemented as such as I understand it.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1491.html" title="Last updated on Sep 22, 2022, 10:08 AM UTC (c245ee4)">Preview</a> | <a href="https://whatpr.org/fetch/1491/0d95632...c245ee4.html" title="Last updated on Sep 22, 2022, 10:08 AM UTC (c245ee4)">Diff</a>