### PR TITLE
Editorial: Remove redundant timingInfo vars

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4795,8 +4795,6 @@ these steps:
 
  <li><p>Let <var>actualResponse</var> be null.
 
- <li><p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
-
  <li>
   <p>If <var>request</var>'s <a>service-workers mode</a> is "<code>all</code>", then:
 
@@ -5382,8 +5380,6 @@ run these steps:
 
     <ol>
      <li>
-      <p>Let <var>timingInfo</var> be <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
-
       <p>Set <var>storedResponse</var> to the result of selecting a response from the
       <var>httpCache</var>, possibly needing validation, as per the
       "<a href=https://datatracker.ietf.org/doc/html/rfc7234#section-4>Constructing Responses from Caches</a>"


### PR DESCRIPTION
Closes #1522

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
