### PR TITLE
Body sizes should be CORS rather than TAO protected

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2470,7 +2470,8 @@ of defining the concrete types of <a for=/>filtered responses</a>.)
 <a for=response>URL list</a> is « »,
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is « », <a for=response>body</a> is null, and
+<a for=response>header list</a> is « »,
+<a for=response>body</a> is null, and
 <a for=response>body info</a> is a new <a for=/>response body info</a>.
 
 <p>An

--- a/fetch.bs
+++ b/fetch.bs
@@ -4678,10 +4678,12 @@ steps:
      <li>
       <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
       then set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
-      <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>, and
-      set <var>cacheState</var> to the empty string.
+      <var>timingInfo</var> and set <var>cacheState</var> to the empty string.
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
+
+     <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then set
+     <var>bodyInfo</var> to a new <a for=/>response body info</a>.
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and

--- a/fetch.bs
+++ b/fetch.bs
@@ -4682,8 +4682,8 @@ steps:
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
 
-     <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then set
-     <var>bodyInfo</var> to a new <a for=/>response body info</a>.
+     <li><p>If <var>response</var>is an <a>opaque filtered response</a> or a <a>network error</a>,
+     then set <var>bodyInfo</var> to a new <a for=/>response body info</a>.
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and

--- a/fetch.bs
+++ b/fetch.bs
@@ -2399,7 +2399,7 @@ this is also tracked internally using the request's <a for=request>timing allow 
 <a for=response>type</a> is "<code>error</code>", <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
 <a for=response>header list</a> is « », <a for=response>body</a> is null, and
-<a for=response>body info</a> is a new <a for=/>response body info</a>,.
+<a for=response>body info</a> is a new <a for=/>response body info</a>.
 
 <p>An <dfn export id=concept-aborted-network-error>aborted network error</dfn> is a
 <a>network error</a> whose <a for=response>aborted flag</a> is set.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2398,7 +2398,8 @@ this is also tracked internally using the request's <a for=request>timing allow 
 <p>A <dfn export id=concept-network-error>network error</dfn> is a <a for=/>response</a> whose
 <a for=response>type</a> is "<code>error</code>", <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is « », and <a for=response>body</a> is null.
+<a for=response>header list</a> is « », <a for=response>body</a> is null, and
+<a for=response>body info</a> is a new <a for=/>response body info</a>,.
 
 <p>An <dfn export id=concept-aborted-network-error>aborted network error</dfn> is a
 <a>network error</a> whose <a for=response>aborted flag</a> is set.
@@ -2469,8 +2470,8 @@ of defining the concrete types of <a for=/>filtered responses</a>.)
 <a for=response>URL list</a> is « »,
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is « », and
-<a for=response>body</a> is null.
+<a for=response>header list</a> is « », <a for=response>body</a> is null, and
+<a for=response>body info</a> is a new <a for=/>response body info</a>.
 
 <p>An
 <dfn export id=concept-filtered-response-opaque-redirect>opaque-redirect filtered response</dfn>
@@ -2478,8 +2479,9 @@ is a <a>filtered response</a> whose
 <a for=response>type</a> is "<code>opaqueredirect</code>",
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is « », and
-<a for=response>body</a> is null.
+<a for=response>header list</a> is « »,
+<a for=response>body</a> is null, and
+<a for=response>body info</a> is a new <a for=/>response body info</a>.
 
 <div class=note>
  <p>Exposing the <a for=response>URL list</a> for
@@ -4681,9 +4683,6 @@ steps:
       <var>timingInfo</var> and set <var>cacheState</var> to the empty string.
 
       <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
-
-     <li><p>If <var>response</var>is an <a>opaque filtered response</a> or a <a>network error</a>,
-     then set <var>bodyInfo</var> to a new <a for=/>response body info</a>.
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and


### PR DESCRIPTION
encoded/decoded body size relate to the resource, not to the timing. Body size of cors-same-origin resources is anyway observable in service workers.

This is part of
https://github.com/w3c/resource-timing/issues/220#issuecomment-1177615190

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37884
   * https://github.com/web-platform-tests/wpt/pull/37257
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1404669
    * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1811293
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=251144
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/23740

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1556.html" title="Last updated on Jan 25, 2023, 12:57 PM UTC (9071708)">Preview</a> | <a href="https://whatpr.org/fetch/1556/0332175...9071708.html" title="Last updated on Jan 25, 2023, 12:57 PM UTC (9071708)">Diff</a>