### PR TITLE
Editorial: Fix typo in 'fetch response handover'

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4462,7 +4462,7 @@ steps:
 
      <li>
       <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
-      then set <var>timingInfo</var> to a the result of <a>creating an opaque timing info</a> for
+      then set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
       <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>, and
       set <var>cacheState</var> to the empty string.
 
@@ -8479,6 +8479,7 @@ Kenji Baheux,
 Lachlan Hunt,
 Larry Masinter,
 Liam Brummitt,
+Linus Groh,
 Louis Ryan,
 Luca Casonato,
 Lucas Gonze,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1502.html" title="Last updated on Oct 14, 2022, 8:39 AM UTC (f3173aa)">Preview</a> | <a href="https://whatpr.org/fetch/1502/8023bd0...f3173aa.html" title="Last updated on Oct 14, 2022, 8:39 AM UTC (f3173aa)">Diff</a>