### PR TITLE
Parse a MIME type expects a string

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -911,8 +911,8 @@ is a <dfn export>CORS-safelisted request-header</dfn>, run these steps:
      <li><p>If <var>value</var> contains a <a>CORS-unsafe request-header byte</a>, then return
      false.
 
-     <li><p>Let <var>mimeType</var> be the result of <a lt="parse a MIME type">parsing</a>
-     <var>value</var>.
+     <li><p>Let <var>mimeType</var> be the result of <a lt="parse a MIME type">parsing</a> the
+     result of <a>isomorphic decoding</a> <var>value</var>.
 
      <li><p>If <var>mimeType</var> is failure, then return false.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1547.html" title="Last updated on Nov 23, 2022, 4:55 PM UTC (cd51409)">Preview</a> | <a href="https://whatpr.org/fetch/1547/92e6c91...cd51409.html" title="Last updated on Nov 23, 2022, 4:55 PM UTC (cd51409)">Diff</a>