### PR TITLE
Editorial: Fix realmless ArrayBuffer creation

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7139,8 +7139,7 @@ steps:
     <p>Run <var>action</var>.
 
     <p>Whenever one or more bytes are available and <var>stream</var> is not
-    <a for=ReadableStream>errored</a>, <a for=ReadableStream>enqueue</a> a {{Uint8Array}} wrapping
-    an {{ArrayBuffer}} containing the available bytes into <var>stream</var>.
+    <a for=ReadableStream>errored</a>, <a for=ReadableStream>enqueue</a> the result of [=ArrayBufferView/create|creating=] a {{Uint8Array}} from the available bytes into <var>stream</var>.
 
     <p>When running <var>action</var> is done, <a for=ReadableStream>close</a> <var>stream</var>.
   </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7274,8 +7274,7 @@ algorithm, given an object that includes {{Body}} <var>object</var> and an algor
 <div algorithm>
 <p>The <dfn method for=Body><code>arrayBuffer()</code></dfn> method steps are to return the result
 of running <a for=Body>consume body</a> with <a>this</a> and the following step given a
-<a for=/>byte sequence</a> <var>bytes</var>: return a new {{ArrayBuffer}} whose contents are
-<var>bytes</var>.
+<a for=/>byte sequence</a> <var>bytes</var>: return the result of [=ArrayBuffer/creating=] an {{ArrayBuffer}} from <var>bytes</var> in <a>this</a>'s <a>relevant realm</a>.
 
 <p class="note">The above method can reject with a {{RangeError}}.
 </div>
@@ -7291,7 +7290,7 @@ and whose {{Blob/type}} attribute is the result of <a for=Body>get the MIME type
 
 <div algorithm>
 <p>The <dfn method for=Body><code>formData()</code></dfn> method steps are to return the result of
-running <a for=Body>consume body</a> with <a>this</a> and the following step given a
+running <a for=Body>consume body</a> with <a>this</a> and the following steps given a
 <a for=/>byte sequence</a> <var>bytes</var>:
 
 <ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -7139,7 +7139,9 @@ steps:
     <p>Run <var>action</var>.
 
     <p>Whenever one or more bytes are available and <var>stream</var> is not
-    <a for=ReadableStream>errored</a>, <a for=ReadableStream>enqueue</a> the result of [=ArrayBufferView/create|creating=] a {{Uint8Array}} from the available bytes into <var>stream</var>.
+    <a for=ReadableStream>errored</a>, <a for=ReadableStream>enqueue</a> the result of
+    [=ArrayBufferView/create|creating=] a {{Uint8Array}} from the available bytes into
+    <var>stream</var>.
 
     <p>When running <var>action</var> is done, <a for=ReadableStream>close</a> <var>stream</var>.
   </ol>
@@ -7273,7 +7275,8 @@ algorithm, given an object that includes {{Body}} <var>object</var> and an algor
 <div algorithm>
 <p>The <dfn method for=Body><code>arrayBuffer()</code></dfn> method steps are to return the result
 of running <a for=Body>consume body</a> with <a>this</a> and the following step given a
-<a for=/>byte sequence</a> <var>bytes</var>: return the result of [=ArrayBuffer/creating=] an {{ArrayBuffer}} from <var>bytes</var> in <a>this</a>'s <a>relevant realm</a>.
+<a for=/>byte sequence</a> <var>bytes</var>: return the result of [=ArrayBuffer/creating=] an
+{{ArrayBuffer}} from <var>bytes</var> in <a>this</a>'s <a>relevant realm</a>.
 
 <p class="note">The above method can reject with a {{RangeError}}.
 </div>


### PR DESCRIPTION
Fixes https://github.com/whatwg/fetch/issues/1675, maybe.

@annevk in that issue also points out that the [extract a body [...]](https://fetch.spec.whatwg.org/#concept-bodyinit-extract) algorithm also creates a Uint8Array in an ad-hoc way, which I've also tried to fix. Unfortunately I don't know what realm to use there - unlike the original issue, these aren't method steps. I am guessing that when the realm is unspecified (which it very often isn't - for example, earlier in the same algorithm there is "set stream to a new ReadableStream object" without a realm argument), it's implicitly the current realm? But maybe we need to thread a realm argument into this algorithm (and quite a few others), or possibly just explicitly pass "the current realm".

(If this right I'll follow up with a PR for https://github.com/whatwg/fetch/issues/1732.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1751.html" title="Last updated on May 7, 2024, 11:17 AM UTC (b9ef20a)">Preview</a> | <a href="https://whatpr.org/fetch/1751/14bad1d...b9ef20a.html" title="Last updated on May 7, 2024, 11:17 AM UTC (b9ef20a)">Diff</a>