### PR TITLE
Pass in Content-Encoding to resource-timing

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -369,6 +369,8 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
  <dd>A number.
  <dt><dfn export for="response body info">content type</dfn> (default the empty string)
  <dd>An <a for=/>ASCII string</a>.
+ <dt><dfn export for="response body info">content encoding</dfn> (default the empty string)
+ <dd>An <a for=/>ASCII string</a>.
 </dl>
 
 <div algorithm>
@@ -4816,7 +4818,17 @@ steps:
        <li><p>If <var>mimeType</var> is not failure, then set <var>bodyInfo</var>'s
        <a for="response body info">content type</a> to the result of
        <a>minimizing a supported MIME type</a> given <var>mimeType</var>.
-      </ol>
+
+       <li><p>Let <var>contentEncoding</var> be the result of
+       <a for="header list">extracting a MIME type</a> from <var>response</var>'s
+       <a for=response>header list</a>.
+
+       <li><p>Let <var>contentEncodings</var> be the result of <a>extracting header list values</a> given
+       `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
+
+       <li><p>If <var>contentEncoding</var> is not failure, then set <var>bodyInfo</var>'s
+       <a for="response body info">content encoding</a> to <var>contentEncoding</var>.
+     </ol>
 
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a> is non-null, then <a for=/>mark resource timing</a> given


### PR DESCRIPTION
These changes are to support addition of content type attribute to Perfomance resource timing. Further details are available at 
https://github.com/w3c/resource-timing/issues/381

- [ ] At least two implementers are interested (and none opposed):
   * Discussed and agreed at Feb 29, 2024 [W3C WebPerf call](https://docs.google.com/document/d/1qPPCtpg1MyVw3GGmd6VKZCdCyqoDub6Xgc8ANnq8SRI/edit#heading=h.wkdzwqaypyq6):
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/5369775
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/327941462
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1886107
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=271632
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed:
  -  https://github.com/mdn/content/issues/32823
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
