### PR TITLE
Export "network partition key"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3036,8 +3036,8 @@ details of reused connections are not exposed and time values are coarsened.
 
 <h3 id=network-partition-keys>Network partition keys</h3>
 
-<p>A <dfn>network partition key</dfn> is a tuple consisting of a <a for=/>site</a> and null or
-an <a>implementation-defined</a> value.
+<p>A <dfn export>network partition key</dfn> is a tuple consisting of a <a for=/>site</a> and null
+or an <a>implementation-defined</a> value.
 
 <div algorithm>
 <p>To <dfn export>determine the network partition key</dfn>, given an


### PR DESCRIPTION
Exporting this allows other specs to partition network state on the same key used for the HTTP cache.

Network Error Logging, in particular, would like to use this concept by reference (see https://github.com/w3c/network-error-logging/issues/138).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1670.html" title="Last updated on Jun 7, 2023, 2:53 AM UTC (4c44911)">Preview</a> | <a href="https://whatpr.org/fetch/1670/5eaaf66...4c44911.html" title="Last updated on Jun 7, 2023, 2:53 AM UTC (4c44911)">Diff</a>