### PR TITLE
Add HTTP OWS handling to single range header parsing

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1020,7 +1020,7 @@ fetch("https://victim.example/naïve-endpoint", {
    <dd>
     <ol>
      <li><p>Let <var>rangeValue</var> be the result of <a>parsing a single range header value</a>
-     given <var>value</var>.
+     given <var>value</var> and false.
 
      <li><p>If <var>rangeValue</var> is failure, then return false.
 
@@ -1292,16 +1292,27 @@ run these steps:
 
 <div algorithm>
 <p>To <dfn id=simple-range-header-value>parse a single range header value</dfn> from a
-<a>byte sequence</a> <var>value</var>, run these steps:
+<a>byte sequence</a> <var>value</var> and a boolean <var>allowWhitespace</var>, run these steps:
 
 <ol>
  <li><p>Let <var>data</var> be the <a>isomorphic decoding</a> of <var>value</var>.
 
- <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes=</code>", then return
+ <li><p>If <var>data</var> does not <a for=string>start with</a> "<code>bytes</code>", then return
  failure.
 
  <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
- pointing at the 6th <a>code point</a> of <var>data</var>.
+ pointing at the 5th <a>code point</a> of <var>data</var>.
+
+ <li><p>If <var>allowWhitespace</var> is true, <a>collect a sequence of code points</a> that are
+ <a>HTTP tab or space</a>, from <var>data</var> given <var>position</var>.
+
+ <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+003D (=),
+ then return failure.
+
+ <li><p>Advance <var>position</var> by 1.
+
+ <li><p>If <var>allowWhitespace</var> is true, <a>collect a sequence of code points</a> that are
+ <a>HTTP tab or space</a>, from <var>data</var> given <var>position</var>.
 
  <li><p>Let <var>rangeStart</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.
@@ -1309,10 +1320,16 @@ run these steps:
  <li><p>Let <var>rangeStartValue</var> be <var>rangeStart</var>, interpreted as decimal number, if
  <var>rangeStart</var> is not the empty string; otherwise null.
 
+ <li><p>If <var>allowWhitespace</var> is true, <a>collect a sequence of code points</a> that are
+ <a>HTTP tab or space</a>, from <var>data</var> given <var>position</var>.
+
  <li><p>If the <a>code point</a> at <var>position</var> within <var>data</var> is not U+002D (-),
  then return failure.
 
  <li><p>Advance <var>position</var> by 1.
+
+ <li><p>If <var>allowWhitespace</var> is true, <a>collect a sequence of code points</a> that are
+ <a>HTTP tab or space</a>, from <var>data</var> given <var>position</var>.
 
  <li><p>Let <var>rangeEnd</var> be the result of <a>collecting a sequence of code points</a> that
  are <a>ASCII digits</a>, from <var>data</var> given <var>position</var>.


### PR DESCRIPTION
Add HTTP optional white space handling to the single range header parser.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/34384
   * https://github.com/web-platform-tests/wpt/pull/37569
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

I didn't see a concrete consensus made about the CORS case in https://github.com/whatwg/fetch/issues/1070, so I went with the more conservative option here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1564.html" title="Last updated on Feb 16, 2023, 1:41 AM UTC (1be32b3)">Preview</a> | <a href="https://whatpr.org/fetch/1564/093c622...1be32b3.html" title="Last updated on Feb 16, 2023, 1:41 AM UTC (1be32b3)">Diff</a>