### PR TITLE
Add a destination type for FedCM

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1517,6 +1517,7 @@ the empty string,
 "<code>style</code>",
 "<code>track</code>",
 "<code>video</code>",
+"<code>webidentity</code>",
 "<code>worker</code>", or
 "<code>xslt</code>". Unless stated otherwise it is the empty string.
 
@@ -1548,7 +1549,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=19>""
+   <td rowspan=20>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.
@@ -1611,6 +1612,10 @@ not always relevant and might require different behavior.
    <td>"<code>sharedworker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>
    <td><code>SharedWorker</code>
+  <tr>
+   <td>"<code>webidentity</code>"
+   <td><code>connect-src</code>
+   <td><code>Federated Credential Management requests</code>
   <tr>
    <td>"<code>worker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>


### PR DESCRIPTION
We think it makes sense to define a destination type specific to FedCM requests (https://fedidcg.github.io/FedCM/)

This would replace the Sec-FedCM-CSRF header that is currently in the FedCM spec.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome is interested (we're the ones proposing this)
   * Firefox is interested in FedCM [in general](https://mozilla.github.io/standards-positions/#fedcm) and has also suggested a change along these lines (https://github.com/fedidcg/FedCM/issues/320, though that issue is kind of meandering and has morphed into general CORS discussions)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * I will add WPT tests once I update Chrome's implementation to use this destination
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1368382
   * Firefox: n/a, fedcm impl still in progress
   * Safari: n/a, does not support fedcm
   * Deno (not for CORS changes): n/a

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1495.html" title="Last updated on Oct 4, 2022, 12:50 PM UTC (58d6ae4)">Preview</a> | <a href="https://whatpr.org/fetch/1495/1fbc40c...58d6ae4.html" title="Last updated on Oct 4, 2022, 12:50 PM UTC (58d6ae4)">Diff</a>