### PR TITLE
Meta: reference new Structured Field Values RFC

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -15,7 +15,7 @@ Translate IDs: typedefdef-bodyinit bodyinit,dictdef-requestinit requestinit,type
 urlPrefix:https://httpwg.org/specs/rfc5861.html#;type:dfn;spec:stale-while-revalidate
     url:n-the-stale-while-revalidate-cache-control-extension;text:stale-while-revalidate lifetime
 
-urlPrefix:https://httpwg.org/specs/rfc8941.html#;type:dfn;spec:rfc8941
+urlPrefix:https://httpwg.org/specs/rfc9651.html#;type:dfn;spec:rfc9651
     url:rfc.section.2;text:structured field value
     url:text-serialize;text:serializing structured fields
     url:text-parse;text:parsing structured fields
@@ -633,7 +633,7 @@ serialize in interesting and efficient ways. For the moment, Fetch only supports
 <a>header values</a> as <a for=/>byte sequences</a>, which means that these objects can be set in
 <a for=/>header lists</a> only via serialization, and they can be obtained from
 <a for=/>header lists</a> only by parsing. In the future the fact that they are objects might be
-preserved end-to-end. [[!RFC8941]]
+preserved end-to-end. [[!RFC9651]]
 </div>
 
 <hr>


### PR DESCRIPTION
Fetch appears aligned with the changes described in https://httpwg.org/specs/rfc9651.html#changes. Sec-Purpose is the sole structured header Fetch defines and it does not use ABNF for its definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1782.html" title="Last updated on Oct 24, 2024, 9:19 PM UTC (8fb3736)">Preview</a> | <a href="https://whatpr.org/fetch/1782/761c414...8fb3736.html" title="Last updated on Oct 24, 2024, 9:19 PM UTC (8fb3736)">Diff</a>