### PR TITLE
Do not CORS-safelist a Range header without a start

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -923,8 +923,19 @@ fetch("https://victim.example/naïve-endpoint", {
     </div>
 
    <dt>`<code>range</code>`
-   <dd><p>If the result of <a>parse a single range header value</a> given <var>value</var> is
-   failure, then return false.
+   <dd>
+    <ol>
+     <li><p>Let <var>rangeValue</var> be the result of <a>parsing a single range header value</a>
+     given <var>value</var>.
+
+     <li><p>If <var>rangeValue</var> is failure, then return false.
+
+     <li>
+      <p>If <var>rangeValue</var>[0] is null, then return false.
+
+      <p class=note>As web browsers have historically not emitted ranges such as
+      `<code>bytes=-500</code>` this algorithm does not safelist them.
+    </ol>
 
    <dt>Otherwise
    <dd><p>Return false.


### PR DESCRIPTION
As per #1450 the intent was never to allow this. The algorithm before #1454 would yield undefined behavior for this input, but after it ended up being allowed. This change makes it clearly disallowed.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1501.html" title="Last updated on Oct 12, 2022, 2:45 PM UTC (9013d5c)">Preview</a> | <a href="https://whatpr.org/fetch/1501/283c2ae...9013d5c.html" title="Last updated on Oct 12, 2022, 2:45 PM UTC (9013d5c)">Diff</a>