### PR TITLE
Review Draft Publication: June 2023

### DIFF
--- a/review-drafts/2023-06.bs
+++ b/review-drafts/2023-06.bs
@@ -1,5 +1,7 @@
 <pre class=metadata>
 Group: WHATWG
+Status: RD
+Date: 2023-06-19
 H1: Fetch
 Shortname: fetch
 Text Macro: TWITTER fetchstandard


### PR DESCRIPTION
The [June 2023 Review Draft](https://fetch.spec.whatwg.org/review-drafts/2023-06/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.