### PR TITLE
Remove Authorization header upon cross-origin redirect

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4934,11 +4934,10 @@ run these steps:
  <li><p>If <var>locationURL</var>'s <a for=url>scheme</a> is not an <a>HTTP(S) scheme</a>, then
  return a <a>network error</a>.
 
- <li><p>If <var>request</var>'s <a for=request>redirect count</a> is
- twenty, return a <a>network error</a>.
+ <li><p>If <var>request</var>'s <a for=request>redirect count</a> is 20, then return a
+ <a>network error</a>.
 
- <li><p>Increase <var>request</var>'s
- <a for=request>redirect count</a> by one.
+ <li><p>Increase <var>request</var>'s <a for=request>redirect count</a> by 1.
 
  <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>cors</code>",
  <var>locationURL</var> <a>includes credentials</a>, and <var>request</var>'s
@@ -4975,6 +4974,16 @@ run these steps:
    <a for="header list">delete</a> <var>headerName</var> from <var>request</var>'s
    <a for=request>header list</a>.
   </ol>
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is not
+  <a>same origin</a> with <var>locationURL</var>'s <a for=url>origin</a>, then
+  <a for=list>for each</a> <var>headerName</var> of <a>CORS non-wildcard request-header name</a>,
+  <a for="header list">delete</a> <var>headerName</var> from <var>request</var>'s
+  <a for=request>header list</a>.
+
+  <p class=note>I.e., the moment another origin is seen after the initial request, the
+  `<code>Authorization</code>` header is removed.
 
  <li>
   <p>If <var>request</var>'s <a for=request>body</a> is non-null, then set <var>request</var>'s


### PR DESCRIPTION
The behavior defined here is such that if you go A1 -> B -> A2, A2 doesn't see the header. I think that's what we want. If you go A1 -> A2 -> B, B won't see the header. (A1 is making the initial request in both scenarios.)

Tests: ...

Fixes #944.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Gecko
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37145
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1393520
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1802086
   * WebKit: N/A
   * Deno (not for CORS changes): https://github.com/denoland/deno/pull/16745
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/22533

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1544.html" title="Last updated on Nov 25, 2022, 8:26 AM UTC (eaa1d3b)">Preview</a> | <a href="https://whatpr.org/fetch/1544/3cafbdf...eaa1d3b.html" title="Last updated on Nov 25, 2022, 8:26 AM UTC (eaa1d3b)">Diff</a>