### PR TITLE
Editorial: clean up definitions of network errors

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -543,10 +543,10 @@ for consistency.
 <h4 id=terminology-headers>Headers</h4>
 
 <p>A <dfn export id=concept-header-list>header list</dfn> is a <a for=/>list</a> of zero or more
-<a for=/>headers</a>. It is initially the empty list.
+<a for=/>headers</a>. It is initially « ».
 
-<p class="note no-backref">A <a for=/>header list</a> is essentially a
-specialized multimap: an ordered list of key-value pairs with potentially duplicate keys.
+<p class=note>A <a for=/>header list</a> is essentially a specialized multimap: an ordered list of
+key-value pairs with potentially duplicate keys.
 
 <div algorithm>
 <p>To
@@ -1524,7 +1524,7 @@ unset.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-header-list>header list</dfn> (a
-<a for=/>header list</a>). Unless stated otherwise it is empty.
+<a for=/>header list</a>). Unless stated otherwise it is « ».
 
 <p>A <a for=/>request</a> has an associated
 <dfn id=unsafe-request-flag export for=request>unsafe-request flag</dfn>. Unless stated otherwise it
@@ -2452,10 +2452,10 @@ of defining the concrete types of <a for=/>filtered responses</a>.)
 <p>An <dfn export id=concept-filtered-response-opaque>opaque filtered response</dfn> is a
 <a>filtered response</a> whose
 <a for=response>type</a> is "<code>opaque</code>",
-<a for=response>URL list</a> is the empty list,
+<a for=response>URL list</a> is « »,
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is empty, and
+<a for=response>header list</a> is « », and
 <a for=response>body</a> is null.
 
 <p>An
@@ -2464,7 +2464,7 @@ is a <a>filtered response</a> whose
 <a for=response>type</a> is "<code>opaqueredirect</code>",
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
-<a for=response>header list</a> is empty, and
+<a for=response>header list</a> is « », and
 <a for=response>body</a> is null.
 
 <div class=note>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2299,9 +2299,9 @@ end-user.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-url-list>URL list</dfn> (a <a for=/>list</a> of zero or
-more <a for=/>URLs</a>). Unless stated otherwise, it is the empty list.
+more <a for=/>URLs</a>). Unless stated otherwise, it is « ».
 
-<p class="note no-backref">Except for the last <a for=/>URL</a>, if any, a <a for=/>response</a>'s
+<p class=note>Except for the last <a for=/>URL</a>, if any, a <a for=/>response</a>'s
 <a for=response>URL list</a> is not exposed to script as that would violate
 <a>atomic HTTP redirect handling</a>.
 
@@ -2318,7 +2318,7 @@ message as HTTP/2 does not support them.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-header-list>header list</dfn> (a
-<a for=/>header list</a>). Unless stated otherwise it is empty.
+<a for=/>header list</a>). Unless stated otherwise it is « ».
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-body>body</dfn> (null or a
@@ -2381,19 +2381,13 @@ this is also tracked internally using the request's <a for=request>timing allow 
 
 <hr>
 
-<p>A <a for=/>response</a> whose
-<a for=response>type</a> is "<code>error</code>" and <a for=response>aborted flag</a> is set is
-known as an <dfn export id=concept-aborted-network-error>aborted network error</dfn>.
+<p>A <dfn export id=concept-network-error>network error</dfn> is a <a for=/>response</a> whose
+<a for=response>type</a> is "<code>error</code>", <a for=response>status</a> is 0,
+<a for=response>status message</a> is the empty byte sequence,
+<a for=response>header list</a> is « », and <a for=response>body</a> is null.
 
-<p>A <a for=/>response</a> whose
-<a for=response>type</a> is "<code>error</code>" is known as a
-<dfn export id=concept-network-error>network error</dfn>.
-
-<p>A <a>network error</a> is a <a for=/>response</a> whose
-<a for=response>status</a> is always 0,
-<a for=response>status message</a> is always the empty byte sequence,
-<a for=response>header list</a> is always empty, and
-<a for=response>body</a> is always null.
+<p>An <dfn export id=concept-aborted-network-error>aborted network error</dfn> is a
+<a>network error</a> whose <a for=response>aborted flag</a> is set.
 
 <div algorithm>
 <p>To create the <dfn>appropriate network error</dfn> given <a for=/>fetch params</a>


### PR DESCRIPTION
Prolly best to wait and rebase this on top of #1556 once it lands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1561.html" title="Last updated on Jan 3, 2023, 9:17 AM UTC (f477029)">Preview</a> | <a href="https://whatpr.org/fetch/1561/f6e9b8d...f477029.html" title="Last updated on Jan 3, 2023, 9:17 AM UTC (f477029)">Diff</a>