### PR TITLE
Send `Sec-Purpose: prefetch` header for prefetch requests

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -18,8 +18,8 @@ urlPrefix:https://httpwg.org/specs/rfc8941.html#;type:dfn;spec:rfc8941
     url:rfc.section.2;text:structured field value
     url:text-serialize;text:serializing structured fields
     url:text-parse;text:parsing structured fields
-    url:name-lists;text:structured header list
     url:;text:structured header
+    url:token;text:structured field token
 
 urlPrefix:https://httpwg.org/specs/rfc9110.html#;type:dfn;spec:http
     url:method.overview;text:method
@@ -4097,18 +4097,16 @@ header specifies that the request serves one or more purposes other than request
 immediate use by the user.
 
 <p>The `<a http-header><code>Sec-Purpose</code></a>` header field is a <a>structured header</a>
-whose value must be a <a data-lt="structured header list">list</a>. Its ABNF is: [[!RFC8941]]
+whose value must be a <a data-lt="structured field token">token</a>.
 
-<pre><code class=lang-abnf>
-Sec-Purpose    = sf-list
-</code></pre>
-
-It may contain an item member which is the token "prefetch". If so, this indicates the request’s
-purpose is to download a resource it is anticipated will be fetched shortly.
+It may contain an item member which is the <a data-lt="structured field token">token</a>
+"<code>prefetch</code>". If so, this indicates the request’s purpose is to download a resource it is
+anticipated will be fetched shortly.
 
 <p class=note>This can be used, for example, to let the server adjust the caching expiry for
 prefetches, to disallow the prefetch by rejecting the request, or treat it differently
 for the purpose of counting page visits.
+
 
 
 <h2 id=fetching>Fetching</h2>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4099,13 +4099,12 @@ immediate use by the user.
 <p>The `<a http-header><code>Sec-Purpose</code></a>` header field is a <a>structured header</a>
 whose value must be a <a data-lt="structured field token">token</a>.
 
-It may contain an item member which is the <a data-lt="structured field token">token</a>
-"<code>prefetch</code>". If so, this indicates the request’s purpose is to download a resource it is
-anticipated will be fetched shortly.
+<p>It may contain an item member which is the <a data-lt="structured field token">token</a>
+<code>prefetch</code>. If so, this indicates the request’s purpose is to fetch a resource it
+anticipates will be needed shortly.
 
-<p class=note>This can be used, for example, to let the server adjust the caching expiry for
-prefetches, to disallow the prefetch by rejecting the request, or treat it differently
-for the purpose of counting page visits.
+<p class=note>The server can use this to adjust the caching expiry for prefetches, to disallow the
+prefetch, or to treat it differently when counting page visits.
 
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5313,9 +5313,15 @@ run these steps:
    <li><p><a abstract-op lt="append the Fetch metadata headers for a request">Append the Fetch metadata headers for <var>httpRequest</var></a>.
    [[!FETCH-METADATA]]
 
-   <li><p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
-   <a for="header list">append</a> (`<code>Sec-Purpose</code>`, "<code>prefetch</code>") to
-   <var>httpRequest</var>'s <a for=request>header list</a>.
+   <li>
+    <p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
+    <a for="header list">append</a> (`<code>Sec-Purpose</code>`, "<code>prefetch</code>") to
+    <var>httpRequest</var>'s <a for=request>header list</a>.
+
+    <p class=note>This header gives servers an opportunity to handle prefetches differently from
+    regular requests. For example, the server may allow caching for a longer period for a prefetch
+    request, disallow prefetches by rejecting the request, or treat it differently for the purpose
+    of counting page visits.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should

--- a/fetch.bs
+++ b/fetch.bs
@@ -4103,7 +4103,7 @@ whose value must be a <a data-lt="structured header list">list</a>. Its ABNF is:
 Sec-Purpose    = sf-list
 </code></pre>
 
-It may contain a Item member which is the Token "prefetch". If so, this indicates the request’s
+It may contain an item member which is the token "prefetch". If so, this indicates the request’s
 purpose is to download a resource it is anticipated will be fetched shortly.
 
 <p class=note>This can be used, for example, to let the server adjust the caching expiry for

--- a/fetch.bs
+++ b/fetch.bs
@@ -5313,6 +5313,10 @@ run these steps:
    <li><p><a abstract-op lt="append the Fetch metadata headers for a request">Append the Fetch metadata headers for <var>httpRequest</var></a>.
    [[!FETCH-METADATA]]
 
+   <li><p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
+   <a for="header list">append</a> (`<code>Sec-Purpose</code>`, "<code>prefetch</code>") to
+   <var>httpRequest</var>'s <a for=request>header list</a>.
+
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should
    <a for="header list">append</a> (`<code>User-Agent</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -4099,9 +4099,8 @@ immediate use by the user.
 <p>The `<a http-header><code>Sec-Purpose</code></a>` header field is a <a>structured header</a>
 whose value must be a <a data-lt="structured field token">token</a>.
 
-<p>It may contain an item member which is the <a data-lt="structured field token">token</a>
-<code>prefetch</code>. If so, this indicates the request’s purpose is to fetch a resource it
-anticipates will be needed shortly.
+<p>The sole <a data-lt="structured field token">token</a> defined is <code>prefetch</code>. It
+indicates the request’s purpose is to fetch a resource that is anticipated to be needed shortly.
 
 <p class=note>The server can use this to adjust the caching expiry for prefetches, to disallow the
 prefetch, or to treat it differently when counting page visits.

--- a/fetch.bs
+++ b/fetch.bs
@@ -18,6 +18,8 @@ urlPrefix:https://httpwg.org/specs/rfc8941.html#;type:dfn;spec:rfc8941
     url:rfc.section.2;text:structured field value
     url:text-serialize;text:serializing structured fields
     url:text-parse;text:parsing structured fields
+    url:name-lists;text:structured header list
+    url:;text:structured header
 
 urlPrefix:https://httpwg.org/specs/rfc9110.html#;type:dfn;spec:http
     url:method.overview;text:method
@@ -4088,6 +4090,26 @@ run these steps:
 </div>
 
 
+<h3 id="sec-purpose-header">`<code>Sec-Purpose</code>` header</h3>
+
+<p>The `<dfn export http-header id=http-sec-purpose><code>Sec-Purpose</code></dfn>` HTTP request
+header specifies that the request serves one or more purposes other than requesting the resource for
+immediate use by the user.
+
+<p>The `<a http-header><code>Sec-Purpose</code></a>` header field is a <a>structured header</a>
+whose value must be a <a data-lt="structured header list">list</a>. Its ABNF is: [[!RFC8941]]
+
+<pre><code class=lang-abnf>
+Sec-Purpose    = sf-list
+</code></pre>
+
+It may contain a Item member which is the Token "prefetch". If so, this indicates the request’s
+purpose is to download a resource it is anticipated will be fetched shortly.
+
+<p class=note>This can be used, for example, to let the server adjust the caching expiry for
+prefetches, to disallow the prefetch by rejecting the request, or treat it differently
+for the purpose of counting page visits.
+
 
 <h2 id=fetching>Fetching</h2>
 
@@ -5313,15 +5335,9 @@ run these steps:
    <li><p><a abstract-op lt="append the Fetch metadata headers for a request">Append the Fetch metadata headers for <var>httpRequest</var></a>.
    [[!FETCH-METADATA]]
 
-   <li>
-    <p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
-    <a for="header list">append</a> (`<code>Sec-Purpose</code>`, "<code>prefetch</code>") to
-    <var>httpRequest</var>'s <a for=request>header list</a>.
-
-    <p class=note>This header gives servers an opportunity to handle prefetches differently from
-    regular requests. For example, the server may allow caching for a longer period for a prefetch
-    request, disallow prefetches by rejecting the request, or treat it differently for the purpose
-    of counting page visits.
+   <li><p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
+   <a>set a structured field value</a> given (`<a http-header><code>Sec-Purpose</code></a>`,
+   "<code>prefetch</code>") in <var>httpRequest</var>'s <a for=request>header list</a>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should

--- a/fetch.bs
+++ b/fetch.bs
@@ -5335,7 +5335,8 @@ run these steps:
 
    <li><p>If <var>httpRequest</var>'s <a for=request>initiator</a> is "<code>prefetch</code>", then
    <a>set a structured field value</a> given (`<a http-header><code>Sec-Purpose</code></a>`,
-   "<code>prefetch</code>") in <var>httpRequest</var>'s <a for=request>header list</a>.
+   the <a data-lt="structured field token">token</a> <code>prefetch</code>) in
+   <var>httpRequest</var>'s <a for=request>header list</a>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should


### PR DESCRIPTION
Send `Sec-Purpose: prefetch` for prefetch requests

The purpose headers allows servers to discern between regular requests
and "resource hints" - requests that are only meant to populate
caches.

This replaces the existing `Purpose` and `x-moz: prefetch` headers.

Closes w3c/webappsec-fetch-metadata#84
Closes https://github.com/w3c/resource-hints/issues/74
Part of whatwg/html#8111

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Apple: https://github.com/WebKit/standards-positions/issues/114
   * https://github.com/mozilla/standards-positions/issues/723

- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/35707
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: 
                     [1358419: `Sec-Purpose` header](https://bugs.chromium.org/p/chromium/issues/detail?id=1358419)
   * Firefox: 
                    [1788167: Align prefetch with spec](https://bugzilla.mozilla.org/show_bug.cgi?id=1788167)
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=49238
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/23553

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1576.html" title="Last updated on Jan 16, 2023, 1:15 PM UTC (ac3e6d4)">Preview</a> | <a href="https://whatpr.org/fetch/1576/4500d3a...ac3e6d4.html" title="Last updated on Jan 16, 2023, 1:15 PM UTC (ac3e6d4)">Diff</a>