### PR TITLE
Correct request's window check

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4312,7 +4312,7 @@ the response. [[!HTTP-CACHING]]
    <li><p><var>request</var>'s <a for=request>mode</a> is "<code>same-origin</code>",
    "<code>cors</code>", or "<code>no-cors</code>"
 
-   <li><p><var>request</var>'s <a for=request>window</a> is non-null
+   <li><p><var>request</var>'s <a for=request>window</a> is an <a>environment settings object</a>
 
    <li><p><var>request</var>'s <a for=request>method</a> is `<code>GET</code>`
 


### PR DESCRIPTION
It's either "no-window" or an environment settings object.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1712.html" title="Last updated on Sep 29, 2023, 7:17 AM UTC (57c1ce1)">Preview</a> | <a href="https://whatpr.org/fetch/1712/c6d7166...57c1ce1.html" title="Last updated on Sep 29, 2023, 7:17 AM UTC (57c1ce1)">Diff</a>