### PR TITLE
Be more selective with handing out the internal response

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4854,11 +4854,10 @@ steps:
   <ol>
    <li><p>Let <var>processBody</var> given <var>nullOrBytes</var> be this step: run
    <var>fetchParams</var>'s <a for="fetch params">process response consume body</a> given
-   <var>internalResponse</var> and <var>nullOrBytes</var>.
+   <var>response</var> and <var>nullOrBytes</var>.
 
    <li><p>Let <var>processBodyError</var> be this step: run <var>fetchParams</var>'s
-   <a for="fetch params">process response consume body</a> given <var>internalResponse</var> and
-   failure.
+   <a for="fetch params">process response consume body</a> given <var>response</var> and failure.
 
    <li><p>If <var>internalResponse</var>'s <a for=response>body</a> is null, then
    <a>queue a fetch task</a> to run <var>processBody</var> given null, with <var>fetchParams</var>'s
@@ -8805,7 +8804,9 @@ particular at what stage you would like to receive a callback:
   <p>To process a <a for=/>response</a> upon completion, pass an algorithm as the
   <a for=fetch><i>processResponseConsumeBody</i></a> argument of <a for=/>fetch</a>. The given
   algorithm is passed a <a for=/>response</a> and an argument representing the fully read
-  <a for=response>body</a>. The second argument's values have the following meaning:
+  <a for=response>body</a> (of the <a for=/>response</a>'s
+  <a for="filtered response">internal response</a>). The second argument's values have the following
+  meaning:
 
   <dl>
    <dt>null
@@ -8819,7 +8820,7 @@ particular at what stage you would like to receive a callback:
    <dt>a <a>byte sequence</a>
    <dd>
     <p><a for=body>Fully reading</a> the contents of the <a for=/>response</a>'s
-    <a for=response>body</a> succeeded.
+    <a for="filtered response">internal response</a>'s <a for=response>body</a> succeeded.
 
     <p class=warning>A <a>byte sequence</a> containing the full contents will be passed also for a
     <a for=/>request</a> whose <a for=request>mode</a> is "<code>no-cors</code>". Callers have to
@@ -8954,6 +8955,7 @@ Adam Barth,
 Adam Lavin,
 Alan Jeffrey,
 Alexey Proskuryakov,
+Andreas Kling,
 Andrés Gutiérrez,
 Andrew Sutherland,
 Ángel González,


### PR DESCRIPTION
Upon reviewing #1645 again it struck me that the first argument to processResponseConsumeBody should not be the internal response. The caller would still have all the same capabilities when it's not and it's safer if it's not.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1661.html" title="Last updated on May 25, 2023, 4:44 PM UTC (4189234)">Preview</a> | <a href="https://whatpr.org/fetch/1661/9003266...4189234.html" title="Last updated on May 25, 2023, 4:44 PM UTC (4189234)">Diff</a>