### PR TITLE
s/early-hint/early-hints/

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1599,7 +1599,7 @@ this flag set are subject to additional processing requirements.
 "<code>beacon</code>",
 "<code>body</code>",
 "<code>css</code>",
-"<code>early-hint</code>",
+"<code>early-hints</code>",
 "<code>embed</code>",
 "<code>fetch</code>",
 "<code>font</code>",


### PR DESCRIPTION
Editorial change so checklist not required: 
As pointed out in https://github.com/w3c/resource-timing/issues/364, there's a discrepancy between the initiator "early-hint" value in Fetch and the Chromium implementation. This aligns the spec to the implementation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1562.html" title="Last updated on Dec 9, 2022, 12:03 PM UTC (dfe6eac)">Preview</a> | <a href="https://whatpr.org/fetch/1562/f6e9b8d...dfe6eac.html" title="Last updated on Dec 9, 2022, 12:03 PM UTC (dfe6eac)">Diff</a>