### PR TITLE
Refactor scheme fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4624,7 +4624,7 @@ steps:
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
  <li>
-  <p>Switch on <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a>, and run
+  <p>Switch on <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a> and run
   the associated steps:
 
   <dl class=switch>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4615,32 +4615,33 @@ steps:
 <h3 id=scheme-fetch oldids=basic-fetch>Scheme fetch</h3>
 
 <p>To <dfn id=concept-scheme-fetch oldids=concept-basic-fetch>scheme fetch</dfn>, given a
-<a for=/>fetch params</a> <var>fetchParams</var>: let <var>request</var> be <var>fetchParams</var>'s
-<a for="fetch params">request</a>, switch on <var>request</var>'s <a for=request>current URL</a>'s
-<a for=url>scheme</a>, and run the associated steps:
+<a for=/>fetch params</a> <var>fetchParams</var>:
 
-<dl class=switch>
- <dt>"<code>about</code>"
- <dd>
-  <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>path</a> is the string
-  "<code>blank</code>", then return a new <a for=/>response</a> whose
-  <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> is «
-  (`<code>Content-Type</code>`, `<code>text/html;charset=utf-8</code>`) », and
-  <a for=response>body</a> is the empty byte sequence <a for="byte sequence">as a body</a>.
+<ol>
+ <li><p>If <var>fetchParams</var> is <a for="fetch params">canceled</a>, then return the
+ <a for=/>appropriate network error</a> for <var>fetchParams</var>.
 
-  <p>Otherwise, return a <a>network error</a>.
+ <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
-  <p class="note no-backref"><a for=/>URLs</a> such as "<code>about:config</code>" are handled
-  during <a lt=navigate>navigation</a> and result in a <a>network error</a> in the context of
-  <a lt=fetch for=/>fetching</a>.
+ <li>
+  <p>Switch on <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a>, and run
+  the associated steps:
 
- <dt>"<code>blob</code>"
- <dd>
-  <ol>
-   <li>
-    <p>Run these steps, but <a>abort when</a> <var>fetchParams</var> is
-    <a for="fetch params">canceled</a>:
+  <dl class=switch>
+   <dt>"<code>about</code>"
+   <dd>
+    <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>path</a> is the string
+    "<code>blank</code>", then return a new <a for=/>response</a> whose
+    <a for=response>status message</a> is `<code>OK</code>`, <a for=response>header list</a> is «
+    (`<code>Content-Type</code>`, `<code>text/html;charset=utf-8</code>`) », and
+    <a for=response>body</a> is the empty byte sequence <a for="byte sequence">as a body</a>.
 
+    <p class=note><a for=/>URLs</a> such as "<code>about:config</code>" are handled during
+    <a lt=navigate>navigation</a> and result in a <a>network error</a> in the context of
+    <a lt=fetch for=/>fetching</a>.
+
+   <dt>"<code>blob</code>"
+   <dd>
     <ol>
      <li><p>Let <var>blobURLEntry</var> be <var>request</var>'s <a for=request>current URL</a>'s
      <a for=url>blob URL entry</a>.
@@ -4671,41 +4672,36 @@ steps:
      <a for=response>body</a> is <var>body</var>.
     </ol>
 
-   <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
-   <var>fetchParams</var>.
-  </ol>
+   <dt>"<code>data</code>"
+   <dd>
+    <ol>
+     <li><p>Let <var>dataURLStruct</var> be the result of running the
+     <a><code>data:</code> URL processor</a> on <var>request</var>'s <a for=request>current URL</a>.
 
- <dt>"<code>data</code>"
- <dd>
-  <ol>
-   <li><p>Let <var>dataURLStruct</var> be the result of running the
-   <a><code>data:</code> URL processor</a> on <var>request</var>'s <a for=request>current URL</a>.
+     <li><p>If <var>dataURLStruct</var> is failure, then return a <a>network error</a>.
 
-   <li><p>If <var>dataURLStruct</var> is failure, then return a <a>network error</a>.
+     <li><p>Let <var>mimeType</var> be <var>dataURLStruct</var>'s
+     <a for="data: URL struct">MIME type</a>, <a lt="serialize a MIME type to bytes">serialized</a>.
 
-   <li><p>Let <var>mimeType</var> be <var>dataURLStruct</var>'s
-   <a for="data: URL struct">MIME type</a>, <a lt="serialize a MIME type to bytes">serialized</a>.
+     <li><p>Return a new <a for=/>response</a> whose <a for=response>status message</a> is
+     `<code>OK</code>`, <a for=response>header list</a> is « (`<code>Content-Type</code>`,
+     <var>mimeType</var>) », and <a for=response>body</a> is <var>dataURLStruct</var>'s
+     <a for="data: URL struct">body</a> <a for="byte sequence">as a body</a>.
+    </ol>
 
-   <li><p>Return a new <a for=/>response</a> whose <a for=response>status message</a> is
-   `<code>OK</code>`, <a for=response>header list</a> is « (`<code>Content-Type</code>`,
-   <var>mimeType</var>) », and <a for=response>body</a> is <var>dataURLStruct</var>'s
-   <a for="data: URL struct">body</a> <a for="byte sequence">as a body</a>.
-  </ol>
+   <dt>"<code>file</code>"
+   <dd>
+    <p>For now, unfortunate as it is, <code>file:</code> <a for=/>URLs</a> are left as an exercise
+    for the reader.
 
- <dt>"<code>file</code>"
- <dd>
-  <p>For now, unfortunate as it is, <code>file</code> <a for=/>URLs</a> are left as an exercise for
-  the reader.
+    <p>When in doubt, return a <a>network error</a>.
 
-  <p>When in doubt, return a <a>network error</a>.
+   <dt><a>HTTP(S) scheme</a>
+   <dd><p>Return the result of running <a>HTTP fetch</a> given <var>fetchParams</var>.
+  </dl>
 
- <dt><a>HTTP(S) scheme</a>
- <dd>
-  <p>Return the result of running <a>HTTP fetch</a> given <var>fetchParams</var>.
-
- <dt>Otherwise
- <dd><p>Return a <a>network error</a>.
-</dl>
+ <li><p>Return a <a for=/>network error</a>.
+</ol>
 
 
 <h3 id=http-fetch>HTTP fetch</h3>


### PR DESCRIPTION
No longer use "abort when" for blob: URLs as all the handling is synchronous anyway.

Capture aborting that might have happened between fetch going in parallel and scheme fetch getting invoked for all schemes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1515.html" title="Last updated on Oct 26, 2022, 7:22 AM UTC (b6af6ff)">Preview</a> | <a href="https://whatpr.org/fetch/1515/b56692a...b6af6ff.html" title="Last updated on Oct 26, 2022, 7:22 AM UTC (b6af6ff)">Diff</a>