### PR TITLE
Editorial: update args for collect an HTTP quoted string

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -446,7 +446,7 @@ preferred. Unlike <a>ASCII whitespace</a> this excludes U+000C FF.
 <p>To
 <dfn export lt="collect an HTTP quoted string|collecting an HTTP quoted string">collect an HTTP quoted string</dfn>
 from a <a for=/>string</a> <var>input</var>, given a <a>position variable</a> <var>position</var>
-and optionally an <var>extract-value flag</var>, run these steps:
+and an optional boolean <var>extract-value</var> (default false):
 
 <ol>
  <li><p>Let <var>positionStart</var> be <var>position</var>.
@@ -495,7 +495,7 @@ and optionally an <var>extract-value flag</var>, run these steps:
     </ol>
   </ol>
 
- <li><p>If the <var>extract-value flag</var> is set, then return <var>value</var>.
+ <li><p>If <var>extract-value</var> is true, then return <var>value</var>.
 
  <li><p>Return the <a for=/>code points</a> from <var>positionStart</var> to <var>position</var>,
  inclusive, within <var>input</var>.
@@ -506,7 +506,7 @@ and optionally an <var>extract-value flag</var>, run these steps:
   <tr>
    <th>Input
    <th>Output
-   <th>Output with the <var>extract-value flag</var> set
+   <th>Output with <var>extract-value</var> set to true
    <th>Final <a>position variable</a> value
   <tr>
    <td>"<code><mark>"\</mark></code>"


### PR DESCRIPTION
Rename the "extract-value flag" argument to the algorithm "collect an HTTP quoted string" to a boolean "extract-value" that will by default be false.

Fixes: #1567


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1641.html" title="Last updated on May 5, 2023, 9:40 PM UTC (ba2d76c)">Preview</a> | <a href="https://whatpr.org/fetch/1641/ca10f49...ba2d76c.html" title="Last updated on May 5, 2023, 9:40 PM UTC (ba2d76c)">Diff</a>