### PR TITLE
Don't automaticallly report resource timing for cross-origin TAO-fail…

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4678,24 +4678,25 @@ steps:
      <li>
       <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
       then:
-       <ol>
-        <li>
-         <p>If <var>fetchParams</var>'s
-         <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>",
-         then abort these <a for="fetch controller">report timing steps</a>.
 
-         <p class=note>Reporting timing information for cross-origin navigations without
-         `<code>Timing-Allow-Origin</code>` may expose information about user interaction with that
-         origin.
+      <ol>
+       <li>
+        <p>If <var>fetchParams</var>'s
+        <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>",
+        then abort these steps.
 
-        <li>
-         <p>Set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
-          <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>,
-          and set <var>cacheState</var> to the empty string.
+        <p class=note>Reporting timing information for cross-origin navigations without
+        `<code>Timing-Allow-Origin</code>` may expose information about user interaction with that
+        origin.
 
-         <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
-        </li>
-       </ol>
+       <li>
+        <p>Set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
+        <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>,
+        and set <var>cacheState</var> to the empty string.
+
+        <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
+       </li>
+      </ol>
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and

--- a/fetch.bs
+++ b/fetch.bs
@@ -4677,11 +4677,25 @@ steps:
 
      <li>
       <p>If <var>response</var>'s <a for=response>timing allow passed flag</a> is not set,
-      then set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
-      <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>, and
-      set <var>cacheState</var> to the empty string.
+      then:
+       <ol>
+        <li>
+         <p>If <var>fetchParams</var>'s
+         <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>",
+         then abort these <a for="fetch controller">report timing steps</a>.
 
-      <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
+         <p class=note>Reporting timing information for cross-origin navigations without
+         `<code>Timing-Allow-Origin</code>` may expose information about user interaction with that
+         origin.
+
+        <li>
+         <p>Set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for
+          <var>timingInfo</var>, set <var>bodyInfo</var> to a new <a for=/>response body info</a>,
+          and set <var>cacheState</var> to the empty string.
+
+         <p class=note>This covers the case of <var>response</var> being a <a>network error</a>.
+        </li>
+       </ol>
 
      <li><p>Let <var>responseStatus</var> be 0 if <var>fetchParams</var>'s
      <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>" and

--- a/fetch.bs
+++ b/fetch.bs
@@ -4685,9 +4685,9 @@ steps:
         <a for="fetch params">request</a>'s <a for=request>mode</a> is "<code>navigate</code>",
         then abort these steps.
 
-        <p class=note>Reporting timing information for cross-origin navigations without
-        `<code>Timing-Allow-Origin</code>` may expose information about user interaction with that
-        origin.
+        <p class=note>Reporting timing information for cross-origin navigations without the
+        `<code>Timing-Allow-Origin</code>` header may expose information about user interaction with
+        that origin, alongside other unintended information about nested navigations.
 
        <li>
         <p>Set <var>timingInfo</var> to the result of <a>creating an opaque timing info</a> for


### PR DESCRIPTION
… iframes

Reporting the response end time for an iframe may leak information about user interaction with that iframe.

See w3c/resource-timing#340

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37810
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1404695
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1809182
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=250322
   * Deno (not for CORS changes): …
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/23740

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1579.html" title="Last updated on Jan 25, 2023, 1:13 PM UTC (c3cff9d)">Preview</a> | <a href="https://whatpr.org/fetch/1579/e1e9567...c3cff9d.html" title="Last updated on Jan 25, 2023, 1:13 PM UTC (c3cff9d)">Diff</a>