### PR TITLE
Actually define Blob-to-ReadableStream conversion

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6543,9 +6543,18 @@ typedef (ReadableStream or XMLHttpRequestBodyInit) BodyInit;</pre>
 steps:
 
 <ol>
- <li><p>Let <var>stream</var> be <var>object</var> if <var>object</var> is a {{ReadableStream}}
- object. Otherwise, let <var>stream</var> be a <a>new</a> {{ReadableStream}}, and
+ <li><p>Let <var>stream</var> be null.
+
+ <li><p>If <var>object</var> is a {{ReadableStream}} object, then set <var>stream</var> to
+ <var>object</var>.
+
+ <li><p>Otherwise, if <var>object</var> is a {{Blob}} object, set <var>stream</var> to the result of
+ running <var>object</var>'s <a for=Blob>get stream</a>.
+
+ <li><p>Otherwise, set <var>stream</var> to a <a>new</a> {{ReadableStream}} object, and
  <a for=ReadableStream>set up</a> <var>stream</var>.
+
+ <li><p><a for=/>Assert</a>: <var>stream</var> is a {{ReadableStream}} object.
 
  <li><p>Let <var>action</var> be null.
 
@@ -6561,8 +6570,6 @@ steps:
   <dl class=switch>
    <dt>{{Blob}}
    <dd>
-    <p>Set <var>action</var> to this step: read <var>object</var>.
-
     <p>Set <var>source</var> to <var>object</var>.
 
     <p>Set <var>length</var> to <var>object</var>'s {{Blob/size}}.


### PR DESCRIPTION
This depends on https://github.com/w3c/FileAPI/pull/182.

Together with #1505 this fixes #1504.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1506.html" title="Last updated on Oct 20, 2022, 3:44 PM UTC (599ebef)">Preview</a> | <a href="https://whatpr.org/fetch/1506/e5f025a...599ebef.html" title="Last updated on Oct 20, 2022, 3:44 PM UTC (599ebef)">Diff</a>