### PR TITLE
Add bytes() method to Body mixin

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7162,6 +7162,7 @@ interface mixin Body {
   readonly attribute boolean bodyUsed;
   [NewObject] Promise&lt;ArrayBuffer> arrayBuffer();
   [NewObject] Promise&lt;Blob> blob();
+  [NewObject] Promise&lt;Uint8Array> bytes();
   [NewObject] Promise&lt;FormData> formData();
   [NewObject] Promise&lt;any> json();
   [NewObject] Promise&lt;USVString> text();
@@ -7194,6 +7195,9 @@ due course.
 
  <dt><code><var>requestOrResponse</var> . <a method for=Body>blob</a>()</code>
  <dd><p>Returns a promise fulfilled with <var>requestOrResponse</var>'s body as {{Blob}}.
+
+ <dt><code><var>requestOrResponse</var> . <a method for=Body>bytes</a>()</code>
+ <dd><p>Returns a promise fulfilled with <var>requestOrResponse</var>'s body as {{Uint8Array}}.
 
  <dt><code><var>requestOrResponse</var> . <a method for=Body>formData</a>()</code>
  <dd><p>Returns a promise fulfilled with <var>requestOrResponse</var>'s body as {{FormData}}.
@@ -7288,6 +7292,15 @@ of running <a for=Body>consume body</a> with <a>this</a> and the following step 
 and whose {{Blob/type}} attribute is the result of <a for=Body>get the MIME type</a> with
 <a>this</a>.
 <!-- This is wrong. It should really set an underlying concept to this. -->
+</div>
+
+<div algorithm>
+<p>The <dfn method for=Body><code>bytes()</code></dfn> method steps are to return the result
+of running <a for=Body>consume body</a> with <a>this</a> and the following step given a
+<a for=/>byte sequence</a> <var>bytes</var>: return the result of [=ArrayBufferView/create|creating=] a
+{{Uint8Array}} from <var>bytes</var> in <a>this</a>'s <a>relevant realm</a>.
+
+<p class="note">The above method can reject with a {{RangeError}}.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Adds a `bytes()` method to get a `Uint8Array` to `Body`, instead of requiring users to get an `ArrayBuffer` and then wrap it.

Fixes https://github.com/whatwg/fetch/issues/1732.

- [x] At least two implementers are interested (and none opposed):
   * Chromium: https://github.com/whatwg/fetch/issues/1732#issuecomment-2066280001
   * Gecko: https://github.com/whatwg/fetch/issues/1732#issuecomment-2036463542
   * WebKit: https://github.com/whatwg/fetch/issues/1732#issuecomment-2036440127
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/46198
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/340206277
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1896475
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=274102
   * Deno (not for CORS changes): https://github.com/denoland/deno/issues/23790
   * Node (undici): https://github.com/nodejs/undici/issues/3256
   * Bun: https://github.com/oven-sh/bun/issues/11049
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/545
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1753.html" title="Last updated on May 13, 2024, 10:34 PM UTC (9ae058c)">Preview</a> | <a href="https://whatpr.org/fetch/1753/5d9d67b...9ae058c.html" title="Last updated on May 13, 2024, 10:34 PM UTC (9ae058c)">Diff</a>