### PR TITLE
Editorial: link "a new promise"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8386,7 +8386,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 method steps are:
 
 <ol>
- <li><p>Let <var>p</var> be a new promise.
+ <li><p>Let <var>p</var> be [=a new promise=].
 
  <li><p>Let <var>requestObject</var> be the result of invoking the initial value of {{Request}} as
  constructor with <var>input</var> and <var>init</var> as arguments. If this throws an exception,


### PR DESCRIPTION
The other uses of this phrase in this document are links, just not the one right at the start of the definition of `fetch`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1752.html" title="Last updated on May 4, 2024, 5:15 AM UTC (1836662)">Preview</a> | <a href="https://whatpr.org/fetch/1752/14bad1d...1836662.html" title="Last updated on May 4, 2024, 5:15 AM UTC (1836662)">Diff</a>