### PR TITLE
Make get, decode, and split handle edge cases correctly

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -778,30 +778,15 @@ a <a for=/>header value</a> <var>value</var>, run these steps. They return a <a 
     <p class=note>The result might be the empty string.
 
    <li>
-    <p>If <var>position</var> is not past the end of <var>input</var>, then:
+    <p>If <var>position</var> is not past the end of <var>input</var> and the
+    <a for=/>code point</a> at <var>position</var> within <var>input</var> is U+0022 ("):
 
     <ol>
-     <li>
-      <p>If the <a for=/>code point</a> at <var>position</var> within <var>input</var> is
-      U+0022 ("), then:
+     <li><p>Append the result of <a>collecting an HTTP quoted string</a> from <var>input</var>,
+     given <var>position</var>, to <var>temporaryValue</var>.
 
-      <ol>
-       <li><p>Append the result of <a>collecting an HTTP quoted string</a> from <var>input</var>,
-       given <var>position</var>, to <var>temporaryValue</var>.
-
-       <li>If <var>position</var> is not past the end of <var>input</var>, then
-       <a for=iteration>continue</a>.
-      </ol>
-
-     <li>
-      <p>Otherwise:
-
-      <ol>
-       <li><p>Assert: the <a for=/>code point</a> at <var>position</var> within <var>input</var> is
-       U+002C (,).
-
-       <li><p>Advance <var>position</var> by 1.
-      </ol>
+     <li>If <var>position</var> is not past the end of <var>input</var>, then
+     <a for=iteration>continue</a>.
     </ol>
 
    <li><p>Remove all <a>HTTP tab or space</a> from the start and end of <var>temporaryValue</var>.
@@ -809,6 +794,19 @@ a <a for=/>header value</a> <var>value</var>, run these steps. They return a <a 
    <li><p><a for=list>Append</a> <var>temporaryValue</var> to <var>values</var>.
 
    <li><p>Set <var>temporaryValue</var> to the empty string.
+
+   <li>
+    <p>If <var>position</var> is not past the end of <var>input</var>:
+
+    <ol>
+     <li><p><a for=/>Assert</a>: the <a for=/>code point</a> at <var>position</var> within
+     <var>input</var> is U+002C (,).
+
+     <li><p>Advance <var>position</var> by 1.
+
+     <li><p>If <var>position</var> is past the end of <var>input</var>, then <a for=list>append</a>
+     the empty string to <var>values</var>.
+    </ol>
   </ol>
 
  <li><p>Return <var>values</var>.
@@ -9040,6 +9038,7 @@ Brad Porter,
 Bryan Smith,
 Caitlin Potter,
 Cameron McCormack,
+Carlo Cannas,
 白丞祐 (Cheng-You Bai)<!-- CYBAI; GitHub -->,
 Chirag S Kumar<!-- fictionistique; GitHub -->,
 Chris Needham,

--- a/fetch.bs
+++ b/fetch.bs
@@ -700,6 +700,19 @@ A:
 </code></pre>
   <tr>
    <td>
+    <pre><code class=lang-http>
+A:
+B: sniff
+</code></pre>
+   <td>« "" »
+  <tr>
+   <td>
+    <pre><code class=lang-http>
+B: sniff
+</code></pre>
+   <td>null
+  <tr>
+   <td>
     <pre><code class=lang-http>A: text/html;", x/x</code></pre>
    <td rowspan=2>« "<code>text/html;", x/x</code>" »
   <tr>
@@ -763,12 +776,12 @@ a <a for=/>header value</a> <var>value</var>, run these steps. They return a <a 
  <li><p>Let <var>position</var> be a <a for=string>position variable</a> for <var>input</var>,
  initially pointing at the start of <var>input</var>.
 
- <li><p>Let <var>values</var> be a <a for=/>list</a> of <a for=/>strings</a>, initially empty.
+ <li><p>Let <var>values</var> be a <a for=/>list</a> of <a for=/>strings</a>, initially « ».
 
  <li><p>Let <var>temporaryValue</var> be the empty string.
 
  <li>
-  <p>While <var>position</var> is not past the end of <var>input</var>:
+  <p>While true:
 
   <ol>
    <li>
@@ -795,21 +808,13 @@ a <a for=/>header value</a> <var>value</var>, run these steps. They return a <a 
 
    <li><p>Set <var>temporaryValue</var> to the empty string.
 
-   <li>
-    <p>If <var>position</var> is not past the end of <var>input</var>:
+   <li><p>If <var>position</var> is past the end of <var>input</var>, then return <var>values</var>.
 
-    <ol>
-     <li><p><a for=/>Assert</a>: the <a for=/>code point</a> at <var>position</var> within
-     <var>input</var> is U+002C (,).
+   <li><p><a for=/>Assert</a>: the <a for=/>code point</a> at <var>position</var> within
+   <var>input</var> is U+002C (,).
 
-     <li><p>Advance <var>position</var> by 1.
-
-     <li><p>If <var>position</var> is past the end of <var>input</var>, then <a for=list>append</a>
-     the empty string to <var>values</var>.
-    </ol>
+   <li><p>Advance <var>position</var> by 1.
   </ol>
-
- <li><p>Return <var>values</var>.
 </ol>
 
 <p class=note>Except for blessed call sites, the algorithm directly above is not to be invoked


### PR DESCRIPTION
Correct how it handles when a header is present but has no value (should be a list solely containing an empty string value) and when there is a trailing comma (should be a list ending with an empty string value).

Fixes #1768.

---

@domenic @MattMenke2 this was an oversight in #831 it appears. If you'd like to review in addition to @CarloCannas I'd appreciate it. Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1769.html" title="Last updated on Aug 19, 2024, 1:43 PM UTC (0334504)">Preview</a> | <a href="https://whatpr.org/fetch/1769/4cb3cf2...0334504.html" title="Last updated on Aug 19, 2024, 1:43 PM UTC (0334504)">Diff</a>