### PR TITLE
Use internalResponse at end of fetch handover

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4810,7 +4810,11 @@ steps:
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
- <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
+ <li><p>Let <var>actualResponse</var> be <var>response</var>'s
+ <a for="filtered response">internal response</a> if <var>response</var> is a
+ <a>filtered response</a>; Otherwise <var>response</var>.
+
+ <li><p>If <var>actualResponse</var>'s <a for=response>body</a> is null, then run
  <var>processResponseEndOfBody</var>.
 
  <li>
@@ -4828,8 +4832,8 @@ steps:
    <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set to
    <var>processResponseEndOfBody</var>.
 
-   <li><p>Set <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the result
-   of <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+   <li><p>Set <var>actualResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the
+   result of <var>actualResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a>
    <a for=ReadableStream>piped through</a> <var>transformStream</var>.
   </ol>
 
@@ -4843,17 +4847,18 @@ steps:
   <ol>
    <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
    <var>fetchParams</var>'s <a for="fetch params">process response consume body</a> given
-   <var>response</var> and <var>nullOrBytes</var>.
+   <var>actualResponse</var> and <var>nullOrBytes</var>.
 
    <li><p>Let <var>processBodyError</var> be this step: run <var>fetchParams</var>'s
-   <a for="fetch params">process response consume body</a> given <var>response</var> and failure.
+   <a for="fetch params">process response consume body</a> given <var>actualResponse</var> and
+   failure.
 
-   <li><p>If <var>response</var>'s <a for=response>body</a> is null, then <a>queue a fetch task</a>
+   <li><p>If <var>actualResponse</var>'s <a for=response>body</a> is null, then <a>queue a fetch task</a>
    to run <var>processBody</var> given null, with <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
 
-   <li><p>Otherwise, <a for=body>fully read</a> <var>response</var>'s <a for=response>body</a> given
-   <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
+   <li><p>Otherwise, <a for=body>fully read</a> <var>actualResponse</var>'s <a for=response>body</a>
+   given <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
   </ol>
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -8812,11 +8812,11 @@ particular at what stage you would like to receive a callback:
     <a for=response>body</a> succeeded.
 
     <p class=warning>A <a>byte sequence</a> containing the full contents will be passed also for a
-    <a for=/>request</a> whose <a for=request>mode</a> is "<code>no-cors</code>". Invokers have to
-    be careful when handling such content, as it shouldn't be accessible to the requesting
-    <a for=/>origin</a>. For example, the invoker may use contents of a "<code>no-cors</code>"
+    <a for=/>request</a> whose <a for=request>mode</a> is "<code>no-cors</code>". Callers have to
+    be careful when handling such content, as it should not be accessible to the requesting
+    <a for=/>origin</a>. For example, the caller may use contents of a "<code>no-cors</code>"
     <a for=/>response</a> to display image contents directly to the user, but those image contents
-    should not be read by scripts in the embedding <code>Document</code>.
+    should not be directly exposed to scripts in the embedding document.
   </dl>
 
   <div id=example-callback-upon-completion class=example>

--- a/fetch.bs
+++ b/fetch.bs
@@ -8807,8 +8807,16 @@ particular at what stage you would like to receive a callback:
    <a for=response>body</a> failed, e.g., due to an I/O error.
 
    <dt>a <a>byte sequence</a>
-   <dd><a for=body>Fully reading</a> the contents of the <a for=/>response</a>'s
-   <a for=response>body</a> succeeded.
+   <dd>
+    <p><a for=body>Fully reading</a> the contents of the <a for=/>response</a>'s
+    <a for=response>body</a> succeeded.
+
+    <p class=warning>A <a>byte sequence</a> containing the full contents will be passed also for a
+    <a for=/>request</a> whose <a for=request>mode</a> is "<code>no-cors</code>". Invokers have to
+    be careful when handling such content, as it shouldn't be accessible to the requesting
+    <a for=/>origin</a>. For example, the invoker may use contents of a "<code>no-cors</code>"
+    <a for=/>response</a> to display image contents directly to the user, but those image contents
+    should not be read by scripts in the embedding <code>Document</code>.
   </dl>
 
   <div id=example-callback-upon-completion class=example>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4810,11 +4810,11 @@ steps:
  <a for="fetch params">process response</a> given <var>response</var>, with <var>fetchParams</var>'s
  <a for="fetch params">task destination</a>.
 
- <li><p>Let <var>actualResponse</var> be <var>response</var>'s
- <a for="filtered response">internal response</a> if <var>response</var> is a
- <a>filtered response</a>; Otherwise <var>response</var>.
+ <li><p>Let <var>internalResponse</var> be <var>response</var>, if <var>response</var> is a
+ <a>network error</a>; otherwise <var>response</var>'s
+ <a for="filtered response">internal response</a> otherwise.
 
- <li><p>If <var>actualResponse</var>'s <a for=response>body</a> is null, then run
+ <li><p>If <var>internalResponse</var>'s <a for=response>body</a> is null, then run
  <var>processResponseEndOfBody</var>.
 
  <li>
@@ -4832,8 +4832,8 @@ steps:
    <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set to
    <var>processResponseEndOfBody</var>.
 
-   <li><p>Set <var>actualResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the
-   result of <var>actualResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+   <li><p>Set <var>internalResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the
+   result of <var>internalResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a>
    <a for=ReadableStream>piped through</a> <var>transformStream</var>.
   </ol>
 
@@ -4847,19 +4847,19 @@ steps:
   <ol>
    <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
    <var>fetchParams</var>'s <a for="fetch params">process response consume body</a> given
-   <var>actualResponse</var> and <var>nullOrBytes</var>.
+   <var>internalResponse</var> and <var>nullOrBytes</var>.
 
    <li><p>Let <var>processBodyError</var> be this step: run <var>fetchParams</var>'s
-   <a for="fetch params">process response consume body</a> given <var>actualResponse</var> and
+   <a for="fetch params">process response consume body</a> given <var>internalResponse</var> and
    failure.
 
-   <li><p>If <var>actualResponse</var>'s <a for=response>body</a> is null, then <a>queue a fetch task</a>
-   to run <var>processBody</var> given null, with <var>fetchParams</var>'s
+   <li><p>If <var>internalResponse</var>'s <a for=response>body</a> is null, then
+   <a>queue a fetch task</a> to run <var>processBody</var> given null, with <var>fetchParams</var>'s
    <a for="fetch params">task destination</a>.
 
-   <li><p>Otherwise, <a for=body>fully read</a> <var>actualResponse</var>'s <a for=response>body</a>
-   given <var>processBody</var>, <var>processBodyError</var>, and <var>fetchParams</var>'s
-   <a for="fetch params">task destination</a>.
+   <li><p>Otherwise, <a for=body>fully read</a> <var>internalResponse</var>'s
+   <a for=response>body</a> given <var>processBody</var>, <var>processBodyError</var>, and
+   <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
   </ol>
 </ol>
 </div>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4812,7 +4812,7 @@ steps:
 
  <li><p>Let <var>internalResponse</var> be <var>response</var>, if <var>response</var> is a
  <a>network error</a>; otherwise <var>response</var>'s
- <a for="filtered response">internal response</a> otherwise.
+ <a for="filtered response">internal response</a>.
 
  <li><p>If <var>internalResponse</var>'s <a for=response>body</a> is null, then run
  <var>processResponseEndOfBody</var>.


### PR DESCRIPTION
This ensures that callers of `processResponseEndOfBody` and `processResponseConsumeBody` would receive the correct body and response without additional steps.

Closes #1512

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1645.html" title="Last updated on May 22, 2023, 9:28 AM UTC (788a467)">Preview</a> | <a href="https://whatpr.org/fetch/1645/625897d...788a467.html" title="Last updated on May 22, 2023, 9:28 AM UTC (788a467)">Diff</a>