### PR TITLE
Update CSM destinations to CSP Level 3.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@ Thank you for contributing to the Fetch Standard! Please describe the change you
 -->
 
 - [ ] At least two implementers are interested (and none opposed):
-   * …
-   * …
+   * … Update CSP destinations to CSP Level 3
+   * … Change 'style-src' to 'style-src-elem'
 - [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
    * …
 - [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:

--- a/fetch.bs
+++ b/fetch.bs
@@ -1654,11 +1654,11 @@ not always relevant and might require different behavior.
    <code>cursor</code>, CSS' <code>list-style-image</code>, …
   <tr>
    <td>"<code>audioworklet</code>"
-   <td><code>script-src</code>
+   <td><code>script-src-elem</code>
    <td><code>audioWorklet.addModule()</code>
   <tr>
    <td>"<code>paintworklet</code>"
-   <td><code>script-src</code>
+   <td><code>script-src-elem</code>
    <td><code>CSS.paintWorklet.addModule()</code>
   <tr>
    <td>"<code>script</code>"
@@ -1678,11 +1678,11 @@ not always relevant and might require different behavior.
    <td><code>Federated Credential Management requests</code>
   <tr>
    <td>"<code>worker</code>"
-   <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>
+   <td><code>worker-src</code>, <code>script-src</code>, <code>worker-src</code>
    <td><code>Worker</code>
   <tr>
    <td>"<code>style</code>"
-   <td><code>style-src</code>
+   <td><code>style-src-elem</code>
    <td>HTML's <code>&lt;link rel=stylesheet></code>, CSS' <code>@import</code>
   <tr>
    <td>"<code>track</code>"
@@ -1718,7 +1718,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>xslt</code>"
    <td>"<code>xslt</code>"
-   <td><code>script-src</code>
+   <td><code>script-src-elem</code>
    <td><code>&lt;?xml-stylesheet></code>
  </table>
 
@@ -8465,6 +8465,7 @@ Tiancheng "Timothy" Gu,
 Tobie Langel,
 Tom Schuster,
 Tomás Aparicio,
+Toni Williams,
 triple-underscore<!-- GitHub -->,
 保呂毅 (Tsuyoshi Horo),
 Tyler Close,


### PR DESCRIPTION
- [ ] At least two implementers are interested (and none opposed):
   *Change 'style-src' to 'style-src-elem'   
   * …Add name to Contributors
  
(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1536.html" title="Last updated on Nov 12, 2022, 7:54 PM UTC (5d5d09a)">Preview</a> | <a href="https://whatpr.org/fetch/1536/3cafbdf...5d5d09a.html" title="Last updated on Nov 12, 2022, 7:54 PM UTC (5d5d09a)">Diff</a>