### PR TITLE
Editorial: clarify preflight-request headers

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3381,13 +3381,17 @@ for all <a for=/>requests</a> whose <a for=request>method</a> is neither `<code>
 
 <p>A <dfn id=cors-preflight-request export>CORS-preflight request</dfn> is a <a>CORS request</a>
 that checks to see if the <a>CORS protocol</a> is understood. It uses `<code>OPTIONS</code>` as
-<a for=/>method</a> and includes these <a for=/>headers</a>:
+<a for=/>method</a> and includes the following <a for=/>header</a>:
 
 <dl>
  <dt>`<dfn export http-header id=http-access-control-request-method><code>Access-Control-Request-Method</code></dfn>`
  <dd><p>Indicates which <a for=/>method</a> a future
  <a>CORS request</a> to the same resource might use.
+</dl>
 
+<p>A <a>CORS-preflight request</a> can also include the following <a for=/>header</a>:
+
+<dl>
  <dt>`<dfn export http-header id=http-access-control-request-headers><code>Access-Control-Request-Headers</code></dfn>`
  <dd><p>Indicates which <a for=/>headers</a> a future
  <a>CORS request</a> to the same resource might use.


### PR DESCRIPTION
Clarify that, although CORS-preflight requests systematically include an Access-Control-Request-Method header, they do not systematically include an Access-Control-Request-Headers header.

Fixes #1717.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1719.html" title="Last updated on Oct 24, 2023, 12:14 PM UTC (6962c78)">Preview</a> | <a href="https://whatpr.org/fetch/1719/aa6f53e...6962c78.html" title="Last updated on Oct 24, 2023, 12:14 PM UTC (6962c78)">Diff</a>