### PR TITLE
Update to use navigables instead of browsing contexts

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1726,9 +1726,8 @@ not always relevant and might require different behavior.
  submission algorithm.
 
  <p>CSP will also need to check <a for=/>request</a>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a>'s
- <a for=Window>browsing context</a>'s <a>ancestor browsing contexts</a> for various CSP
- directives.
+ <a for="environment settings object">global object</a>'s <a>associated <code>Document</code></a>'s
+ <a for=Document>ancestor navigables</a> for various CSP directives.
 </div>
 
 <hr>
@@ -6187,7 +6186,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is not
   <a>same origin</a> with <var>request</var>'s <a for=request>origin</a>, then return failure.
 
-  <p class=note>This is necessary for navigations of a nested browsing context. There,
+  <p class=note>This is necessary for navigations of a nested navigable. There,
   <var>request</var>'s <a for=request>origin</a> would be the container document's
   <a for=Document>origin</a> and the <a>TAO check</a> would return failure. Since navigation timing
   never validates the results of the <a>TAO check</a>, the nested document would still have access


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/6315. One reference remains to "target browsing context" which probably requires HTML-side updates first.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1525.html" title="Last updated on Nov 2, 2022, 2:57 AM UTC (591d70b)">Preview</a> | <a href="https://whatpr.org/fetch/1525/1c3a3bb...591d70b.html" title="Last updated on Nov 2, 2022, 2:57 AM UTC (591d70b)">Diff</a>