### PR TITLE
Editorial: add algorithm wrapper to header algorithms

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -548,6 +548,7 @@ for consistency.
 <p class="note no-backref">A <a for=/>header list</a> is essentially a
 specialized multimap: an ordered list of key-value pairs with potentially duplicate keys.
 
+<div algorithm>
 <p>To
 <dfn export for="header list" id=concept-header-list-get-structured-header>get a structured field value</dfn>
 given a <a for=/>header name</a> <var>name</var> and a string <var>type</var> from a
@@ -574,7 +575,9 @@ given a <a for=/>header name</a> <var>name</var> and a string <var>type</var> fr
 <p class="note"><a>Get a structured field value</a> intentionally does not distinguish between a
 <a for=/>header</a> not being present and its <a for=header>value</a> failing to parse as a
 <a>structured field value</a>. This ensures uniform processing across the web platform.
+</div>
 
+<div algorithm>
 <p>To
 <dfn export for="header list" id=concept-header-list-set-structured-header>set a structured field value</dfn>
 given a <a for=/>tuple</a> (<a for=/>header name</a> <var>name</var>, <a>structured field value</a>
@@ -594,15 +597,19 @@ serialize in interesting and efficient ways. For the moment, Fetch only supports
 <a for=/>header lists</a> only via serialization, and they can be obtained from
 <a for=/>header lists</a> only by parsing. In the future the fact that they are objects might be
 preserved end-to-end. [[!RFC8941]]
+</div>
 
 <hr>
 
+<div algorithm>
 <p>A <a for=/>header list</a> <var>list</var>
 <dfn export for="header list" lt="contains|does not contain">contains</dfn> a
 <a for=/>header name</a> <var>name</var> if <var>list</var> <a for=list>contains</a> a
 <a for=/>header</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for
 <var>name</var>.
+</div>
 
+<div algorithm>
 <p>To <dfn export for="header list" id=concept-header-list-get>get</dfn> a <a for=/>header name</a>
 <var>name</var> from a <a for=/>header list</a> <var>list</var>, run these steps:
 
@@ -614,7 +621,9 @@ preserved end-to-end. [[!RFC8941]]
  whose <a for=header>name</a> is a <a>byte-case-insensitive</a> match for <var>name</var>, separated
  from each other by 0x2C 0x20, in order.
 </ol>
+</div>
 
+<div algorithm>
 <p>To
 <dfn export for="header list" lt="get, decode, and split|getting, decoding, and splitting" id=concept-header-list-get-decode-split>get, decode, and split</dfn>
 a <a for=/>header name</a> <var>name</var> from <a for=/>header list</a> <var>list</var>, run these
@@ -629,6 +638,7 @@ steps:
  <li><p>Return the result of <a for="header value">getting, decoding, and splitting</a>
  <var>value</var>.
 </ol>
+</div>
 
 <div class=example id=example-header-list-get-decode-split>
  <p>This is how <a for="header list">get, decode, and split</a> functions in practice with
@@ -703,6 +713,7 @@ A: 3
  </table>
 </div>
 
+<div algorithm>
 <p>To
 <dfn for="header value" lt="get, decode, and split|getting, decoding, and splitting">get, decode, and split</dfn>
 a <a for=/>header value</a> <var>value</var>, run these steps:
@@ -766,7 +777,9 @@ a <a for=/>header value</a> <var>value</var>, run these steps:
 
 <p class=note>Except for blessed call sites, the algorithm directly above is not to be invoked
 directly. Use <a for="header list">get, decode, and split</a> instead.
+</div>
 
+<div algorithm>
 <p>To <dfn export for="header list" id=concept-header-list-append>append</dfn> a <a for=/>header</a>
 (<var>name</var>, <var>value</var>) to a <a for=/>header list</a> <var>list</var>, run these steps:
 
@@ -781,12 +794,16 @@ directly. Use <a for="header list">get, decode, and split</a> instead.
 
  <li><p><a for=list>Append</a> (<var>name</var>, <var>value</var>) to <var>list</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export for="header list" id=concept-header-list-delete>delete</dfn> a
 <a for=/>header name</a> <var>name</var> from a <a for=/>header list</a> <var>list</var>,
 <a for=list>remove</a> all <a for=/>headers</a> whose <a for=header>name</a> is a
 <a>byte-case-insensitive</a> match for <var>name</var> from <var>list</var>.
+</div>
 
+<div algorithm>
 <p>To <dfn export for="header list" id=concept-header-list-set>set</dfn> a <a for=/>header</a>
 (<var>name</var>, <var>value</var>) in a <a for=/>header list</a> <var>list</var>, run these steps:
 
@@ -797,7 +814,9 @@ directly. Use <a for="header list">get, decode, and split</a> instead.
 
  <li><p>Otherwise, <a for=list>append</a> (<var>name</var>, <var>value</var>) to <var>list</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export for="header list" id=concept-header-list-combine>combine</dfn> a
 <a for=/>header</a> (<var>name</var>, <var>value</var>) in a <a for=/>header list</a>
 <var>list</var>, run these steps:
@@ -812,7 +831,9 @@ directly. Use <a for="header list">get, decode, and split</a> instead.
 
 <p class=note><a for="header list">Combine</a> is used by {{XMLHttpRequest}} and the
 <a spec=websockets lt="establish a WebSocket connection">WebSocket protocol handshake</a>.
+</div>
 
+<div algorithm>
 <p>To <dfn>convert header names to a sorted-lowercase set</dfn>, given a <a for=/>list</a> of
 <a lt=name for=header>names</a> <var>headerNames</var>, run these steps:
 
@@ -826,7 +847,9 @@ directly. Use <a for="header list">get, decode, and split</a> instead.
  <li><p>Return the result of <a for=set>sorting</a> <var>headerNamesSet</var> in ascending order
  with <a>byte less than</a>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To
 <dfn export for="header list" id=concept-header-list-sort-and-combine>sort and combine</dfn>
 a <a for=/>header list</a> <var>list</var>, run these steps:
@@ -853,6 +876,7 @@ a <a for=/>header list</a> <var>list</var>, run these steps:
 
  <li><p>Return <var>headers</var>.
 </ol>
+</div>
 
 <hr>
 
@@ -875,12 +899,15 @@ conditions:
 production as
 <a href=https://github.com/httpwg/http11bis/issues/19 title="fix field-value ABNF">it is broken</a>.
 
+<div algorithm>
 <p>To <dfn export for="header value" id=concept-header-value-normalize>normalize</dfn> a
 <a for=/>byte sequence</a> <var>potentialValue</var>, remove any leading and trailing
 <a>HTTP whitespace bytes</a> from <var>potentialValue</var>.
+</div>
 
 <hr>
 
+<div algorithm>
 <p id=simple-header>To determine whether a <a for=/>header</a> (<var>name</var>, <var>value</var>)
 is a <dfn export>CORS-safelisted request-header</dfn>, run these steps:
 
@@ -964,7 +991,9 @@ fetch("https://victim.example/naïve-endpoint", {
 
 <p class="note">There are limited exceptions to the `<code>Content-Type</code>` header safelist, as
 documented in <a href=#cors-protocol-exceptions>CORS protocol exceptions</a>.
+</div>
 
+<div algorithm>
 <p>A <dfn>CORS-unsafe request-header byte</dfn> is a byte <var>byte</var> for which one of the
 following is true:
 
@@ -976,7 +1005,9 @@ following is true:
  <!-- Delimiters from https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6 except for ,/;=
       and including DEL -->
 </ul>
+</div>
 
+<div algorithm>
 <p>The <dfn noexport>CORS-unsafe request-header names</dfn>, given a <a for=/>header list</a>
 <var>headers</var>, are determined as follows:
 
@@ -1006,6 +1037,7 @@ following is true:
  <li><p>Return the result of <a>convert header names to a sorted-lowercase set</a> with
  <var>unsafeNames</var>.
 </ol>
+</div>
 
 <p>A <dfn export>CORS non-wildcard request-header name</dfn> is a <a for=/>header name</a> that is a
 <a>byte-case-insensitive</a> match for `<code>Authorization</code>`.
@@ -1054,6 +1086,7 @@ is a <a>byte-case-insensitive</a> match for one of
  <li>`<code>Content-Type</code>`
 </ul>
 
+<div algorithm>
 <p>To determine whether a <a for/>header</a> (<var>name</var>, <var>value</var>) is a
 <dfn noexport>no-CORS-safelisted request-header</dfn>, run these steps:
 
@@ -1064,7 +1097,9 @@ is a <a>byte-case-insensitive</a> match for one of
  <li><p>Return whether (<var>name</var>, <var>value</var>) is a
  <a>CORS-safelisted request-header</a>.
 </ol>
+</div>
 
+<div algorithm>
 <p id=forbidden-header-name>A <a for=/>header</a> (<var>name</var>, <var>value</var>) is
 <dfn export>forbidden request-header</dfn> if these steps return true:
 
@@ -1135,6 +1170,7 @@ is a <a>byte-case-insensitive</a> match for one of
  handling in the {{Headers}} object. It is forbidden here to avoid leaking this complexity into
  requests.
 </div>
+</div>
 
 <p>A <dfn export>forbidden response-header name</dfn> is a <a for=/>header name</a> that is a
 <a>byte-case-insensitive</a> match for one of:
@@ -1156,6 +1192,7 @@ is a <a>byte-case-insensitive</a> match for one of
 
 <hr>
 
+<div algorithm>
 <p>To <dfn export lt="extract header values|extracting header values">extract header values</dfn>
 given a <a for=/>header</a> <var>header</var>, run these steps:
 
@@ -1166,7 +1203,9 @@ given a <a for=/>header</a> <var>header</var>, run these steps:
  <li><p>Return one or more <a for=header>values</a> resulting from parsing <var>header</var>'s
  <a for=header>value</a>, per the <a>ABNF</a> for <var>header</var>'s <a for=header>name</a>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To
 <dfn export lt="extract header list values|extracting header list values">extract header list values</dfn>
 given a <a for=/>header name</a> <var>name</var> and a <a for=/>header list</a> <var>list</var>,
@@ -1200,7 +1239,9 @@ run these steps:
 
  <li><p>Return <var>values</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn id=simple-range-header-value>parse a single range header value</dfn> from a
 <a>byte sequence</a> <var>value</var>, run these steps:
 
@@ -1247,6 +1288,7 @@ run these steps:
 <p class=note><a>Parse a single range header value</a> succeeds for a subset of allowed range header
 values, but it is the most common form used by user agents when requesting media or resuming
 downloads. This format of range header value can be set using <a>add a range header</a>.
+</div>
 
 <hr>
 
@@ -2125,6 +2167,7 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 
 <hr>
 
+<div algorithm>
 <p>To <dfn export for=request id=concept-request-add-range-header>add a range header</dfn> to a
 <a for=/>request</a> <var>request</var>, with an integer <var>first</var>, and an optional integer
 <var>last</var>, run these steps:
@@ -2152,6 +2195,7 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 
 <p class=note>Features that combine multiple responses into one logical resource are historically a
 source of security bugs. Please seek security review for features that deal with partial responses.
+</div>
 
 <hr>
 


### PR DESCRIPTION
Add `<div algorithm>` wrappers to defined header algorithms.

Related to: https://github.com/whatwg/fetch/issues/1526


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1549.html" title="Last updated on Nov 24, 2022, 7:20 PM UTC (eb48da0)">Preview</a> | <a href="https://whatpr.org/fetch/1549/223ca89...eb48da0.html" title="Last updated on Nov 24, 2022, 7:20 PM UTC (eb48da0)">Diff</a>