### PR TITLE
Editorial: Create the build a content range algorithm

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1301,6 +1301,30 @@ run these steps:
 </div>
 
 <div algorithm>
+<p>To <dfn>build a content range</dfn> given an integer <var>rangeStart</var>, an integer
+<var>rangeEnd</var>, and an integer <var>fullLength</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>contentRange</var> be `<code>bytes </code>`.
+
+ <li><p>Append <var>rangeStart</var>, <a lt="serialize an integer">serialized</a> and
+ <a>isomorphic encoded</a>, to <var>contentRange</var>.
+
+ <li><p>Append 0x2D (-) to <var>contentRange</var>.
+
+ <li><p>Append <var>rangeEnd</var>, <a lt="serialize an integer">serialized</a> and
+ <a>isomorphic encoded</a> to <var>contentRange</var>.
+
+ <li><p>Append 0x2F (/) to <var>contentRange</var>.
+
+ <li><p>Append <var>fullLength</var>, <a lt="serialize an integer">serialized</a> and
+ <a>isomorphic encoded</a> to <var>contentRange</var>.
+
+ <li><p>Return <var>contentRange</var>.
+</ol>
+</div>
+
+<div algorithm>
 <p>To <dfn id=simple-range-header-value>parse a single range header value</dfn> from a
 <a>byte sequence</a> <var>value</var> and a boolean <var>allowWhitespace</var>, run these steps:
 
@@ -5004,21 +5028,8 @@ steps:
        <li><p>Let <var>serializedSlicedLength</var> be <var>slicedBlob</var>'s {{Blob/size}},
        <a lt="serialize an integer">serialized</a> and <a>isomorphic encoded</a>.
 
-       <!-- The following steps for content-range should be definined in a separate algorithm.
-            See https://github.com/whatwg/fetch/issues/1552 for future work -->
-       <li><p>Let <var>contentRange</var> be `<code>bytes </code>`.
-
-       <li><p>Append <var>rangeStart</var>, <a lt="serialize an integer">serialized</a> and
-       <a>isomorphic encoded</a>, to <var>contentRange</var>.
-
-       <li><p>Append 0x2D (-) to <var>contentRange</var>.
-
-       <li><p>Append <var>rangeEnd</var>, <a lt="serialize an integer">serialized</a> and
-       <a>isomorphic encoded</a> to <var>contentRange</var>.
-
-       <li><p>Append 0x2F (/) to <var>contentRange</var>.
-
-       <li><p>Append <var>serializedFullLength</var> to <var>contentRange</var>.
+       <li><p>Let <var>contentRange</var> be the result of invoking <a>build a content range</a>
+       given <var>rangeStart</var>, <var>rangeEnd</var>, and <var>fullLength</var>.
 
        <li><p>Set <var>response</var>'s <a for=response>status</a> to 206.
 


### PR DESCRIPTION
Move the content-range algorithm to a standalone algorithm to avoid the additional inlined steps in Scheme fetch.

Fixes: #1552


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1696.html" title="Last updated on Aug 24, 2023, 12:44 PM UTC (96c4d27)">Preview</a> | <a href="https://whatpr.org/fetch/1696/53e4c3d...96c4d27.html" title="Last updated on Aug 24, 2023, 12:44 PM UTC (96c4d27)">Diff</a>