### PR TITLE
Add http method to fetch timing info

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -353,6 +353,8 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dd>A <a for=/>list</a> of strings.
  <dt><dfn export for="fetch timing info">render-blocking</dfn> (default false)
  <dd>A boolean.
+ <dt><dfn export for="fetch timing info">http method</dfn> (default: GET)
+ <dd> A {{ByteString}}
 </dl>
 
 <p>A <dfn export>response body info</dfn> is a <a for=/>struct</a> used to maintain
@@ -4231,7 +4233,9 @@ the response. [[!HTTP-CACHING]]
  <li><p>Let <var>timingInfo</var> be a new <a for=/>fetch timing info</a> whose
  <a for="fetch timing info">start time</a> and
  <a for="fetch timing info">post-redirect start time</a> are the
- <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>, and
+ <a for=/>coarsened shared current time</a> given <var>crossOriginIsolatedCapability</var>,
+ <a for="fetch timing info">http method</a> is set to <var>request</var>'s
+ <a for=request>method</a>, and
  <a for="fetch timing info">render-blocking</a> is set to <var>request</var>'s
  <a for=request>render-blocking</a>.
 


### PR DESCRIPTION
This change will allow for the addition of the http method to the resource-timing spec

Explainer: https://github.com/sohomdatta1/rt-explainer
Associated resource-timing PR: w3c/resource-timing#375

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1632.html" title="Last updated on Apr 17, 2023, 4:16 PM UTC (6ed966f)">Preview</a> | <a href="https://whatpr.org/fetch/1632/8f10983...6ed966f.html" title="Last updated on Apr 17, 2023, 4:16 PM UTC (6ed966f)">Diff</a>