### PR TITLE
Support ServiceWorker Static Routing API

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1724,10 +1724,6 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
  </dl>
 </div>
 
-<p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers race token</dfn> (a string). Unless stated otherwise it is null.
-
-<p class=note>This is only set by <a for=/>handle fetch</a> in service workers.
-
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
@@ -4510,6 +4506,9 @@ steps:
 
  <li><p>If <var>recursive</var> is false, then run the remaining steps <a>in parallel</a>.
 
+ <li><p>Let |raceReesponse| be the result of [=lookup-race-response=].
+ <li><p>If |raceReesponse| is <var>response</var>, return |raceReesponse|.
+
  <li>
   <p>If <var>response</var> is null, then set <var>response</var> to the result of running the steps
   corresponding to the first matching statement:
@@ -4525,22 +4524,6 @@ steps:
      <a for="fetch params">preloaded response candidate</a> is a <a for=/>response</a>.
 
      <li><p>Return <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a>.
-    </ol>
-
-   <dt><var>request</var>'s <a for=request>service-workers race token</a> is not null
-   <dd>
-    <ol>
-     <li><p>Let <var>raceReesponse</var> to the result of [=lookup-race-response=] given <var>request</var>'s <a for=request>service-workers race token</a>, <var>request</var>'s <a for=request>reserved client</a>, <var>request</var>'s <a for=request>URL</a>.
-     <li><p>If <var>raceReesponse</var> is non-null, then:
-      <ol>
-       <li><p>Wait until <var>raceReesponse</var> settles.
-       <li><p>If <var>raceReesponse</var> resolves with <var>response</var>, then:
-        <ol>
-         <li><p><a for=/>Assert</a>: <var>response</var> is a <a for=/>response</a>.
-         <li><p>Return <var>response</var>.
-        </ol>
-       <li><p>If <var>raceReesponse</var> rejects, return a <a>network error</a>.
-      </ol>
     </ol>
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is

--- a/fetch.bs
+++ b/fetch.bs
@@ -1724,6 +1724,10 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
  </dl>
 </div>
 
+<p>A <a for=/>request</a> has an associated <dfn for=request export>service-workers race token</dfn> (a string). Unless stated otherwise it is null.
+
+<p class=note>This is only set by <a for=/>handle fetch</a> in service workers.
+
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
@@ -4521,6 +4525,22 @@ steps:
      <a for="fetch params">preloaded response candidate</a> is a <a for=/>response</a>.
 
      <li><p>Return <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a>.
+    </ol>
+
+   <dt><var>request</var>'s <a for=request>service-workers race token</a> is not null
+   <dd>
+    <ol>
+     <li><p>Let <var>raceReesponse</var> to the result of [=lookup-race-response=] given <var>request</var>'s <a for=request>service-workers race token</a>, <var>request</var>'s <a for=request>reserved client</a>, <var>request</var>'s <a for=request>URL</a>.
+     <li><p>If <var>raceReesponse</var> is non-null, then:
+      <ol>
+       <li><p>Wait until <var>raceReesponse</var> settles.
+       <li><p>If <var>raceReesponse</var> resolves with <var>response</var>, then:
+        <ol>
+         <li><p><a for=/>Assert</a>: <var>response</var> is a <a for=/>response</a>.
+         <li><p>Return <var>response</var>.
+        </ol>
+       <li><p>If <var>raceReesponse</var> rejects, return a <a>network error</a>.
+      </ol>
     </ol>
 
    <dt><var>request</var>'s <a for=request>current URL</a>'s <a for=url>origin</a> is


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

We propose [ServiceWorker static routing API](https://github.com/WICG/service-worker-static-routing-api), which allows developers to configure routing, and offload things ServiceWorkers do. The main spec update is in https://github.com/w3c/ServiceWorker/pull/1701, but some behavior involves the fetch spec change (specifically, "race-network-and-fetch-handler" option).

- [ ] At least two implementers are interested (and none opposed):
   * Chrome is proposing this change https://groups.google.com/a/chromium.org/g/blink-dev/c/-SEMMttEqz4
   * Mozilla https://github.com/mozilla/standards-positions/pull/894
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/tree/master/service-workers/service-worker/tentative/static-router
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: [crbug.com/40241479](https://crbug.com/40241479)
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
