### PR TITLE
Fully read's processBodyError argument needs to take an exception

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1510,7 +1510,8 @@ must be an algorithm accepting an exception.
 <var>processBody</var>, an algorithm <var>processBodyError</var>, and an optional null,
 <a for=/>parallel queue</a>, or <a for=/>global object</a> <var>taskDestination</var> (default
 null), run these steps. <var>processBody</var> must be an algorithm accepting a
-<a for=/>byte sequence</a>. <var>processBodyError</var> must be an algorithm accepting no arguments.
+<a for=/>byte sequence</a>. <var>processBodyError</var> must be an algorithm optionally accepting an
+<a for=/>exception</a>.
 
 <ol>
  <li><p>If <var>taskDestination</var> is null, then set <var>taskDestination</var> to the result of
@@ -1520,8 +1521,9 @@ null), run these steps. <var>processBody</var> must be an algorithm accepting a
  <a>queue a fetch task</a> to run <var>processBody</var> given <var>bytes</var>, with
  <var>taskDestination</var>.
 
- <li><p>Let <var>errorSteps</var> be to <a>queue a fetch task</a> to run
- <var>processBodyError</var>, with <var>taskDestination</var>.
+ <li><p>Let <var>errorSteps</var> optionally given an <a for=/>exception</a> <var>exception</var> be
+ to <a>queue a fetch task</a> to run <var>processBodyError</var> given <var>exception</var>, with
+ <var>taskDestination</var>.
 
  <li><p>Let <var>reader</var> be the result of <a for=ReadableStream>getting a reader</a> for
  <var>body</var>'s <a for=body>stream</a>. If that threw an exception, then run
@@ -8988,6 +8990,7 @@ Rondinelly,
 Rory Hewitt,
 Ross A. Baker,
 Ryan Sleevi,
+Sam Atkins,
 Samy Kamkar,
 Sébastien Cevey,
 Sendil Kumar N,


### PR DESCRIPTION
Fixes #1636.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1650.html" title="Last updated on May 4, 2023, 8:08 AM UTC (47df1a3)">Preview</a> | <a href="https://whatpr.org/fetch/1650/4502481...47df1a3.html" title="Last updated on May 4, 2023, 8:08 AM UTC (47df1a3)">Diff</a>