### PR TITLE
Fix outdated HTML PR link

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1113,8 +1113,7 @@ a <a>byte-case-insensitive</a> match for one of
  request object is copied, but will be removed if the request is modified by unprivileged APIs.
 
  <p>`<code>Range</code>` headers are commonly used by <a lt="download the hyperlink">downloads</a>
- and <a lt="resource fetch algorithm">media fetches</a>. More details can be found in
- <a href=https://github.com/whatwg/html/pull/7655>html/7655</a>.
+ and <a lt="resource fetch algorithm">media fetches</a>.
 
  <p>A helper is provided to <a for=request>add a range header</a> to a particular request.
 </div>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1113,8 +1113,8 @@ a <a>byte-case-insensitive</a> match for one of
  request object is copied, but will be removed if the request is modified by unprivileged APIs.
 
  <p>`<code>Range</code>` headers are commonly used by <a lt="download the hyperlink">downloads</a>
- and <a lt="resource fetch algorithm">media fetches</a>, although neither of these currently specify
- how. <a href=https://github.com/whatwg/html/pull/2814>html/2914</a> aims to solve this.
+ and <a lt="resource fetch algorithm">media fetches</a>. More details can be found in
+ <a href=https://github.com/whatwg/html/pull/7655>html/7655</a>.
 
  <p>A helper is provided to <a for=request>add a range header</a> to a particular request.
 </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1758.html" title="Last updated on Jun 5, 2024, 6:35 PM UTC (cc13052)">Preview</a> | <a href="https://whatpr.org/fetch/1758/1085f4f...cc13052.html" title="Last updated on Jun 5, 2024, 6:35 PM UTC (cc13052)">Diff</a>