### PR TITLE
Fix broken markup

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8878,7 +8878,7 @@ particular at what stage you would like to receive a callback:
   continues from there.
 
   <p>To process a <a for=/>response</a> chunk-by-chunk, pass an algorithm to the
-  <a for=fetch><i>processResponse</i></a> argument of <a for/>fetch</a>. The given
+  <a for=fetch><i>processResponse</i></a> argument of <a for=/>fetch</a>. The given
   algorithm is passed a <a for=/>response</a> when the response's headers have been
   received and is responsible for reading the <a for=/>response</a>'s
   <a for=response>body</a>'s <a for=body>stream</a> in order to download the rest


### PR DESCRIPTION
There was an `<a for/>` tag, it meant to be `<a for=/>`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1689.html" title="Last updated on Jul 21, 2023, 5:57 PM UTC (584008f)">Preview</a> | <a href="https://whatpr.org/fetch/1689/0291bf1...584008f.html" title="Last updated on Jul 21, 2023, 5:57 PM UTC (584008f)">Diff</a>