### PR TITLE
Editorial: account for removal of AbortSignal's follow

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7542,8 +7542,8 @@ object), initially null.
 
 <div algorithm>
 <p>To <dfn export for=Request lt=create|creating>create</dfn> a {{Request}} object, given a
-<a for=/>request</a> <var>request</var>, <a for=/>headers guard</a> <var>guard</var>, and
-<a>realm</a> <var>realm</var>, run these steps:
+<a for=/>request</a> <var>request</var>, <a for=/>headers guard</a> <var>guard</var>,
+{{AbortSignal}} object <var>signal</var>, and <a>realm</a> <var>realm</var>:
 
 <ol>
  <li><p>Let <var>requestObject</var> be a <a for=/>new</a> {{Request}} object with <var>realm</var>.
@@ -7554,8 +7554,7 @@ object), initially null.
  object with <var>realm</var>, whose <a for=Headers>headers list</a> is <var>request</var>'s
  <a for=request>headers list</a> and <a for=Headers>guard</a> is <var>guard</var>.
 
- <li><p>Set <var>requestObject</var>'s <a for=Request>signal</a> to a <a for=/>new</a>
- {{AbortSignal}} object with <var>realm</var>.
+ <li><p>Set <var>requestObject</var>'s <a for=Request>signal</a> to <var>signal</var>.
 
  <li><p>Return <var>requestObject</var>.
 </ol>
@@ -7826,11 +7825,12 @@ constructor steps are:
 
  <li><p>Set <a>this</a>'s <a for=Request>request</a> to <var>request</var>.
 
- <li><p>Set <a>this</a>'s <a for=Request>signal</a> to a <a for=/>new</a> {{AbortSignal}} object
- with <a>this</a>'s <a>relevant realm</a>.
+ <li><p>Let <var>signals</var> be « <var>signal</var> » if <var>signal</var> is non-null; otherwise
+ « ».
 
- <li><p>If <var>signal</var> is non-null, then make <a>this</a>'s <a for=Request>signal</a>
- <a for=AbortSignal>follow</a> <var>signal</var>.
+ <li><p>Set <a>this</a>'s <a for=Request>signal</a> to the result of
+ <a>creating a dependent abort signal</a> from <var>signals</var>, using {{AbortSignal}} and
+ <a>this</a>'s <a>relevant realm</a>.
 
  <li><p>Set <a>this</a>'s <a for=Request>headers</a> to a <a for=/>new</a> {{Headers}} object with
  <a>this</a>'s <a>relevant realm</a>, whose <a for=Headers>header list</a> is <var>request</var>'s
@@ -8015,12 +8015,15 @@ set; otherwise false.
  <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a>
  <a>this</a>'s <a for=Request>request</a>.
 
- <li><p>Let <var>clonedRequestObject</var> be the result of <a for=Request>creating</a> a
- {{Request}} object, given <var>clonedRequest</var>, <a>this</a>'s
- <a for=Request>headers</a>'s <a for=Headers>guard</a>, and <a>this</a>'s <a>relevant realm</a>.
+ <li><p><a for=/>Assert</a>: <a>this</a>'s <a for=Request>signal</a> is non-null.
 
- <li><p>Make <var>clonedRequestObject</var>'s <a for=Request>signal</a>
- <a for=AbortSignal>follow</a> <a>this</a>'s <a for=Request>signal</a>.
+ <li><p>Let <var>clonedSignal</var> be the result of <a>creating a dependent abort signal</a> from
+ « <a>this</a>'s <a for=Request>signal</a> », using {{AbortSignal}} and <a>this</a>'s
+ <a>relevant realm</a>.
+
+ <li><p>Let <var>clonedRequestObject</var> be the result of <a for=Request>creating</a> a
+ {{Request}} object, given <var>clonedRequest</var>, <a>this</a>'s <a for=Request>headers</a>'s
+ <a for=Headers>guard</a>, <var>clonedSignal</var> and <a>this</a>'s <a>relevant realm</a>.
 
  <li><p>Return <var>clonedRequestObject</var>.
 </ol>


### PR DESCRIPTION
For https://github.com/whatwg/dom/pull/1152.

---

This is incomplete. https://fetch.spec.whatwg.org/#dom-request-clone needs to be updated as well. While we could probably leave https://fetch.spec.whatwg.org/#request-create (also called by Service Workers) alone, that doesn't seem entirely right as we'd be creating a redundant `AbortSignal` object.

Would the best solution here be that "create" takes a signal(s?) argument and then uses that to create a new composite signal for itself?

It doesn't have to do anything for service workers it seems, but if service workers were to pass an empty list it'd do the same thing it does today.

cc @jakearchibald @shaseley


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1646.html" title="Last updated on May 17, 2023, 12:54 PM UTC (a11ffe2)">Preview</a> | <a href="https://whatpr.org/fetch/1646/018ac19...a11ffe2.html" title="Last updated on May 17, 2023, 12:54 PM UTC (a11ffe2)">Diff</a>