### PR TITLE
Add process model processing for the "Priority" header.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5654,6 +5654,12 @@ run these steps:
     default), and `<code>Accept-Charset</code>` is a waste of bytes. See
     <a>HTTP header layer division</a> for more details.
 
+   <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
+    <a for="header list">does not contain</a> `<code>Priority</code>`, then user agents may
+    <a for="header list">append</a> a `<code>Priority</code>` <a>header</a> with an
+    <a>implementation-defined</a> value derived from <var>httpRequest</var>'s
+    <a for=request>internal priority</a> in accordance with RFC 9218. [[!RFC9218]]
+
    <li>
     <p>If <var>includeCredentials</var> is true, then:
 


### PR DESCRIPTION
- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
   * See discussion in #1718
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

This adds the processing for the `Priority` HTTP header from HTTP Extensible Priorities ([RFC 9218](https://datatracker.ietf.org/doc/rfc9218/)).

The actual priority values are implementation-specific but this change makes it clear that an existing value should not be overwritten if the header is already present.

Fix #1718 