### PR TITLE
Add reference to MIX in main fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4338,6 +4338,8 @@ steps:
 
  <li><p><a>Upgrade <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
+ <li><p><a>Upgrade a mixed content <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
+
  <li><p>If <a lt="block bad port">should <var>request</var> be blocked due to a bad port</a>,
  <a lt="should fetching request be blocked as mixed content?">should fetching <var>request</var> be blocked as mixed content</a>, or
  <a lt="should request be blocked by Content Security Policy?">should <var>request</var> be blocked by Content Security Policy</a>


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * This was proposed originally as part of changes to MIX, which have since been implemented by Chrome and are in the process of being implemented by Firefox. Additionally Safari supported the MIX changes.
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Tests exist under https://github.com/web-platform-tests/wpt/tree/master/mixed-content/tentative/autoupgrades.
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: This behavior is already launched in Chrome
   * Gecko: Unclear if bug exists yet, but it's planned for launching in Nightly soon (see discussion in web-platform-tests/wpt#37080)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: Unclear if this necessary for this change since it doesn't add any new features.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1578.html" title="Last updated on Dec 21, 2022, 1:11 AM UTC (1bce7f0)">Preview</a> | <a href="https://whatpr.org/fetch/1578/84ea7db...1bce7f0.html" title="Last updated on Dec 21, 2022, 1:11 AM UTC (1bce7f0)">Diff</a>