### PR TITLE
Clarify that request.origin cannot be "client" at certain points

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -458,7 +458,8 @@ and an optional boolean <var>extract-value</var> (default false):
 
  <li><p>Let <var>value</var> be the empty string.
 
- <li><p>Assert: the <a>code point</a> at <var>position</var> within <var>input</var> is U+0022 (").
+ <li><p><a for=/>Assert</a>: the <a>code point</a> at <var>position</var> within
+ <var>input</var> is U+0022 (").
 
  <li><p>Advance <var>position</var> by 1.
 
@@ -494,7 +495,7 @@ and an optional boolean <var>extract-value</var> (default false):
     <p>Otherwise:
 
     <ol>
-     <li><p>Assert: <var>quoteOrBackslash</var> is U+0022 (").
+     <li><p><a for=/>Assert</a>: <var>quoteOrBackslash</var> is U+0022 (").
 
      <li><p><a for=iteration>Break</a>.
     </ol>
@@ -591,8 +592,8 @@ given a <a for=/>header name</a> <var>name</var> and a string <var>type</var> fr
 <a>structured field value</a>.
 
 <ol>
- <li><p>Assert: <var>type</var> is one of "<code>dictionary</code>", "<code>list</code>", or
- "<code>item</code>".
+ <li><p><a for=/>Assert</a>: <var>type</var> is one of "<code>dictionary</code>",
+ "<code>list</code>", or "<code>item</code>".
 
  <li><p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var> from
  <var>list</var>.
@@ -931,7 +932,7 @@ directly. Use <a for="header list">get, decode, and split</a> instead.
      <li><p>Let <var>value</var> be the result of <a for="header list">getting</a> <var>name</var>
      from <var>list</var>.
 
-     <li><p>Assert: <var>value</var> is non-null.
+     <li><p><a for=/>Assert</a>: <var>value</var> is non-null.
 
      <li><p><a for=list>Append</a> (<var>name</var>, <var>value</var>) to <var>headers</var>.
     </ol>
@@ -2301,8 +2302,8 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 <var>last</var>, run these steps:
 
 <ol>
- <li><p>Assert: <var>last</var> is not given, or <var>first</var> is less than or equal to
- <var>last</var>.
+ <li><p><a for=/>Assert</a>: <var>last</var> is not given, or <var>first</var> is less than
+ or equal to <var>last</var>.
 
  <li><p>Let <var>rangeValue</var> be `<code>bytes=</code>`.
 
@@ -2332,7 +2333,8 @@ source of security bugs. Please seek security review for features that deal with
 <var>response</var>, run these steps:
 
 <ol>
- <li><p>Assert: <var>response</var>'s <a for=response>URL list</a> <a for=list>is not empty</a>.
+ <li><p><a for=/>Assert</a>: <var>response</var>'s <a for=response>URL list</a>
+ <a for=list>is not empty</a>.
 
  <li>
   <p>Let <var>url</var> be a copy of <var>response</var>'s <a for=response>URL list</a>[0].
@@ -2503,7 +2505,7 @@ this is also tracked internally using the request's <a for=request>timing allow 
 <var>fetchParams</var>:
 
 <ol>
- <li><p>Assert: <var>fetchParams</var> is <a for="fetch params">canceled</a>.
+ <li><p><a for=/>Assert</a>: <var>fetchParams</var> is <a for="fetch params">canceled</a>.
 
  <li><p>Return an <a>aborted network error</a> if <var>fetchParams</var> is
  <a for="fetch params">aborted</a>; otherwise return a <a>network error</a>.
@@ -2702,7 +2704,7 @@ manually. [[!HTML]]
 <ol>
  <li><p>If <var>potentialDestination</var> is "<code>fetch</code>", then return the empty string.
 
- <li><p>Assert: <var>potentialDestination</var> is a <a for=request>destination</a>.
+ <li><p><a for=/>Assert</a>: <var>potentialDestination</var> is a <a for=request>destination</a>.
 
  <li><p>Return <var>potentialDestination</var>.
 </ol>
@@ -3098,7 +3100,7 @@ or an <a>implementation-defined</a> value.
  <li><p>If <var>topLevelOrigin</var> is null, then set <var>topLevelOrigin</var> to
  <var>environment</var>'s <a for="environment">top-level creation URL</a>'s <a for=url>origin</a>.
 
- <li><p>Assert: <var>topLevelOrigin</var> is an <a for=/>origin</a>.
+ <li><p><a for=/>Assert</a>: <var>topLevelOrigin</var> is an <a for=/>origin</a>.
 
  <li><p>Let <var>topLevelSite</var> be the result of <a lt="obtain a site">obtaining a site</a>,
  given <var>topLevelOrigin</var>.
@@ -5433,7 +5435,8 @@ run these steps:
   <p>If <var>request</var>'s <a for=request>redirect mode</a> is "<code>manual</code>", then:
 
   <ol>
-   <li><p>Assert: <var>request</var>'s <a for=request>mode</a> is "<code>navigate</code>".
+   <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>mode</a> is
+   "<code>navigate</code>".
 
    <li><p>Set <var>recursive</var> to false.
   </ol>
@@ -7047,8 +7050,8 @@ typedef (ReadableStream or XMLHttpRequestBodyInit) BodyInit;</pre>
   <p>If <var>object</var> is a {{ReadableStream}} object, then:
 
   <ol>
-   <li><p>Assert: <var>object</var> is neither <a for=ReadableStream>disturbed</a> nor
-   <a for=ReadableStream>locked</a>.
+   <li><p><a for=/>Assert</a>: <var>object</var> is neither <a for=ReadableStream>disturbed</a>
+   nor <a for=ReadableStream>locked</a>.
   </ol>
 
  <li><p>Return the result of <a for=BodyInit>extracting</a> <var>object</var>.
@@ -7695,7 +7698,7 @@ constructor steps are:
   <p>Otherwise:
 
   <ol>
-   <li><p>Assert: <var>input</var> is a {{Request}} object.
+   <li><p><a for=/>Assert</a>: <var>input</var> is a {{Request}} object.
 
    <li><p>Set <var>request</var> to <var>input</var>'s
    <a for=Request>request</a>.
@@ -8614,7 +8617,7 @@ that RFC's normative processing requirements to be compatible with deployed cont
 <var>dataURL</var> and then runs these steps:
 
 <ol>
- <li><p>Assert: <var>dataURL</var>'s <a for=url>scheme</a> is "<code>data</code>".
+ <li><p><a for=/>Assert</a>: <var>dataURL</var>'s <a for=url>scheme</a> is "<code>data</code>".
 
  <li><p>Let <var>input</var> be the result of running the <a>URL serializer</a> on
  <var>dataURL</var> with <a for="URL serializer"><i>exclude fragment</i></a> set to true.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2230,6 +2230,9 @@ or "<code>object</code>".
 return true:
 
 <ol>
+ <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>origin</a> is not
+ "<code>client</code>".
+
  <li><p>Let <var>lastURL</var> be null.
 
  <li>
@@ -2255,6 +2258,9 @@ return true:
 run these steps:
 
 <ol>
+ <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>origin</a> is not
+ "<code>client</code>".
+
  <li><p>If <var>request</var> has a <a for=request>redirect-tainted origin</a>, then return
  "<code>null</code>".
 
@@ -2350,6 +2356,9 @@ source of security bugs. Please seek security review for features that deal with
 <a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
+ <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>origin</a> is not
+ "<code>client</code>".
+
  <li><p>If <var>request</var>'s <a for=request>mode</a> is not "<code>no-cors</code>", then return
  true.</p>
 
@@ -3309,6 +3318,9 @@ request <a for=/>header</a> indicates where a
 given a <a for=/>request</a> <var>request</var>, run these steps:
 
 <ol>
+ <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>origin</a> is not
+ "<code>client</code>".
+
  <li><p>Let <var>serializedOrigin</var> be the result of <a>byte-serializing a request origin</a>
  with <var>request</var>.
 
@@ -6632,6 +6644,9 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 <var>response</var>, run these steps:
 
 <ol>
+ <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>origin</a> is not
+ "<code>client</code>".
+
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is set, then return
  failure.
 
@@ -9189,6 +9204,7 @@ Shivani Sharma,
 Sigbjørn Finne,
 Simon Pieters,
 Simon Sapin,
+Simon Wülker,
 Srirama Chandra Sekhar Mogali,
 Stephan Paul,
 Steven Salat,

--- a/fetch.bs
+++ b/fetch.bs
@@ -458,8 +458,8 @@ and an optional boolean <var>extract-value</var> (default false):
 
  <li><p>Let <var>value</var> be the empty string.
 
- <li><p><a for=/>Assert</a>: the <a>code point</a> at <var>position</var> within
- <var>input</var> is U+0022 (").
+ <li><p><a for=/>Assert</a>: the <a>code point</a> at <var>position</var> within <var>input</var> is
+ U+0022 (").
 
  <li><p>Advance <var>position</var> by 1.
 
@@ -2302,8 +2302,8 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 <var>last</var>, run these steps:
 
 <ol>
- <li><p><a for=/>Assert</a>: <var>last</var> is not given, or <var>first</var> is less than
- or equal to <var>last</var>.
+ <li><p><a for=/>Assert</a>: <var>last</var> is not given, or <var>first</var> is less than or equal
+ to <var>last</var>.
 
  <li><p>Let <var>rangeValue</var> be `<code>bytes=</code>`.
 
@@ -7050,8 +7050,8 @@ typedef (ReadableStream or XMLHttpRequestBodyInit) BodyInit;</pre>
   <p>If <var>object</var> is a {{ReadableStream}} object, then:
 
   <ol>
-   <li><p><a for=/>Assert</a>: <var>object</var> is neither <a for=ReadableStream>disturbed</a>
-   nor <a for=ReadableStream>locked</a>.
+   <li><p><a for=/>Assert</a>: <var>object</var> is neither <a for=ReadableStream>disturbed</a> nor
+   <a for=ReadableStream>locked</a>.
   </ol>
 
  <li><p>Return the result of <a for=BodyInit>extracting</a> <var>object</var>.


### PR DESCRIPTION
Previously, the code implicitly guaranteed that a requests origin could not be "client" after Step 10 of
https://fetch.spec.whatwg.org/#concept-fetch.

Other algorithms then simply relied on this fact. This is confusing. Instead, we now explicitly assert that the origin is not client whereever we need it.

This closes #1773

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->
---
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1776.html" title="Last updated on Oct 1, 2024, 7:43 AM UTC (6835582)">Preview</a> | <a href="https://whatpr.org/fetch/1776/edfa8d1...6835582.html" title="Last updated on Oct 1, 2024, 7:43 AM UTC (6835582)">Diff</a>