### PR TITLE
Editorial: Export fetch controller/serialized abort reason

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -236,7 +236,7 @@ lt="authentication entry">authentication entries</a> (for HTTP authentication). 
  <dt><dfn for="fetch controller">report timing steps</dfn> (default null)
  <dd>Null or an algorithm accepting a <a for=/>global object</a>.
 
- <dt><dfn for="fetch controller">serialized abort reason</dfn> (default null)
+ <dt><dfn for="fetch controller" export>serialized abort reason</dfn> (default null)
  <dd>Null or a <a>Record</a> (result of [$StructuredSerialize$]).
 
  <dt><dfn for="fetch controller">next manual redirect steps</dfn> (default null)


### PR DESCRIPTION
This is referenced [1] by the Service Worker spec, so should either be exported or something else to achieve the same thing would need to exist (forwarding the "abort reason" from a fetch controller to an AbortController; note that the service worker algorithm is currently extra confusing because it uses the same variable name for both "controller" objects).

[1]: https://w3c.github.io/ServiceWorker/#clients-openwindow:~:text=If%20controller%E2%80%99s%20serialized%20abort%20reason%20is%20non%2Dnull


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1736.html" title="Last updated on Feb 12, 2024, 6:54 PM UTC (d5affe7)">Preview</a> | <a href="https://whatpr.org/fetch/1736/8dd73db...d5affe7.html" title="Last updated on Feb 12, 2024, 6:54 PM UTC (d5affe7)">Diff</a>