### PR TITLE
Editorial: clarify response's URL list

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2321,8 +2321,7 @@ source of security bugs. Please seek security review for features that deal with
  <li><p>Assert: <var>response</var>'s <a for=response>URL list</a> <a for=list>is not empty</a>.
 
  <li>
-  <p>Let <var>url</var> be a copy of <var>response</var>'s <a for=response>URL list</a>'s first
-  element.
+  <p>Let <var>url</var> be a copy of <var>response</var>'s <a for=response>URL list</a>[0].
 
   <p class="note">This is not <var>response</var>'s <a for=response>URL</a> in order to avoid
   leaking information about redirect targets (see
@@ -2393,8 +2392,8 @@ end-user.
 <dfn export for=response id=concept-response-url-list>URL list</dfn> (a <a for=/>list</a> of zero or
 more <a for=/>URLs</a>). Unless stated otherwise, it is « ».
 
-<p class=note>Except for the last <a for=/>URL</a>, if any, a <a for=/>response</a>'s
-<a for=response>URL list</a> is not exposed to script as that would violate
+<p class=note>Except for the first and last <a for=/>URL</a>, if any, a <a for=/>response</a>'s
+<a for=response>URL list</a> is not directly exposed to script as that would violate
 <a>atomic HTTP redirect handling</a>.
 
 <p>A <a for=/>response</a> has an associated
@@ -4634,8 +4633,8 @@ steps:
   <p>If <var>internalResponse</var>'s <a for=response>URL list</a> <a for=list>is empty</a>, then
   set it to a <a for=list>clone</a> of <var>request</var>'s <a for=request>URL list</a>.
 
-  <p class=note>A <a for=/>response</a>'s <a for=response>URL list</a> can be empty (for example,
-  when the response represents an <code>about</code> URL).
+  <p class=note>A <a for=/>response</a>'s <a for=response>URL list</a> can be empty, e.g., when
+  fetching an <code>about:</code> URL.
  <!-- If you are ever tempted to move this around, carefully consider responses from about URLs,
       blob URLs, service workers, HTTP cache, HTTP network, etc. -->
 
@@ -8318,8 +8317,8 @@ otherwise <a>this</a>'s <a for=Response>response</a>'s <a for=response>URL</a>,
 to true.
 
 <p>The <dfn attribute for=Response><code>redirected</code></dfn> getter steps are to return true if
-<a>this</a>'s <a for=Response>response</a>'s <a for=response>URL list</a> has more than one item;
-otherwise false.
+<a>this</a>'s <a for=Response>response</a>'s <a for=response>URL list</a>'s <a for=list>size</a> is
+greater than 1; otherwise false.
 
 <p class=note>To filter out <a for=/>responses</a> that are the result of a
 redirect, do this directly through the API, e.g., <code>fetch(url, { redirect:"error" })</code>.


### PR DESCRIPTION
Mainly to give myself more confidence about https://github.com/whatwg/html/issues/9695.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1699.html" title="Last updated on Sep 6, 2023, 12:21 PM UTC (fc377fd)">Preview</a> | <a href="https://whatpr.org/fetch/1699/f64d43f...fc377fd.html" title="Last updated on Sep 6, 2023, 12:21 PM UTC (fc377fd)">Diff</a>