### PR TITLE
Remove slash in ACAO example value

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3350,7 +3350,7 @@ request to <code>https://rabbit.invalid/</code>:
   `<a http-header><code>Access-Control-Allow-Credentials</code></a>` is ignored.
  <tr>
   <td>"<code>omit</code>"
-  <td>`<code>https://rabbit.invalid/</code>`
+  <td>`<code>https://rabbit.invalid</code>`
   <td>Omitted
   <td>❌
   <td>A <a lt="serialization of an origin">serialized</a> origin has no trailing slash.


### PR DESCRIPTION
Fixes typo by removing the slash in URI path in ACAO example: https://fetch.spec.whatwg.org/commit-snapshots/3cafbdfc3925085184ea49feecbcf551cf5036e6/#example-xhr-credentials

Changes: `https://rabbit.invalid/` to `https://rabbit.invalid`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1537.html" title="Last updated on Nov 14, 2022, 1:02 PM UTC (a5418ee)">Preview</a> | <a href="https://whatpr.org/fetch/1537/3cafbdf...a5418ee.html" title="Last updated on Nov 14, 2022, 1:02 PM UTC (a5418ee)">Diff</a>