### PR TITLE
Editorial: introduce "convert" operation for byte-sequence to body

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1263,9 +1263,9 @@ worked on in <a href=https://github.com/whatwg/fetch/issues/1156>issue #1156</a>
  <var>body</var>.
 </ol>
 
-<p>To <dfn export for=body>convert</dfn> a <a for=/>byte sequence</a> <var>bytes</var>, return the
-<a for="body with type">body</a> of the result of <a for=BodyInit>safely extracting</a>
-<var>bytes</var>.
+<p>To get a <a for=/>byte sequence</a> <var>bytes</var>
+<dfn export for="byte sequence">as a body</dfn>, return the <a for="body with type">body</a> of the
+result of <a for=BodyInit>safely extracting</a> <var>bytes</var>.
 
 <hr>
 
@@ -3990,8 +3990,8 @@ the request.
  <var>crossOriginIsolatedCapability</var>.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
- <var>request</var>'s <a for=request>body</a> to <var>request</var>'s <a for=request>body</a>,
- <a for=body>converted</a>.
+ <var>request</var>'s <a for=request>body</a> to <var>request</var>'s <a for=request>body</a>
+ <a for="byte sequence">as a body</a>.
 
  <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then set
  <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>,
@@ -4402,8 +4402,8 @@ steps:
      <var>request</var>'s <a for=request>integrity metadata</a>, then run
      <var>processBodyError</var> and abort these steps. [[!SRI]]
 
-     <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>bytes</var>,
-     <a for=body>converted</a>.
+     <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>bytes</var>
+     <a for="byte sequence">as a body</a>.
 
      <li><p>Run <a>fetch response handover</a> given <var>fetchParams</var> and <var>response</var>.
     </ol>
@@ -4572,7 +4572,7 @@ steps:
   "<code>blank</code>", then return a new <a for=/>response</a> whose
   <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> is «
   (`<code>Content-Type</code>`, `<code>text/html;charset=utf-8</code>`) », and
-  <a for=response>body</a> is the empty byte sequence, <a for=body>converted</a>.
+  <a for=response>body</a> is the empty byte sequence <a for="byte sequence">as a body</a>.
 
   <p>Otherwise, return a <a>network error</a>.
 
@@ -4635,7 +4635,7 @@ steps:
    <li><p>Return a new <a for=/>response</a> whose <a for=response>status message</a> is
    `<code>OK</code>`, <a for=response>header list</a> is « (`<code>Content-Type</code>`,
    <var>mimeType</var>) », and <a for=response>body</a> is <var>dataURLStruct</var>'s
-   <a for="data: URL struct">body</a>, <a for=body>converted</a>.
+   <a for="data: URL struct">body</a> <a for="byte sequence">as a body</a>.
   </ol>
 
  <dt>"<code>file</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -1263,6 +1263,10 @@ worked on in <a href=https://github.com/whatwg/fetch/issues/1156>issue #1156</a>
  <var>body</var>.
 </ol>
 
+<p>To <dfn export for=body>convert</dfn> a <a for=/>byte sequence</a> <var>bytes</var>, return the
+<a for="body with type">body</a> of the result of <a for=BodyInit>safely extracting</a>
+<var>bytes</var>.
+
 <hr>
 
 <p>To <dfn export for=body>incrementally read</dfn> a <a for=/>body</a> <var>body</var>, given an
@@ -3986,8 +3990,8 @@ the request.
  <var>crossOriginIsolatedCapability</var>.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is a <a for=/>byte sequence</a>, then set
- <var>request</var>'s <a for=request>body</a> to the <a for="body with type">body</a> of the result
- of <a for=BodyInit>safely extracting</a> <var>request</var>'s <a for=request>body</a>.
+ <var>request</var>'s <a for=request>body</a> to <var>request</var>'s <a for=request>body</a>,
+ <a for=body>converted</a>.
 
  <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then set
  <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>,
@@ -4398,9 +4402,8 @@ steps:
      <var>request</var>'s <a for=request>integrity metadata</a>, then run
      <var>processBodyError</var> and abort these steps. [[!SRI]]
 
-     <li><p>Set <var>response</var>'s <a for=response>body</a> to the
-     <a for="body with type">body</a> of the result of <a for=BodyInit>safely extracting</a>
-     <var>bytes</var>.
+     <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>bytes</var>,
+     <a for=body>converted</a>.
 
      <li><p>Run <a>fetch response handover</a> given <var>fetchParams</var> and <var>response</var>.
     </ol>
@@ -4569,8 +4572,7 @@ steps:
   "<code>blank</code>", then return a new <a for=/>response</a> whose
   <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> is «
   (`<code>Content-Type</code>`, `<code>text/html;charset=utf-8</code>`) », and
-  <a for=response>body</a> is the <a for="body with type">body</a> of the result of
-  <a for=BodyInit>safely extracting</a> the empty byte sequence.
+  <a for=response>body</a> is the empty byte sequence, <a for=body>converted</a>.
 
   <p>Otherwise, return a <a>network error</a>.
 
@@ -4632,9 +4634,8 @@ steps:
 
    <li><p>Return a new <a for=/>response</a> whose <a for=response>status message</a> is
    `<code>OK</code>`, <a for=response>header list</a> is « (`<code>Content-Type</code>`,
-   <var>mimeType</var>) », and <a for=response>body</a> is the <a for="body with type">body</a> of
-   the result of <a for=BodyInit>safely extracting</a> <var>dataURLStruct</var>'s
-   <a for="data: URL struct">body</a>.
+   <var>mimeType</var>) », and <a for=response>body</a> is <var>dataURLStruct</var>'s
+   <a for="data: URL struct">body</a>, <a for=body>converted</a>.
   </ol>
 
  <dt>"<code>file</code>"


### PR DESCRIPTION
It doesn't save a whole lot of text, but maybe this is good? Or were you thinking of a response constructor type of thing?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1507.html" title="Last updated on Oct 21, 2022, 9:05 AM UTC (89fb617)">Preview</a> | <a href="https://whatpr.org/fetch/1507/4cd70cf...89fb617.html" title="Last updated on Oct 21, 2022, 9:05 AM UTC (89fb617)">Diff</a>