### PR TITLE
Use internal response for Server-Timing

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4624,8 +4624,9 @@ steps:
   from <var>response</var>'s <a for="filtered response">internal response</a>'s
   <a for=response>header list</a>.
 
-  <p class="note">We can safely use filtered response here as the opt-in to protect
-  `<code>Server-Timing</code>` responses is `<code>Timing-Allow-Origin</code>`.
+  <p class=note>Using _response_'s <a for="filtered response">internal response</a> is safe as
+  exposing `<code>Server-Timing</code>` header data is guarded through the
+  `<code>Timing-Allow-Origin</code>` header.
 
   <p>The user agent may decide to expose `<code>Server-Timing</code>` headers to non-secure contexts
   requests as well.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4621,7 +4621,11 @@ steps:
   <a for="fetch params">request</a>'s <a for=request>client</a> is a <a>secure context</a>, then set
   <var>timingInfo</var>'s <a for="fetch timing info">server-timing headers</a> to the
   result of <a for="header list">getting, decoding, and splitting</a> `<code>Server-Timing</code>`
-  from <var>response</var>'s <a for=response>header list</a>.
+  from <var>response</var>'s <a for="filtered response">internal response</a>'s
+  <a for=response>header list</a>.
+
+  <p class="note">We can safely use filtered response here as the opt-in to protect
+  `<code>Server-Timing</code>` responses is `<code>Timing-Allow-Origin</code>`.
 
   <p>The user agent may decide to expose `<code>Server-Timing</code>` headers to non-secure contexts
   requests as well.


### PR DESCRIPTION
The `Server-Timing` header is protected by TAO, so there's no need to safelist it in CORS as well.

Closes #1511

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Already implemented
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37714
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Already implemented
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1584.html" title="Last updated on Jan 3, 2023, 8:07 AM UTC (edff313)">Preview</a> | <a href="https://whatpr.org/fetch/1584/464326e...edff313.html" title="Last updated on Jan 3, 2023, 8:07 AM UTC (edff313)">Diff</a>