### PR TITLE
Editorial: Remove `prefetch-src`

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1814,7 +1814,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>prefetch</code>"
    <td rowspan=2>""
-   <td rowspan=2><code>prefetch-src</code>
+   <td rowspan=2><code>default-src</code>, or least restrictive directive. [[!CSP]]
    <td>HTML's <code>&lt;link rel=prefetch></code>
   <tr>
    <td>"<code>prerender</code>"

--- a/fetch.bs
+++ b/fetch.bs
@@ -1814,7 +1814,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>prefetch</code>"
    <td rowspan=2>""
-   <td rowspan=2><code>default-src</code>, or least restrictive directive. [[!CSP]]
+   <td rowspan=2><code>default-src</code> (no specific directive)
    <td>HTML's <code>&lt;link rel=prefetch></code>
   <tr>
    <td>"<code>prerender</code>"


### PR DESCRIPTION
The `prefetch-src` directive was [removed from CSP](https://github.com/w3c/webappsec-csp/pull/582). Instead we use either `default-src` or the least restrictive directive if one exists.

Updating the destination table to reflect this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1595.html" title="Last updated on Jan 25, 2023, 1:11 PM UTC (86af10f)">Preview</a> | <a href="https://whatpr.org/fetch/1595/a5560d2...86af10f.html" title="Last updated on Jan 25, 2023, 1:11 PM UTC (86af10f)">Diff</a>