### PR TITLE
Remove HTTP cache talk in HTTP-network fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5511,12 +5511,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
- <li><p>Let <var>httpCache</var> be the result of <a>determining the HTTP cache partition</a>, given
- <var>request</var>.
-
- <li><p>If <var>httpCache</var> is null, then set <var>request</var>'s <a for=request>cache mode</a>
- to "<code>no-store</code>".
-
  <li><p>Let <var>networkPartitionKey</var> be the result of
  <a for=request>determining the network partition key</a> given <var>request</var>.
 
@@ -5738,42 +5732,17 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <a for="ReadableStream/set up"><var>highWaterMark</var></a> set to <var>highWaterMark</var>, and
  <a for="ReadableStream/set up"><var>sizeAlgorithm</var></a> set to <var>sizeAlgorithm</var>.
 
- <li>
-  <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-  <a for="fetch params">canceled</a>:
+ <li><p>Set <var>response</var>'s <a for=response>body</a> to a new <a for=/>body</a> whose
+ <a for=body>stream</a> is <var>stream</var>.
 
-  <ol>
-   <li><p>Set <var>response</var>'s <a for=response>body</a> to a new
-   <a for=/>body</a> whose <a for=body>stream</a> is
-   <var>stream</var>.
-
-   <li><p>If <var>response</var> is not a <a>network error</a> and <var>request</var>'s
-   <a for=request>cache mode</a> is not "<code>no-store</code>", then update <var>response</var> in
-   <var>httpCache</var> for <var>request</var>.
-
-   <li>
-    <p>If <var>includeCredentials</var> is true and the user agent is not configured to block
-    cookies for <var>request</var> (see
-    <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-7>section 7</a> of [[!COOKIES]]),
-    then run the "set-cookie-string" parsing algorithm (see
-    <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-5.2>section 5.2</a> of
-    [[!COOKIES]]) on the <a for=header>value</a> of each <var>header</var> whose
-    <a for=header>name</a> is a <a>byte-case-insensitive</a> match for `<code>Set-Cookie</code>` in
-    <var>response</var>'s <a for=response>header list</a>, if any, and <var>request</var>'s
-    <a for=request>current URL</a>.
-
-    <p class=note>This is a fingerprinting vector.
-  </ol>
-
- <li>
-  <p><a>If aborted</a>, then:
-
-  <ol>
-   <li><p>If <var>fetchParams</var> is <a for="fetch params">aborted</a>, then set
-   <var>response</var>'s <a for=response>aborted flag</a>.
-
-   <li><p>Return <var>response</var>.
-  </ol>
+ <li><p tracking-vector>If <var>includeCredentials</var> is true and the user agent is not
+ configured to block cookies for <var>request</var> (see
+ <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-7>section 7</a> of [[!COOKIES]]),
+ then run the "set-cookie-string" parsing algorithm (see
+ <a href=https://datatracker.ietf.org/doc/html/rfc6265#section-5.2>section 5.2</a> of [[!COOKIES]])
+ on the <a for=header>value</a> of each <var>header</var> whose <a for=header>name</a> is a
+ <a>byte-case-insensitive</a> match for `<code>Set-Cookie</code>` in <var>response</var>'s
+ <a for=response>header list</a>, if any, and <var>request</var>'s <a for=request>current URL</a>.
 
  <li>
   <p>Run these steps <a>in parallel</a>:


### PR DESCRIPTION
This was overlooked in https://github.com/whatwg/fetch/commit/cbca2c2f3a37084e336e14348de683f8ffa0fed9 and is already handled by HTTP-network-or-cache fetch.

Also remove the "abort when" wrapper as this can all be done synchronously. If the fetch is canceled it's caught immediately after.

And finally use the tracking-vector feature instead of a note.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1508.html" title="Last updated on Oct 21, 2022, 12:36 PM UTC (53a367e)">Preview</a> | <a href="https://whatpr.org/fetch/1508/4a7bf35...53a367e.html" title="Last updated on Oct 21, 2022, 12:36 PM UTC (53a367e)">Diff</a>