### PR TITLE
Define opaque-response blocking (updated)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3333,8 +3333,7 @@ and a <a for=/>response</a> <var>response</var>, is to run these steps:
    <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is an
    <a>opaque-response-blocklisted MIME type</a>, then return false.
 
-   <li><p>If <var>nosniff</var> is true and <var>mimeType</var> is an
-   <a>opaque-response-blocklisted MIME type</a> or its <a for="MIME type">essence</a> is
+   <li><p>If <var>nosniff</var> is true and <var>mimeType</var>'s <a for="MIME type">essence</a> is
    "<code>text/plain</code>", then return false.
   </ol>
 
@@ -3466,6 +3465,7 @@ run these steps:</p>
 
 <hr>
 
+<div algorithm>
 <p>To <dfn>obtain a copy of the first 1024 bytes of response</dfn>, given a <a for=/>response</a>
 <var>response</var>, run these  steps:
 
@@ -3527,9 +3527,11 @@ run these steps:</p>
 
  <li>Return <var>first1024Bytes</var>.
 </ol>
+</div>
 
 <hr>
 
+<div algorithm>
 <p>To <dfn>determine if response is JavaScript and not JSON</dfn> given a <a for=/>response</a>
 <var>response</var>, run these steps:</p>
 
@@ -3585,6 +3587,7 @@ run these steps:</p>
 
  <li><p>Return false.
 </ol>
+</div>
 
 
 <h4 id=orb-mime-type-sets>New MIME type sets</h4>
@@ -3603,12 +3606,14 @@ run these steps:</p>
 whose <a for="MIME type">essence</a> is one of:
 
 <ul class=brief>
+ <li>"<code>application/dash+xml</code>"
  <li>"<code>application/gzip</code>"
  <li>"<code>application/msexcel</code>"
  <li>"<code>application/mspowerpoint</code>"
  <li>"<code>application/msword</code>"
  <li>"<code>application/msword-template</code>"
  <li>"<code>application/pdf</code>"
+ <li>"<code>application/vnd.apple.mpegurl</code>"
  <li>"<code>application/vnd.ces-quickpoint</code>"
  <li>"<code>application/vnd.ces-quicksheet</code>"
  <li>"<code>application/vnd.ces-quickword</code>"
@@ -3634,10 +3639,16 @@ whose <a for="MIME type">essence</a> is one of:
  <li>"<code>application/x-protobuf</code>"
  <li>"<code>application/x-protobuffer</code>"
  <li>"<code>application/zip</code>"
+ <li>"<code>audio/aac</code>"
+ <li>"<code>audio/aacp</code>"
+ <li>"<code>audio/mpegurl</code>"
+ <li>"<code>audio/mpeg</code>"
  <li>"<code>multipart/byteranges</code>"
  <li>"<code>multipart/signed</code>"
+ <li>"<code>multipart/x-mixed-replace</code>"
  <li>"<code>text/event-stream</code>"
  <li>"<code>text/csv</code>"
+ <li>"<code>text/vtt</code>"
 </ul>
 
 
@@ -5643,9 +5654,15 @@ these steps:
    <a>HTTP-network-or-cache fetch</a> given <var>fetchParams</var>.
 
    <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
-   <var>response</var>'s <a for=response>status</a> is not a <a>redirect status</a>, and the
-   <a>opaque-response-safelist check</a> given <var>request</var> and <var>response</var> returns
-   false, then return a <a>network error</a>.
+   <var>response</var>'s <a for=response>status</a> is not a <a>redirect status</a>, then
+
+   <ol>
+    <li><p>If <var>request</var>'s <a for=request>initiator type</a> is "<code>fetch</code>",
+    then set <var>internalResponse</var>'s <a for=response >body</a> to null.
+
+    <li><p>Otherwise, if <a>opaque-response-safelist check</a> given <var>request</var> and <var>response</var> returns
+    false, then return a <a>network error</a>.
+   </ol>
 
    <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and
    the <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return

--- a/fetch.bs
+++ b/fetch.bs
@@ -3305,7 +3305,7 @@ through TLS using ALPN. The protocol cannot be spoofed through HTTP requests in 
  set of bytes, and ultimately falls back to a full parse due to unfortunate (lack of) design
  decisions in the early days of the web platform. As a result there are still quite a few responses
  whose secrets can end up being revealed to attackers. Web developers are strongly encouraged to use
- the `<code http-header>Cross-Origin-Resource-Policy</code>` response header to defend them.
+ the `<code dfn-type=http-header>Cross-Origin-Resource-Policy</code>` response header to defend them.
 </div>
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -52,7 +52,9 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
 urlPrefix:https://tc39.es/ecma262/#;type:dfn;spec:ecma-262
     url:realm;text:realm
     url:sec-list-and-record-specification-type;text:Record
-    url:current-realm;text:current realm
+    url:sec-parsetext;text:ParseText
+    url:prod-Script;text:Script
+    url:script-record;text:Script Record
 </pre>
 
 <pre class=biblio>
@@ -2161,6 +2163,17 @@ Unless stated otherwise, it is false.
 
 <p class=note>This flag is for exclusive use by HTML's render-blocking mechanism. [[!HTML]]
 
+<p class=XXX>A <a for=/>request</a> has an associated
+<dfn export for=request>no-cors media request state</dfn> ...
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
+<p>A <a for=/>request</a> has an associated
+<dfn for=request>no-cors JavaScript fallback encoding</dfn> (an <a for=/>encoding</a>). Unless
+stated otherwise, it is <a for=/>UTF-8</a>.
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -3273,6 +3286,285 @@ through TLS using ALPN. The protocol cannot be spoofed through HTTP requests in 
  <li><p>Return <b>allowed</b>.
 </ol>
 </div>
+
+
+<h3 id=orb>Opaque-response blocking</h3>
+
+<div class=note>
+ <p>Opaque-response blocking, also known as <abbr>ORB</abbr>, is a network filter that blocks access
+ to <a>opaque filtered responses</a>. These responses would likely would not have been useful to the
+ fetching party. Blocking them reduces information leakage to potential attackers.
+
+ <p>Essentially, CSS, JavaScript, images, and media (audio and video) can be requested across
+ origins without the <a>CORS protocol</a>. And unfortunately except for CSS there is no MIME type
+ enforcement. This algorithm aims to block as many responses as possible that are not one of these
+ types (or are newer variants of those types) to avoid leaking their contents through side channels.
+
+ <p>The network filter combines pro-active blocking based on response headers, sniffing a limited
+ set of bytes, and ultimately falls back to a full parse due to unfortunate (lack of) design
+ decisions in the early days of the web platform. As a result there are still quite a few responses
+ whose secrets can end up being revealed to attackers. Web developers are strongly encouraged to use
+ the `<code http-header>Cross-Origin-Resource-Policy</code>` response header to defend them.
+</div>
+
+
+<h4 id=orb-algorithm>The opaque-response-safelist check</h4>
+
+<p>The <dfn>opaque-response-safelist check</dfn>, given a <a for=/>request</a> <var>request</var>
+and a <a for=/>response</a> <var>response</var>, is to run these steps:
+
+<ol>
+ <li><p>Let <var>mimeType</var> be the result of <a>extracting a MIME type</a> from
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>Let <var>nosniff</var> be the result of <a>determining nosniff</a> given
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li>
+  <p>If <var>mimeType</var> is not failure, then:
+
+  <ol>
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-safelisted MIME type</a>, then return
+   true.
+
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-blocklisted-never-sniffed MIME type</a>,
+   then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is an
+   <a>opaque-response-blocklisted MIME type</a>, then return false.
+
+   <li><p>If <var>nosniff</var> is true and <var>mimeType</var> is an
+   <a>opaque-response-blocklisted MIME type</a> or its <a for="MIME type">essence</a> is
+   "<code>text/plain</code>", then return false.
+  </ol>
+
+ <li><p>If <var>request</var>'s <a for=request>no-cors media request state</a> is
+ "<code>subsequent</code>", then return true.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and
+ <a>validate a partial response</a> given 0 and <var>response</var> returns invalid, then return
+ false.
+ <!-- TODO Integrate https://wicg.github.io/background-fetch/#validate-a-partial-response into Fetch -->
+
+ <li><p>Let <var>bytes</var> be the result of running
+ <a>obtain a copy of the first 1024 bytes of response</a> given <var>response</var>.
+
+ <li><p>If <var>bytes</var> is failure, then return false.
+
+ <li>
+  <p>If the <a>audio or video type pattern matching algorithm</a> given <var>bytes</var> does not
+  return undefined, then:
+
+  <ol>
+   <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+   "<code>initial</code>", then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is not 200 or 206, then return false.
+
+   <li><p>Return true.
+  </ol>
+
+ <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+ "<code>N/A</code>", then return false.
+
+ <li><p>If the <a>image type pattern matching algorithm</a> given <var>bytes</var> does not return
+ undefined, then return true.
+
+ <li>
+  <p>If <var>nosniff</var> is true, then return false.
+
+  <p class=note>This check is made late as unfortunately images and media are always sniffed.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is not an <a>ok status</a>, then return
+ false.
+
+ <li>
+  <p>If <var>mimeType</var> is failure, then return true.
+
+  <p class=note>This could be improved at somewhat significant cost. See
+  <a href=https://github.com/annevk/orb/issues/28>annevk/orb #28</a>.
+
+ <li><p>If <var>mimeType</var>'s <a for="MIME type">essence</a> <a for=string>starts with</a>
+ "<code>audio/</code>", "<code>image/</code>", or "<code>video/</code>", then return false.
+
+ <li><p>Return <a>determine if response is JavaScript and not JSON</a> given <var>response</var>.
+</ol>
+
+<hr>
+
+<p>To <dfn>obtain a copy of the first 1024 bytes of response</dfn>, given a <a for=/>response</a>
+<var>response</var>, run these  steps:
+
+<ol>
+ <li><p>Let <var>first1024Bytes</var> be null.
+
+ <li>
+  <p><a for=/>In parallel</a>:
+
+  <ol>
+   <li><p>Let <var>bytes</var> be the empty <a for=/>byte sequence</a>.
+
+   <li><p>Let <var>transformStream</var> be a new {{TransformStream}}.
+
+   <li>
+    <p>Let <var>transformAlgorithm</var> given a <var>chunk</var> be these steps:
+
+    <ol>
+     <li><p><a for=ReadableStream>Enqueue</a> <var>chunk</var> in <var>transformStream</var>.
+
+     <li>
+      <p>If <var>first1024Bytes</var> is null, then:
+
+      <ol>
+       <li><p>Let <var>chunkBytes</var> be
+       <a lt="get a copy of the bytes held by the buffer source">a copy of the bytes held by</a>
+       <var>chunk</var>.
+
+       <li><p>Append <var>chunkBytes</var> to <var>bytes</var>.
+
+       <li>
+        <p>If <var>bytes</var>'s <a for="byte sequencue">length</a> is greater than 1024, then:
+
+        <ol>
+         <li><p>Truncate <var>bytes</var> from the end so that it only contains 1024 bytes.
+
+         <li><p>Set <var>first1024Bytes</var> to <var>bytes</var>.
+        </ol>
+      </ol>
+    </ol>
+
+   <li><p>Let <var>flushAlgorithm</var> be this step: if <var>first1024Bytes</var> is null, then set
+   <var>first1024Bytes</var> to <var>bytes</var>.
+
+   <li><p><a for=TransformStream>Set up</a> <var>transformStream</var> with
+   <a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to
+   <var>transformAlgorithm</var> and <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set
+   to <var>flushAlgorithm</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the result
+   of <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+   <a for=TransformStream>piped through</a> <var>transformStream</var>.
+  </ol>
+
+ <li><p>Wait until <var>first1024Bytes</var> is non-null or <var>response</var>'s
+ <a for=response>body</a>'s <a for=body>stream</a> is <a for=ReadableStream>errored</a>.
+
+ <li><p>If <var>first1024Bytes</var> is null, then return failure.
+
+ <li>Return <var>first1024Bytes</var>.
+</ol>
+
+<hr>
+
+<p>To <dfn>determine if response is JavaScript and not JSON</dfn> given a <a for=/>response</a>
+<var>response</var>, run these steps:</p>
+
+<ol>
+ <li><p>Let <var>responseBodyBytes</var> be null.
+
+ <li>
+  <p>Let <var>processBody</var> given a <a for=/>byte sequence</a> <var>bytes</var> be these steps:
+
+  <ol>
+   <li><p>Set <var>responseBodyBytes</var> to <var>bytes</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the <a for="body with type">body</a>
+   of the result of <a for=BodyInit>safely extracting</a> <var>bytes</var>.
+  </ol>
+
+ <li><p>Let <var>processBodyError</var> be this step: set <var>responseBodyBytes</var> to failure.
+
+ <li><p><a>Fully read</a> <var>response</var>'s <a for=response>body</a> given <a>processBody</a>
+ and <var>processBodyError</var>.
+
+ <li><p>Wait for <var>responseBodyBytes</var> to be non-null.
+
+ <li><p>If <var>responseBodyBytes</var> is failure, then return false.
+
+ <li><p><a for=/>Assert</a>: <var>responseBodyBytes</var> is a <a for=/>byte sequence</a>.
+
+ <li>
+  <p>If <a>parse JSON bytes to a JavaScript value</a> given <var>responseBodyBytes</var> does not
+  throw, then return false. If it throws, catch the exception and ignore it.
+
+  <p class=note>If there is an exception, <var>response</var> is not JSON. If there is not, it is.
+
+ <li><p>Let <var>potentialMIMETypeForEncoding</var> be the result of <a>extracting a MIME type</a>
+ given <var>response</var>'s <a for=response>header list</a>.
+
+ <li>
+  <p>Let <var>encoding</var> be the result of <a>legacy extracting an encoding</a> given
+  <var>potentialMIMETypeForEncoding</var> and <var>request</var>'s
+  <a for=request>no-cors JavaScript fallback encoding</a>.
+
+  <p class=note>Equivalently to <a>fetch a classic script</a>, this ignores the
+  <a for="MIME type" lt=essence>MIME type essence</a>.
+
+ <li><p>Let <var>sourceText</var> be the result of <a for=/>decoding</a>
+ <var>responseBodyBytes</var> given <var>encoding</var>.
+
+ <li><p>If <a>ParseText</a>(<var>sourceText</var>, <a>Script</a>) returns a <a>Script Record</a>,
+ then return true.
+ <!-- Ideally HTML owns this so ECMAScript changes don't end up impacting Fetch. We could
+      potentially make this use "create a classic script" instead with some mock data. Maybe that is
+      better? -->
+
+ <li><p>Return false.
+</ol>
+
+
+<h4 id=orb-mime-type-sets>New MIME type sets</h4>
+
+<p class=note>The definitions in this section are solely for the purpose of abstracting parts of the
+<a>opaque-response-safelist check</a>. They are not suited for usage elsewhere.
+
+<p>An <dfn>opaque-response-safelisted MIME type</dfn> is a <a>JavaScript MIME type</a> or a
+<a for=/>MIME type</a> whose <a for="MIME type">essence</a> is "<code>text/css</code>" or
+"<code>image/svg+xml</code>".
+
+<p>An <dfn>opaque-response-blocklisted MIME type</dfn> is an <a>HTML MIME type</a>,
+<a>JSON MIME type</a>, or <a>XML MIME type</a>.
+
+<p>An <dfn>opaque-response-blocklisted-never-sniffed MIME type</dfn> is a <a for=/>MIME type</a>
+whose <a for="MIME type">essence</a> is one of:
+
+<ul class=brief>
+ <li>"<code>application/gzip</code>"
+ <li>"<code>application/msexcel</code>"
+ <li>"<code>application/mspowerpoint</code>"
+ <li>"<code>application/msword</code>"
+ <li>"<code>application/msword-template</code>"
+ <li>"<code>application/pdf</code>"
+ <li>"<code>application/vnd.ces-quickpoint</code>"
+ <li>"<code>application/vnd.ces-quicksheet</code>"
+ <li>"<code>application/vnd.ces-quickword</code>"
+ <li>"<code>application/vnd.ms-excel</code>"
+ <li>"<code>application/vnd.ms-excel.sheet.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-powerpoint</code>"
+ <li>"<code>application/vnd.ms-powerpoint.presentation.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-word</code>"
+ <li>"<code>application/vnd.ms-word.document.12</code>"
+ <li>"<code>application/vnd.ms-word.document.macroenabled.12</code>"
+ <li>"<code>application/vnd.msword</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.presentation</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.document</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.template</code>"
+ <li>"<code>application/vnd.presentation-openxml</code>"
+ <li>"<code>application/vnd.presentation-openxmlm</code>"
+ <li>"<code>application/vnd.spreadsheet-openxml</code>"
+ <li>"<code>application/vnd.wordprocessing-openxml</code>"
+ <li>"<code>application/x-gzip</code>"
+ <li>"<code>application/x-protobuf</code>"
+ <li>"<code>application/x-protobuffer</code>"
+ <li>"<code>application/zip</code>"
+ <li>"<code>multipart/byteranges</code>"
+ <li>"<code>multipart/signed</code>"
+ <li>"<code>text/event-stream</code>"
+ <li>"<code>text/csv</code>"
+</ul>
 
 
 
@@ -5237,18 +5529,22 @@ these steps:
    <li><p>Set <var>response</var> and <var>internalResponse</var> to the result of running
    <a>HTTP-network-or-cache fetch</a> given <var>fetchParams</var>.
 
-   <li>
-    <p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and a
-    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return a
-    <a>network error</a>.
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+   <var>response</var>'s <a for=response>status</a> is not a <a>redirect status</a>, and the
+   <a>opaque-response-safelist check</a> given <var>request</var> and <var>response</var> returns
+   false, then return a <a>network error</a>.
 
-    <p class=note>As the <a>CORS check</a> is not to be applied to <a for=/>responses</a> whose
-    <a for=response>status</a> is 304 or 407, or <a for=/>responses</a> from a service worker for
-    that matter, it is applied here.
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and
+   the <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return
+   a <a>network error</a>.
 
    <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
    then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
   </ol>
+
+  <p class=note>As the <a>opaque-response-safelist check</a>, <a>CORS check</a>, and
+  <a>TAO check</a> are not to be applied to <a for=/>responses</a> whose <a for=response>status</a>
+  is 304 or 407, or to <a for=/>responses</a> from a service worker, they are applied here.
 
  <li>
   <p>If either <var>request</var>'s <a for=request>response tainting</a> or <var>response</var>'s
@@ -9152,6 +9448,7 @@ Mohamed Zergaoui,
 Mohammed Zubair Ahmed<!-- M-ZubairAhmed; GitHub -->,
 Moritz Kneilmann,
 Ms2ger,
+Nathan Froyd,
 Nico Schlömer,
 Nicolás Peña Moreno,
 Nidhi Jaju,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3344,7 +3344,6 @@ and a <a for=/>response</a> <var>response</var>, is to run these steps:
  <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and
  <a>validate a partial response</a> given 0 and <var>response</var> returns invalid, then return
  false.
- <!-- TODO Integrate https://wicg.github.io/background-fetch/#validate-a-partial-response into Fetch -->
 
  <li><p>Let <var>bytes</var> be the result of running
  <a>obtain a copy of the first 1024 bytes of response</a> given <var>response</var>.
@@ -3389,6 +3388,81 @@ and a <a for=/>response</a> <var>response</var>, is to run these steps:
 
  <li><p>Return <a>determine if response is JavaScript and not JSON</a> given <var>response</var>.
 </ol>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>extract content-range values</dfn>, given a <a for=/>response</a> <var>response</var>
+run these steps:<p>
+
+<ol>
+ <li><p>If <var>response</var>’s <a for=response>header list</a> <a for="header list">does not contain</a> `<code>Content-Range</code>`, then return failure.
+
+ <li><p>Let <var>contentRangeValue</var> be the <a lt=value for=header>value</a> of the first <a for=/>header</a> whose <a for=header>name</a> is a
+ <a>byte-case-insensitive</a> match for `<code>Content-Range</code>` in <var>response</var>’s <a for=response>header list</a>.
+
+ <li><p>If parsing <var>contentRangeValue</var> per <a>single byte content-range</a> fails, then return failure.
+
+ <li><p>Let <var>firstBytePos</var> be the portion of <var>contentRangeValue</var> named
+ first-byte-pos when parsed as <a>single byte content-range</a>, parsed as an integer.
+
+ <li><p>Let <var>lastBytePos</var> be the portion of <var>contentRangeValue</var> named
+ last-byte-pos when parsed as <a>single byte content-range</a>, parsed as an integer.
+
+ <li><p>Let <var>completeLength</var> be the portion of <var>contentRangeValue</var> named
+ complete-length when parsed as <a>single byte content-range</a>.
+
+ <li><p>If <var>completeLength</var> is "<code>*</code>", then set <var>completeLength</var> to null, otherwise
+ set <var>completeLength</var> to <var>completeLength</var> parsed as an integer.
+
+ <li><p>Return <var>firstBytePos</var>, <var>lastBytePos</var>, and <var>completeLength</var>.
+</ol>
+
+<p class=XXX>Parsing as an integer <a href="https://github.com/whatwg/infra/issues/189">infra/189</a>
+</div>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>validate a partial response</dfn>, given an integer <var>expectedRangeStart</var> , a
+<a for=/>response</a> <var>partialResponse</var>, and an optional <a for=/>response</a> <var>previousResponse</var> (default null),
+run these steps:</p>
+
+<ol>
+ <li><p>Assert: <var>partialResponse</var>'s <a for=response>status</a> is `206`.
+
+ <li><p>Let <var>responseFirstBytePos</var>, <var ignore>responseLastBytePos</var>, and <var>responseCompleteLength</var> be the
+ result of <a>extracting content-range values</a> from <var>partialResponse</var>. If this fails, then return invalid.
+
+ <li><p>If <var>responseFirstBytePos</var> does not equal <var>expectedRangeStart</var>, then return invalid.
+
+ <li><p>If <var>previousResponse</var> is not null, then:
+
+  <ol>
+   <li><p>For <var>headerName</var> of « `<code>ETag</code>`, `<code>Last-Modified</code>` »:
+
+    <ol>
+     <li>If <var>previousResponse</var>'s <a for=response>header list</a> <a for="header list">contains</a> <var>headerName</var>
+     and the <a for="header list">combined</a> value of <var>headerName</var>
+     in <var>previousResponse</var>'s <a for=response>header list</a> does not equal the
+     <a for="header list">combined</a> value of <var>headerName</var> in <var>partialResponse</var>'s
+     <a for=response>header list</a>, then return invalid.
+    </ol>
+
+   <li><p>If <var>previousResponse</var>'s <a for=response>status</a> is 206, then:
+
+    <ol>
+     <li><p>Let <var ignore>previousResponseFirstBytePos</var>, <var ignore>previousResponseLastBytePos</var>,
+     and <var>previousResponseCompleteLength</var> be the result of <a>extracting content-range values</a>
+     from <var>previousResponse</var>. If this fails, then return invalid.
+
+     <li><p>If <var>previousResponseCompleteLength</var> is not null, and
+     <var>responseCompleteLength</var> does not equal <var>previousResponseCompleteLength</var>, then return invalid.
+    </ol>
+  </ol>
+ <li>Return valid.
+</ol>
+</div>
 
 <hr>
 
@@ -3813,6 +3887,45 @@ response <a for=/>headers</a>, the <a for=header>value</a> `<code>*</code>` coun
 <a for=/>requests</a> without <a for=/>credentials</a>. For such <a for=/>requests</a> there is no
 way to solely match a <a for=/>header name</a> or <a for=/>method</a> that is `<code>*</code>`.
 
+<p><a>ABNF</a> for a <dfn export> single byte content-range</dfn>:
+
+<pre><code class=lang-abnf>
+"bytes=" first-byte-pos "-" last-byte-pos "/" complete-length
+first-byte-pos = 1*DIGIT
+last-byte-pos  = 1*DIGIT
+complete-length = ( 1*DIGIT / "*" )
+</code></pre>
+
+<p class=note>This is a subset of what <a href="https://tools.ietf.org/html/rfc7233#section-3.1">RFC 7233</a> allows.
+
+<div class="note">
+
+  The above as a railroad diagram:
+
+  <pre class="railroad">
+  T: "bytes="
+  Stack:
+    Sequence:
+      Comment: first-byte-pos
+      OneOrMore:
+        N: digit
+      Comment: /first-byte-pos
+      N: "/"
+    Sequence:
+      Comment: last-byte-pos
+      OneOrMore:
+        N: digit
+      Comment: /last-byte-pos
+      N: "/"
+    Sequence:
+      Comment: complete-length
+      Choice:
+        N: "*"
+        OneOrMore:
+          N: digit
+      Comment: /complete-length
+  </pre>
+</div>
 
 <h4 id=cors-protocol-and-credentials>CORS protocol and credentials</h4>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -52,6 +52,7 @@ urlPrefix:https://w3c.github.io/hr-time/#;spec:hr-time
 urlPrefix:https://tc39.es/ecma262/#;type:dfn;spec:ecma-262
     url:realm;text:realm
     url:sec-list-and-record-specification-type;text:Record
+    url:current-realm;text:current realm
     url:sec-parsetext;text:ParseText
     url:prod-Script;text:Script
     url:script-record;text:Script Record
@@ -3392,7 +3393,7 @@ and a <a for=/>response</a> <var>response</var>, is to run these steps:
 
 <div algorithm>
 <p>To <dfn>extract content-range values</dfn>, given a <a for=/>response</a> <var>response</var>
-run these steps:<p>
+run these steps:</p>
 
 <ol>
  <li><p>If <var>response</var>’s <a for=response>header list</a> <a for="header list">does not contain</a> `<code>Content-Range</code>`, then return failure.
@@ -3497,7 +3498,7 @@ run these steps:</p>
        <li><p>Append <var>chunkBytes</var> to <var>bytes</var>.
 
        <li>
-        <p>If <var>bytes</var>'s <a for="byte sequencue">length</a> is greater than 1024, then:
+        <p>If <var>bytes</var>'s <a for="byte sequence">length</a> is greater than 1024, then:
 
         <ol>
          <li><p>Truncate <var>bytes</var> from the end so that it only contains 1024 bytes.
@@ -3517,7 +3518,7 @@ run these steps:</p>
 
    <li><p>Set <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the result
    of <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
-   <a for=TransformStream>piped through</a> <var>transformStream</var>.
+   <a for=ReadableStream>piped through</a> <var>transformStream</var>.
   </ol>
 
  <li><p>Wait until <var>first1024Bytes</var> is non-null or <var>response</var>'s
@@ -3532,8 +3533,8 @@ run these steps:</p>
 <hr>
 
 <div algorithm>
-<p>To <dfn>determine if response is JavaScript and not JSON</dfn> given a <a for=/>response</a>
-<var>response</var>, run these steps:</p>
+<p>To <dfn>determine if response is JavaScript and not JSON</dfn>, given a <a for=/>request</a> <var>request</var>,
+a <a for=/>response</a> <var>response</var>, run these steps:</p>
 
 <ol>
  <li><p>Let <var>responseBodyBytes</var> be null.
@@ -3550,7 +3551,7 @@ run these steps:</p>
 
  <li><p>Let <var>processBodyError</var> be this step: set <var>responseBodyBytes</var> to failure.
 
- <li><p><a>Fully read</a> <var>response</var>'s <a for=response>body</a> given <a>processBody</a>
+ <li><p><a>Fully read</a> <var>response</var>'s <a for=response>body</a> given <var>processBody</var>
  and <var>processBodyError</var>.
 
  <li><p>Wait for <var>responseBodyBytes</var> to be non-null.
@@ -3569,7 +3570,7 @@ run these steps:</p>
  given <var>response</var>'s <a for=response>header list</a>.
 
  <li>
-  <p>Let <var>encoding</var> be the result of <a>legacy extracting an encoding</a> given
+  <p>Let <var>encoding</var> be the result of <a>legacy extract an encoding</a> given
   <var>potentialMIMETypeForEncoding</var> and <var>request</var>'s
   <a for=request>no-cors JavaScript fallback encoding</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -53,6 +53,9 @@ urlPrefix:https://tc39.es/ecma262/#;type:dfn;spec:ecma-262
     url:realm;text:realm
     url:sec-list-and-record-specification-type;text:Record
     url:current-realm;text:current realm
+    url:sec-parsetext;text:ParseText
+    url:prod-Script;text:Script
+    url:script-record;text:Script Record
 </pre>
 
 <pre class=biblio>
@@ -2161,6 +2164,17 @@ Unless stated otherwise, it is false.
 
 <p class=note>This flag is for exclusive use by HTML's render-blocking mechanism. [[!HTML]]
 
+<p class=XXX>A <a for=/>request</a> has an associated
+<dfn export for=request>no-cors media request state</dfn> ...
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
+<p>A <a for=/>request</a> has an associated
+<dfn for=request>no-cors JavaScript fallback encoding</dfn> (an <a for=/>encoding</a>). Unless
+stated otherwise, it is <a for=/>UTF-8</a>.
+
+<p class=note>This is for exclusive use by the <a>opaque-response-safelist check</a>.
+
 <hr>
 
 <p>A <a for=/>request</a> has an associated
@@ -3275,6 +3289,370 @@ through TLS using ALPN. The protocol cannot be spoofed through HTTP requests in 
 </div>
 
 
+<h3 id=orb>Opaque-response blocking</h3>
+
+<div class=note>
+ <p>Opaque-response blocking, also known as <abbr>ORB</abbr>, is a network filter that blocks access
+ to <a>opaque filtered responses</a>. These responses would likely would not have been useful to the
+ fetching party. Blocking them reduces information leakage to potential attackers.
+
+ <p>Essentially, CSS, JavaScript, images, and media (audio and video) can be requested across
+ origins without the <a>CORS protocol</a>. And unfortunately except for CSS there is no MIME type
+ enforcement. This algorithm aims to block as many responses as possible that are not one of these
+ types (or are newer variants of those types) to avoid leaking their contents through side channels.
+
+ <p>The network filter combines pro-active blocking based on response headers, sniffing a limited
+ set of bytes, and ultimately falls back to a full parse due to unfortunate (lack of) design
+ decisions in the early days of the web platform. As a result there are still quite a few responses
+ whose secrets can end up being revealed to attackers. Web developers are strongly encouraged to use
+ the `<code dfn-type=http-header>Cross-Origin-Resource-Policy</code>` response header to defend them.
+</div>
+
+
+<h4 id=orb-algorithm>The opaque-response-safelist check</h4>
+
+<p>The <dfn>opaque-response-safelist check</dfn>, given a <a for=/>request</a> <var>request</var>
+and a <a for=/>response</a> <var>response</var>, is to run these steps:
+
+<ol>
+ <li><p>Let <var>mimeType</var> be the result of <a>extracting a MIME type</a> from
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>Let <var>nosniff</var> be the result of <a>determining nosniff</a> given
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li>
+  <p>If <var>mimeType</var> is not failure, then:
+
+  <ol>
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-safelisted MIME type</a>, then return
+   true.
+
+   <li><p>If <var>mimeType</var> is an <a>opaque-response-blocklisted-never-sniffed MIME type</a>,
+   then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and <var>mimeType</var> is an
+   <a>opaque-response-blocklisted MIME type</a>, then return false.
+
+   <li><p>If <var>nosniff</var> is true and <var>mimeType</var>'s <a for="MIME type">essence</a> is
+   "<code>text/plain</code>", then return false.
+  </ol>
+
+ <li><p>If <var>request</var>'s <a for=request>no-cors media request state</a> is
+ "<code>subsequent</code>", then return true.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is 206 and
+ <a>validate a partial response</a> given 0 and <var>response</var> returns invalid, then return
+ false.
+
+ <li><p>Let <var>bytes</var> be the result of running
+ <a>obtain a copy of the first 1024 bytes of response</a> given <var>response</var>.
+
+ <li><p>If <var>bytes</var> is failure, then return false.
+
+ <li>
+  <p>If the <a>audio or video type pattern matching algorithm</a> given <var>bytes</var> does not
+  return undefined, then:
+
+  <ol>
+   <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+   "<code>initial</code>", then return false.
+
+   <li><p>If <var>response</var>'s <a for=response>status</a> is not 200 or 206, then return false.
+
+   <li><p>Return true.
+  </ol>
+
+ <li><p>If <var>requests</var>'s <a for=request>no-cors media request state</a> is not
+ "<code>N/A</code>", then return false.
+
+ <li><p>If the <a>image type pattern matching algorithm</a> given <var>bytes</var> does not return
+ undefined, then return true.
+
+ <li>
+  <p>If <var>nosniff</var> is true, then return false.
+
+  <p class=note>This check is made late as unfortunately images and media are always sniffed.
+
+ <li><p>If <var>response</var>'s <a for=response>status</a> is not an <a>ok status</a>, then return
+ false.
+
+ <li>
+  <p>If <var>mimeType</var> is failure, then return true.
+
+  <p class=note>This could be improved at somewhat significant cost. See
+  <a href=https://github.com/annevk/orb/issues/28>annevk/orb #28</a>.
+
+ <li><p>If <var>mimeType</var>'s <a for="MIME type">essence</a> <a for=string>starts with</a>
+ "<code>audio/</code>", "<code>image/</code>", or "<code>video/</code>", then return false.
+
+ <li><p>Return <a>determine if response is JavaScript and not JSON</a> given <var>response</var>.
+</ol>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>extract content-range values</dfn>, given a <a for=/>response</a> <var>response</var>
+run these steps:</p>
+
+<ol>
+ <li><p>If <var>response</var>’s <a for=response>header list</a> <a for="header list">does not contain</a> `<code>Content-Range</code>`, then return failure.
+
+ <li><p>Let <var>contentRangeValue</var> be the <a lt=value for=header>value</a> of the first <a for=/>header</a> whose <a for=header>name</a> is a
+ <a>byte-case-insensitive</a> match for `<code>Content-Range</code>` in <var>response</var>’s <a for=response>header list</a>.
+
+ <li><p>If parsing <var>contentRangeValue</var> per <a>single byte content-range</a> fails, then return failure.
+
+ <li><p>Let <var>firstBytePos</var> be the portion of <var>contentRangeValue</var> named
+ first-byte-pos when parsed as <a>single byte content-range</a>, parsed as an integer.
+
+ <li><p>Let <var>lastBytePos</var> be the portion of <var>contentRangeValue</var> named
+ last-byte-pos when parsed as <a>single byte content-range</a>, parsed as an integer.
+
+ <li><p>Let <var>completeLength</var> be the portion of <var>contentRangeValue</var> named
+ complete-length when parsed as <a>single byte content-range</a>.
+
+ <li><p>If <var>completeLength</var> is "<code>*</code>", then set <var>completeLength</var> to null, otherwise
+ set <var>completeLength</var> to <var>completeLength</var> parsed as an integer.
+
+ <li><p>Return <var>firstBytePos</var>, <var>lastBytePos</var>, and <var>completeLength</var>.
+</ol>
+
+<p class=XXX>Parsing as an integer <a href="https://github.com/whatwg/infra/issues/189">infra/189</a>
+</div>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>validate a partial response</dfn>, given an integer <var>expectedRangeStart</var> , a
+<a for=/>response</a> <var>partialResponse</var>, and an optional <a for=/>response</a> <var>previousResponse</var> (default null),
+run these steps:</p>
+
+<ol>
+ <li><p>Assert: <var>partialResponse</var>'s <a for=response>status</a> is `206`.
+
+ <li><p>Let <var>responseFirstBytePos</var>, <var ignore>responseLastBytePos</var>, and <var>responseCompleteLength</var> be the
+ result of <a>extracting content-range values</a> from <var>partialResponse</var>. If this fails, then return invalid.
+
+ <li><p>If <var>responseFirstBytePos</var> does not equal <var>expectedRangeStart</var>, then return invalid.
+
+ <li><p>If <var>previousResponse</var> is not null, then:
+
+  <ol>
+   <li><p>For <var>headerName</var> of « `<code>ETag</code>`, `<code>Last-Modified</code>` »:
+
+    <ol>
+     <li>If <var>previousResponse</var>'s <a for=response>header list</a> <a for="header list">contains</a> <var>headerName</var>
+     and the <a for="header list">combined</a> value of <var>headerName</var>
+     in <var>previousResponse</var>'s <a for=response>header list</a> does not equal the
+     <a for="header list">combined</a> value of <var>headerName</var> in <var>partialResponse</var>'s
+     <a for=response>header list</a>, then return invalid.
+    </ol>
+
+   <li><p>If <var>previousResponse</var>'s <a for=response>status</a> is 206, then:
+
+    <ol>
+     <li><p>Let <var ignore>previousResponseFirstBytePos</var>, <var ignore>previousResponseLastBytePos</var>,
+     and <var>previousResponseCompleteLength</var> be the result of <a>extracting content-range values</a>
+     from <var>previousResponse</var>. If this fails, then return invalid.
+
+     <li><p>If <var>previousResponseCompleteLength</var> is not null, and
+     <var>responseCompleteLength</var> does not equal <var>previousResponseCompleteLength</var>, then return invalid.
+    </ol>
+  </ol>
+ <li>Return valid.
+</ol>
+</div>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>obtain a copy of the first 1024 bytes of response</dfn>, given a <a for=/>response</a>
+<var>response</var>, run these  steps:
+
+<ol>
+ <li><p>Let <var>first1024Bytes</var> be null.
+
+ <li>
+  <p><a for=/>In parallel</a>:
+
+  <ol>
+   <li><p>Let <var>bytes</var> be the empty <a for=/>byte sequence</a>.
+
+   <li><p>Let <var>transformStream</var> be a new {{TransformStream}}.
+
+   <li>
+    <p>Let <var>transformAlgorithm</var> given a <var>chunk</var> be these steps:
+
+    <ol>
+     <li><p><a for=ReadableStream>Enqueue</a> <var>chunk</var> in <var>transformStream</var>.
+
+     <li>
+      <p>If <var>first1024Bytes</var> is null, then:
+
+      <ol>
+       <li><p>Let <var>chunkBytes</var> be
+       <a lt="get a copy of the bytes held by the buffer source">a copy of the bytes held by</a>
+       <var>chunk</var>.
+
+       <li><p>Append <var>chunkBytes</var> to <var>bytes</var>.
+
+       <li>
+        <p>If <var>bytes</var>'s <a for="byte sequence">length</a> is greater than 1024, then:
+
+        <ol>
+         <li><p>Truncate <var>bytes</var> from the end so that it only contains 1024 bytes.
+
+         <li><p>Set <var>first1024Bytes</var> to <var>bytes</var>.
+        </ol>
+      </ol>
+    </ol>
+
+   <li><p>Let <var>flushAlgorithm</var> be this step: if <var>first1024Bytes</var> is null, then set
+   <var>first1024Bytes</var> to <var>bytes</var>.
+
+   <li><p><a for=TransformStream>Set up</a> <var>transformStream</var> with
+   <a for="TransformStream/set up"><i>transformAlgorithm</i></a> set to
+   <var>transformAlgorithm</var> and <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set
+   to <var>flushAlgorithm</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the result
+   of <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+   <a for=ReadableStream>piped through</a> <var>transformStream</var>.
+  </ol>
+
+ <li><p>Wait until <var>first1024Bytes</var> is non-null or <var>response</var>'s
+ <a for=response>body</a>'s <a for=body>stream</a> is <a for=ReadableStream>errored</a>.
+
+ <li><p>If <var>first1024Bytes</var> is null, then return failure.
+
+ <li>Return <var>first1024Bytes</var>.
+</ol>
+</div>
+
+<hr>
+
+<div algorithm>
+<p>To <dfn>determine if response is JavaScript and not JSON</dfn>, given a <a for=/>request</a> <var>request</var>,
+a <a for=/>response</a> <var>response</var>, run these steps:</p>
+
+<ol>
+ <li><p>Let <var>responseBodyBytes</var> be null.
+
+ <li>
+  <p>Let <var>processBody</var> given a <a for=/>byte sequence</a> <var>bytes</var> be these steps:
+
+  <ol>
+   <li><p>Set <var>responseBodyBytes</var> to <var>bytes</var>.
+
+   <li><p>Set <var>response</var>'s <a for=response>body</a> to the <a for="body with type">body</a>
+   of the result of <a for=BodyInit>safely extracting</a> <var>bytes</var>.
+  </ol>
+
+ <li><p>Let <var>processBodyError</var> be this step: set <var>responseBodyBytes</var> to failure.
+
+ <li><p><a>Fully read</a> <var>response</var>'s <a for=response>body</a> given <var>processBody</var>
+ and <var>processBodyError</var>.
+
+ <li><p>Wait for <var>responseBodyBytes</var> to be non-null.
+
+ <li><p>If <var>responseBodyBytes</var> is failure, then return false.
+
+ <li><p><a for=/>Assert</a>: <var>responseBodyBytes</var> is a <a for=/>byte sequence</a>.
+
+ <li>
+  <p>If <a>parse JSON bytes to a JavaScript value</a> given <var>responseBodyBytes</var> does not
+  throw, then return false. If it throws, catch the exception and ignore it.
+
+  <p class=note>If there is an exception, <var>response</var> is not JSON. If there is not, it is.
+
+ <li><p>Let <var>potentialMIMETypeForEncoding</var> be the result of <a>extracting a MIME type</a>
+ given <var>response</var>'s <a for=response>header list</a>.
+
+ <li>
+  <p>Let <var>encoding</var> be the result of <a>legacy extract an encoding</a> given
+  <var>potentialMIMETypeForEncoding</var> and <var>request</var>'s
+  <a for=request>no-cors JavaScript fallback encoding</a>.
+
+  <p class=note>Equivalently to <a>fetch a classic script</a>, this ignores the
+  <a for="MIME type" lt=essence>MIME type essence</a>.
+
+ <li><p>Let <var>sourceText</var> be the result of <a for=/>decoding</a>
+ <var>responseBodyBytes</var> given <var>encoding</var>.
+
+ <li><p>If <a>ParseText</a>(<var>sourceText</var>, <a>Script</a>) returns a <a>Script Record</a>,
+ then return true.
+ <!-- Ideally HTML owns this so ECMAScript changes don't end up impacting Fetch. We could
+      potentially make this use "create a classic script" instead with some mock data. Maybe that is
+      better? -->
+
+ <li><p>Return false.
+</ol>
+</div>
+
+
+<h4 id=orb-mime-type-sets>New MIME type sets</h4>
+
+<p class=note>The definitions in this section are solely for the purpose of abstracting parts of the
+<a>opaque-response-safelist check</a>. They are not suited for usage elsewhere.
+
+<p>An <dfn>opaque-response-safelisted MIME type</dfn> is a <a>JavaScript MIME type</a> or a
+<a for=/>MIME type</a> whose <a for="MIME type">essence</a> is "<code>text/css</code>" or
+"<code>image/svg+xml</code>".
+
+<p>An <dfn>opaque-response-blocklisted MIME type</dfn> is an <a>HTML MIME type</a>,
+<a>JSON MIME type</a>, or <a>XML MIME type</a>.
+
+<p>An <dfn>opaque-response-blocklisted-never-sniffed MIME type</dfn> is a <a for=/>MIME type</a>
+whose <a for="MIME type">essence</a> is one of:
+
+<ul class=brief>
+ <li>"<code>application/dash+xml</code>"
+ <li>"<code>application/gzip</code>"
+ <li>"<code>application/msexcel</code>"
+ <li>"<code>application/mspowerpoint</code>"
+ <li>"<code>application/msword</code>"
+ <li>"<code>application/msword-template</code>"
+ <li>"<code>application/pdf</code>"
+ <li>"<code>application/vnd.apple.mpegurl</code>"
+ <li>"<code>application/vnd.ces-quickpoint</code>"
+ <li>"<code>application/vnd.ces-quicksheet</code>"
+ <li>"<code>application/vnd.ces-quickword</code>"
+ <li>"<code>application/vnd.ms-excel</code>"
+ <li>"<code>application/vnd.ms-excel.sheet.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-powerpoint</code>"
+ <li>"<code>application/vnd.ms-powerpoint.presentation.macroenabled.12</code>"
+ <li>"<code>application/vnd.ms-word</code>"
+ <li>"<code>application/vnd.ms-word.document.12</code>"
+ <li>"<code>application/vnd.ms-word.document.macroenabled.12</code>"
+ <li>"<code>application/vnd.msword</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.presentation</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.presentationml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.spreadsheetml.template</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.document</code>"
+ <li>"<code>application/vnd.openxmlformats-officedocument.wordprocessingml.template</code>"
+ <li>"<code>application/vnd.presentation-openxml</code>"
+ <li>"<code>application/vnd.presentation-openxmlm</code>"
+ <li>"<code>application/vnd.spreadsheet-openxml</code>"
+ <li>"<code>application/vnd.wordprocessing-openxml</code>"
+ <li>"<code>application/x-gzip</code>"
+ <li>"<code>application/x-protobuf</code>"
+ <li>"<code>application/x-protobuffer</code>"
+ <li>"<code>application/zip</code>"
+ <li>"<code>audio/aac</code>"
+ <li>"<code>audio/aacp</code>"
+ <li>"<code>audio/mpegurl</code>"
+ <li>"<code>audio/mpeg</code>"
+ <li>"<code>multipart/byteranges</code>"
+ <li>"<code>multipart/signed</code>"
+ <li>"<code>multipart/x-mixed-replace</code>"
+ <li>"<code>text/event-stream</code>"
+ <li>"<code>text/csv</code>"
+ <li>"<code>text/vtt</code>"
+</ul>
+
+
 
 <h2 id=http-extensions>HTTP extensions</h2>
 
@@ -3521,6 +3899,45 @@ response <a for=/>headers</a>, the <a for=header>value</a> `<code>*</code>` coun
 <a for=/>requests</a> without <a for=/>credentials</a>. For such <a for=/>requests</a> there is no
 way to solely match a <a for=/>header name</a> or <a for=/>method</a> that is `<code>*</code>`.
 
+<p><a>ABNF</a> for a <dfn export> single byte content-range</dfn>:
+
+<pre><code class=lang-abnf>
+"bytes=" first-byte-pos "-" last-byte-pos "/" complete-length
+first-byte-pos = 1*DIGIT
+last-byte-pos  = 1*DIGIT
+complete-length = ( 1*DIGIT / "*" )
+</code></pre>
+
+<p class=note>This is a subset of what <a href="https://tools.ietf.org/html/rfc7233#section-3.1">RFC 7233</a> allows.
+
+<div class="note">
+
+  The above as a railroad diagram:
+
+  <pre class="railroad">
+  T: "bytes="
+  Stack:
+    Sequence:
+      Comment: first-byte-pos
+      OneOrMore:
+        N: digit
+      Comment: /first-byte-pos
+      N: "/"
+    Sequence:
+      Comment: last-byte-pos
+      OneOrMore:
+        N: digit
+      Comment: /last-byte-pos
+      N: "/"
+    Sequence:
+      Comment: complete-length
+      Choice:
+        N: "*"
+        OneOrMore:
+          N: digit
+      Comment: /complete-length
+  </pre>
+</div>
 
 <h4 id=cors-protocol-and-credentials>CORS protocol and credentials</h4>
 
@@ -5237,18 +5654,28 @@ these steps:
    <li><p>Set <var>response</var> and <var>internalResponse</var> to the result of running
    <a>HTTP-network-or-cache fetch</a> given <var>fetchParams</var>.
 
-   <li>
-    <p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and a
-    <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return a
-    <a>network error</a>.
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+   <var>response</var>'s <a for=response>status</a> is not a <a>redirect status</a>, then
 
-    <p class=note>As the <a>CORS check</a> is not to be applied to <a for=/>responses</a> whose
-    <a for=response>status</a> is 304 or 407, or <a for=/>responses</a> from a service worker for
-    that matter, it is applied here.
+   <ol>
+    <li><p>If <var>request</var>'s <a for=request>initiator type</a> is "<code>fetch</code>",
+    then set <var>internalResponse</var>'s <a for=response >body</a> to null.
+
+    <li><p>Otherwise, if <a>opaque-response-safelist check</a> given <var>request</var> and <var>response</var> returns
+    false, then return a <a>network error</a>.
+   </ol>
+
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>cors</code>" and
+   the <a>CORS check</a> for <var>request</var> and <var>response</var> returns failure, then return
+   a <a>network error</a>.
 
    <li><p>If the <a>TAO check</a> for <var>request</var> and <var>response</var> returns failure,
    then set <var>request</var>'s <a for=request>timing allow failed flag</a>.
   </ol>
+
+  <p class=note>As the <a>opaque-response-safelist check</a>, <a>CORS check</a>, and
+  <a>TAO check</a> are not to be applied to <a for=/>responses</a> whose <a for=response>status</a>
+  is 304 or 407, or to <a for=/>responses</a> from a service worker, they are applied here.
 
  <li>
   <p>If either <var>request</var>'s <a for=request>response tainting</a> or <var>response</var>'s
@@ -9152,6 +9579,7 @@ Mohamed Zergaoui,
 Mohammed Zubair Ahmed<!-- M-ZubairAhmed; GitHub -->,
 Moritz Kneilmann,
 Ms2ger,
+Nathan Froyd,
 Nico Schlömer,
 Nicolás Peña Moreno,
 Nidhi Jaju,


### PR DESCRIPTION
This PR is based on what @annevk has proposed in https://github.com/whatwg/fetch/pull/1442, with additional changes. It includes the `validate a partial response` and the `Content-Range header parser` algorithm, plus the additional changes that Firefox has made in its implementation. 

https://github.com/whatwg/fetch/pull/1442 had some discussions and references, and I wish I can keep them, but I don't have write access to annevk/orb, hence this PR. Please let me know if there's a better way to move this forward. 

cc @zcorpan @annevk 
***

TODO:

- [x] Define "validate a partial response" (and Content-Range header parser)
- [x] "ParseText" vs "create a classic script" + mock data
- [x] A PR against HTML is needed to ensure it passes the appropriate metadata for media element and classic script requests. https://github.com/whatwg/html/pull/12914
- [x] Double check this operates on the internal response (and if not pass it)
- [x] Also use response in encoding extraction, depends on https://github.com/whatwg/fetch/pull/1447
- [ ] https://github.com/annevk/orb/labels/mvp
- [ ] PR to make tests non-tentative
***
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome 
   * Firefox
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/fetch/orb/tentative?label=experimental&label=master&aligned
   * Non-tentative: todo
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …

- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/specinfra/pr-preview#pr-preview) failed to build. _(Last tried on Sep 7, 2026, 11:49 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsefeng211%2Ffetch%2F280840beb65203e0fab45995739d4e77444321c8%2Ffetch.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201755)

**Error output:**

```json
[
    {
        "lineNum": "4584:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "4585:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "9176:177",
        "messageType": "fatal",
        "text": "Saw a heading end tag </h2>, but the current open heading is <h3> (at 9176:1)."
    },
    {
        "lineNum": "9341:3",
        "messageType": "fatal",
        "text": "Saw an end tag </div>, but there were unclosed elements remaining before the nearest matching start tag (at 9322:3).\nOpen tags: <dl> at 9285:1, <dd> at 9287:2, <div> at 9322:3, <ol> at 9323:4"
    },
    {
        "lineNum": "9391:3",
        "messageType": "fatal",
        "text": "Saw an end tag </div>, but there were unclosed elements remaining before the nearest matching start tag (at 9369:3).\nOpen tags: <dl> at 9285:1, <dd> at 9345:2, <div> at 9369:3, <ol> at 9370:4"
    },
    {
        "lineNum": "637:23",
        "messageType": "link",
        "text": "Obsolete biblio ref: [rfc8941] is replaced by [rfc9651]. Either update the reference, or use [rfc8941 obsolete] if this is an intentionally-obsolete reference."
    },
    {
        "lineNum": "4450:30",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'report only value'."
    },
    {
        "lineNum": "4567:2",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'report only reporting endpoint'."
    },
    {
        "lineNum": "5374:7",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'object' with for='['blob URL entry']'."
    },
    {
        "lineNum": "5380:62",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'object' with for='['blob URL entry']'."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/specinfra/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/fetch%231755.)._

</details>
