### PR TITLE
Partition Blob URL fetches by Storage Key

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3136,9 +3136,10 @@ or an <a>implementation-defined</a> value.
 <h3 id=storage-keys-for-requests>Storage keys for requests</h3>
 
 <p class=note>Requests made to Blob URLs (other than those corresponding to navigations) are
-prevented from succeeding if the <a>storage key</a> for the <a>environment</a> making the request
-is different than the <a>storage key</a> of the <environment> where the Blob URL was created.
-[[STORAGE]]
+prevented from succeeding if the <a spec=storage>storage key</a> of the
+<a>environment settings object</a> making the request is different than the
+<a spec=storage>storage key</a> of the <a>environment settings object</a> corresponding to where
+the Blob URL was created.
 
 <div algorithm>
 <p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
@@ -3147,11 +3148,11 @@ is different than the <a>storage key</a> of the <environment> where the Blob URL
 <ol>
  <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
  result of running <a for=/>obtain a storage key for non-storage purposes</a> given
- <var>request</var>'s <a for=request>reserved client</a>. [[!STORAGE]]
+ <var>request</var>'s <a for=request>reserved client</a>.
 
  <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the result of
- running <a for=/>obtain a storage key for non-storage purposes/a> given <var>request</var>'s
- <a for=request>client</a>. [[!STORAGE]]
+ running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
+ <a for=request>client</a>.
 
  <li><p>Return null.
 </ol>
@@ -5006,7 +5007,7 @@ steps:
      <li>
       <p>Let <var>blobStorageKey</var> be the result of running
       <a>obtain a storage key for non-storage purposes</a> with <var>blobURLEntry</var>'s
-      <a>environment settings object</a>. [[!STORAGE]]
+      <a>environment settings object</a>.
 
      <li>
       <p>Let <var>requestStorageKey</var> be the result of
@@ -5020,7 +5021,8 @@ steps:
 
        <li><p><var>requestStorageKey</var> is non-null
 
-       <li><p><var>requestStorageKey</var> is does not <a>storage key equal</a> <var>blobStorageKey</var> [[!STORAGE]]
+       <li><p><var>requestStorageKey</var> does not <a for="storage key">equal</a>
+       <var>blobStorageKey</var>
       </ul>
 
       <p>then return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -3133,32 +3133,6 @@ or an <a>implementation-defined</a> value.
 </div>
 
 
-<h3 id=storage-keys-for-requests>Storage keys for requests</h3>
-
-<p class=note>Requests made to Blob URLs (other than those corresponding to navigations) are
-prevented from succeeding if the <a spec=storage>storage key</a> of the
-<a>environment settings object</a> making the request is different than the
-<a spec=storage>storage key</a> of the <a>environment settings object</a> corresponding to where
-the Blob URL was created.
-
-<div algorithm>
-<p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
-<var>request</var>:
-
-<ol>
- <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
- result of running <a for=/>obtain a storage key for non-storage purposes</a> given
- <var>request</var>'s <a for=request>reserved client</a>.
-
- <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the result of
- running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
- <a for=request>client</a>.
-
- <li><p>Return null.
-</ol>
-</div>
-
-
 <h3 id=http-cache-partitions>HTTP cache partitions</h3>
 
 <div algorithm>
@@ -5007,7 +4981,7 @@ steps:
      <li>
       <p>Let <var>blobStorageKey</var> be the result of running
       <a>obtain a storage key for non-storage purposes</a> with <var>blobURLEntry</var>'s
-      <a>environment settings object</a>.
+      <a for="blob URL entry">environment</a>.
 
      <li>
       <p>Let <var>requestStorageKey</var> be the result of
@@ -5017,12 +4991,12 @@ steps:
       <p>If all of the following conditions are true:
 
       <ul class=brief>
-       <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>navigate</code>"
+       <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>navigate</code>";
 
-       <li><p><var>requestStorageKey</var> is non-null
+       <li><p><var>requestStorageKey</var> is non-null; and
 
        <li><p><var>requestStorageKey</var> does not <a for="storage key">equal</a>
-       <var>blobStorageKey</var>
+       <var>blobStorageKey</var>,
       </ul>
 
       <p>then return a <a>network error</a>.
@@ -5157,6 +5131,23 @@ steps:
   </dl>
 
  <li><p>Return a <a for=/>network error</a>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
+<var>request</var>:
+
+<ol>
+ <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
+ result of running <a for=/>obtain a storage key for non-storage purposes</a> given
+ <var>request</var>'s <a for=request>reserved client</a>.
+
+ <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the result of
+ running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
+ <a for=request>client</a>.
+
+ <li><p>Return null.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -9091,6 +9091,7 @@ Alexey Proskuryakov,
 Andreas Kling,
 Andrés Gutiérrez,
 Andrew Sutherland,
+Andrew Williams,<!-- recvfrom; GitHub -->
 Ángel González,
 Anssi Kostiainen,
 Arkadiusz Michalski,

--- a/fetch.bs
+++ b/fetch.bs
@@ -3132,6 +3132,27 @@ or an <a>implementation-defined</a> value.
 </ol>
 </div>
 
+<h3 id=storage-keys-for-requests>Storage keys for requests</h3>
+
+<p class=note>Requests made to Blob URLs (other than those corresponding to navigations) are prevented from succeeding if the <a>storage key</a> for the <a>environment</a> making the request is different than the <a>storage key</a> of the <environment> where the Blob URL was created. [[STORAGE]]
+
+<div algorithm>
+<p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
+<var>request</var>:
+
+<ol>
+ <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
+ result of running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
+ <a for=request>reserved client</a>. [[!STORAGE]]
+
+ <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the
+ result of running <a for=/>obtain a storage key for non-storage purposes/a> given <var>request</var>'s
+ <a for=request>client</a>. [[!STORAGE]]
+
+ <li><p>Return null.
+</ol>
+</div>
+
 
 <h3 id=http-cache-partitions>HTTP cache partitions</h3>
 
@@ -4977,6 +4998,24 @@ steps:
 
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
       other than being interoperable.
+
+     <li><p>Let <var>blob storage key</var> be the result of running <a>obtain a storage key for non-storage purposes</a> with
+     <var>blobURLEntry</var>'s <a>environment settings object</a>. [[!STORAGE]]
+
+     <li><p>Let <var>request storage key</var> be the result of <a for=request>determining the storage key</a> given <var>request</var>.
+
+     <li>
+      <p>If all of the following conditions are true:
+
+      <ul class=brief>
+       <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>navigate</code>"
+
+       <li><p><var>request storage key</var> is non-null
+
+       <li><p><var>request storage key</var> is does not <a>storage key equal</a> <var>blob storage key</var> [[!STORAGE]]
+      </ul>
+
+      <p>then return a <a>network error</a>.
 
      <li><p>Let <var>blob</var> be <var>blobURLEntry</var>'s <a for="blob URL entry">object</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4985,15 +4985,11 @@ steps:
      <li><p>If <var>isTopLevelNavigation</var> is false and <var>requestEnvironment</var> is null,
      then return a <a>network error</a>.
 
-     <li><p>Let <var>blob</var> be null.
+     <li><p>Let <var>navigationOrEnvironment</var> be the string "<code>navigation</code>" if
+     <var>isTopLevelNavigation</var> is true; otherwise, <var>requestEnvironment</var>.
 
-     <li><p>If <var>isTopLevelNavigation</var> is true, then set <var>blob</var> to the result of
-     <a href="https://w3c.github.io/FileAPI/#blob-url-obtain-object">obtaining a blob object</a>
-     given <var>blobURLEntry</var> and the string "<code>navigation</code>".
-
-     <li><p>Otherwise, set <var>blob</var> to the result of <a
-     href="https://w3c.github.io/FileAPI/#blob-url-obtain-object">obtaining a blob object</a> given
-     <var>blobURLEntry</var> and <var>requestEnvironment</var>.
+     <li><p>Let <var>blob</var> be the result of <a>obtaining a blob object</a> given
+     <var>blobURLEntry</var> and <var>navigationOrEnvironment</var>.
 
      <li><p>If <var>blob</var> is not a {{Blob}} object, then return a <a>network error</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4970,10 +4970,8 @@ steps:
      <a for=url>blob URL entry</a>.
 
      <li>
-      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>`,
-      <var>blobURLEntry</var> is null, or <var>blobURLEntry</var>'s
-      <a for="blob URL entry">object</a> is not a {{Blob}} object, then return a
-      <a>network error</a>. [[!FILEAPI]]
+      <p>If <var>request</var>'s <a for=request>method</a> is not `<code>GET</code>` or
+      <var>blobURLEntry</var> is null, then return a <a>network error</a>. [[!FILEAPI]]
 
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
       other than being interoperable.
@@ -4990,7 +4988,8 @@ steps:
      <li><p>Let <var>blob</var> be the result of <a>obtaining a blob object</a> given
      <var>blobURLEntry</var>, <var>requestEnvironment</var>, and <var>isNavigation</var>.
 
-     <li><p>If <var>blob</var> is failure, then return a <a>network error</a>.
+     <li><p>If <var>blob</var> is failure, or <var>blob</var> is not a {{Blob}} object, then
+     return a <a>network error</a>.
 
      <li><p>Let <var>response</var> be a new <a for=/>response</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4979,17 +4979,22 @@ steps:
      <li><p>Let <var>requestEnvironment</var> be the result of
      <a for=request>determining the environment</a> given <var>request</var>.
 
-     <li><p>Let <var>isNavigation</var> be true if <var>request</var>'s <a for=request>mode</a> is
-     not "<code>navigate</code>"; otherwise, false.
+     <li><p>Let <var>isTopLevelNavigation</var> be true if <var>request</var>'s <a
+     for=request>destination</a> is "<code>document</code>"; otherwise, false.
 
-     <li><p>If <var>isNavigation</var> is false and <var>requestEnvironment</var> is null, then
-     return a <a>network error</a>.
+     <li><p>If <var>isTopLevelNavigation</var> is false and <var>requestEnvironment</var> is null,
+     then return a <a>network error</a>.
 
-     <li><p>Let <var>blob</var> be the result of <a>obtaining a blob object</a> given
-     <var>blobURLEntry</var>, <var>requestEnvironment</var>, and <var>isNavigation</var>.
+     <li><p>Let <var>blob</var> be null.
 
-     <li><p>If <var>blob</var> is failure, or <var>blob</var> is not a {{Blob}} object, then
-     return a <a>network error</a>.
+     <li><p>If <var>isTopLevelNavigation</var> is true, then set <var>blob</var> to the result of
+     <a>obtaining a blob object</a> given <var>blobURLEntry</var> and the string
+     "<code>navigation</code>".
+
+     <li><p>Otherwise, set <var>blob</var> to the result of <a>obtaining a blob object</a> given
+     <var>blobURLEntry</var> and <var>requestEnvironment</var>.
+
+     <li><p>If <var>blob</var> is not a {{Blob}} object, then return a <a>network error</a>.
 
      <li><p>Let <var>response</var> be a new <a for=/>response</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3132,9 +3132,13 @@ or an <a>implementation-defined</a> value.
 </ol>
 </div>
 
+
 <h3 id=storage-keys-for-requests>Storage keys for requests</h3>
 
-<p class=note>Requests made to Blob URLs (other than those corresponding to navigations) are prevented from succeeding if the <a>storage key</a> for the <a>environment</a> making the request is different than the <a>storage key</a> of the <environment> where the Blob URL was created. [[STORAGE]]
+<p class=note>Requests made to Blob URLs (other than those corresponding to navigations) are
+prevented from succeeding if the <a>storage key</a> for the <a>environment</a> making the request
+is different than the <a>storage key</a> of the <environment> where the Blob URL was created.
+[[STORAGE]]
 
 <div algorithm>
 <p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
@@ -3142,11 +3146,11 @@ or an <a>implementation-defined</a> value.
 
 <ol>
  <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
- result of running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
- <a for=request>reserved client</a>. [[!STORAGE]]
+ result of running <a for=/>obtain a storage key for non-storage purposes</a> given
+ <var>request</var>'s <a for=request>reserved client</a>. [[!STORAGE]]
 
- <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the
- result of running <a for=/>obtain a storage key for non-storage purposes/a> given <var>request</var>'s
+ <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the result of
+ running <a for=/>obtain a storage key for non-storage purposes/a> given <var>request</var>'s
  <a for=request>client</a>. [[!STORAGE]]
 
  <li><p>Return null.
@@ -4999,10 +5003,14 @@ steps:
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
       other than being interoperable.
 
-     <li><p>Let <var>blob storage key</var> be the result of running <a>obtain a storage key for non-storage purposes</a> with
-     <var>blobURLEntry</var>'s <a>environment settings object</a>. [[!STORAGE]]
+     <li>
+      <p>Let <var>blobStorageKey</var> be the result of running
+      <a>obtain a storage key for non-storage purposes</a> with <var>blobURLEntry</var>'s
+      <a>environment settings object</a>. [[!STORAGE]]
 
-     <li><p>Let <var>request storage key</var> be the result of <a for=request>determining the storage key</a> given <var>request</var>.
+     <li>
+      <p>Let <var>requestStorageKey</var> be the result of
+      <a for=request>determining the storage key</a> given <var>request</var>.
 
      <li>
       <p>If all of the following conditions are true:
@@ -5010,9 +5018,9 @@ steps:
       <ul class=brief>
        <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>navigate</code>"
 
-       <li><p><var>request storage key</var> is non-null
+       <li><p><var>requestStorageKey</var> is non-null
 
-       <li><p><var>request storage key</var> is does not <a>storage key equal</a> <var>blob storage key</var> [[!STORAGE]]
+       <li><p><var>requestStorageKey</var> is does not <a>storage key equal</a> <var>blobStorageKey</var> [[!STORAGE]]
       </ul>
 
       <p>then return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4988,10 +4988,11 @@ steps:
      <li><p>Let <var>blob</var> be null.
 
      <li><p>If <var>isTopLevelNavigation</var> is true, then set <var>blob</var> to the result of
-     <a>obtaining a blob object</a> given <var>blobURLEntry</var> and the string
-     "<code>navigation</code>".
+     <a href="https://w3c.github.io/FileAPI/#blob-url-obtain-object">obtaining a blob object</a>
+     given <var>blobURLEntry</var> and the string "<code>navigation</code>".
 
-     <li><p>Otherwise, set <var>blob</var> to the result of <a>obtaining a blob object</a> given
+     <li><p>Otherwise, set <var>blob</var> to the result of <a
+     href="https://w3c.github.io/FileAPI/#blob-url-obtain-object">obtaining a blob object</a> given
      <var>blobURLEntry</var> and <var>requestEnvironment</var>.
 
      <li><p>If <var>blob</var> is not a {{Blob}} object, then return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4979,8 +4979,8 @@ steps:
      <li><p>Let <var>requestEnvironment</var> be the result of
      <a for=request>determining the environment</a> given <var>request</var>.
 
-     <li><p>Let <var>isTopLevelNavigation</var> be true if <var>request</var>'s <a
-     for=request>destination</a> is "<code>document</code>"; otherwise, false.
+     <li><p>Let <var>isTopLevelNavigation</var> be true if <var>request</var>'s
+     <a for=request>destination</a> is "<code>document</code>"; otherwise, false.
 
      <li><p>If <var>isTopLevelNavigation</var> is false and <var>requestEnvironment</var> is null,
      then return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -4978,30 +4978,19 @@ steps:
       <p class=note>The `<code>GET</code>` <a for=/>method</a> restriction serves no useful purpose
       other than being interoperable.
 
-     <li>
-      <p>Let <var>blobStorageKey</var> be the result of running
-      <a>obtain a storage key for non-storage purposes</a> with <var>blobURLEntry</var>'s
-      <a for="blob URL entry">environment</a>.
+     <li><p>Let <var>requestEnvironment</var> be the result of
+     <a for=request>determining the environment</a> given <var>request</var>.
 
-     <li>
-      <p>Let <var>requestStorageKey</var> be the result of
-      <a for=request>determining the storage key</a> given <var>request</var>.
+     <li><p>Let <var>isNavigation</var> be true if <var>request</var>'s <a for=request>mode</a> is
+     not "<code>navigate</code>"; otherwise, false.
 
-     <li>
-      <p>If all of the following conditions are true:
+     <li><p>If <var>isNavigation</var> is false and <var>requestEnvironment</var> is null, then
+     return a <a>network error</a>.
 
-      <ul class=brief>
-       <li><p><var>request</var>'s <a for=request>mode</a> is not "<code>navigate</code>";
+     <li><p>Let <var>blob</var> be the result of <a>obtaining a blob object</a> given
+     <var>blobURLEntry</var>, <var>requestEnvironment</var>, and <var>isNavigation</var>.
 
-       <li><p><var>requestStorageKey</var> is non-null; and
-
-       <li><p><var>requestStorageKey</var> does not <a for="storage key">equal</a>
-       <var>blobStorageKey</var>,
-      </ul>
-
-      <p>then return a <a>network error</a>.
-
-     <li><p>Let <var>blob</var> be <var>blobURLEntry</var>'s <a for="blob URL entry">object</a>.
+     <li><p>If <var>blob</var> is failure, then return a <a>network error</a>.
 
      <li><p>Let <var>response</var> be a new <a for=/>response</a>.
 
@@ -5135,17 +5124,15 @@ steps:
 </div>
 
 <div algorithm>
-<p>To <dfn for=request>determine the storage key</dfn>, given a <a for=/>request</a>
+<p>To <dfn for=request>determine the environment</dfn>, given a <a for=/>request</a>
 <var>request</var>:
 
 <ol>
- <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return the
- result of running <a for=/>obtain a storage key for non-storage purposes</a> given
+ <li><p>If <var>request</var>'s <a for=request>reserved client</a> is non-null, then return
  <var>request</var>'s <a for=request>reserved client</a>.
 
- <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return the result of
- running <a for=/>obtain a storage key for non-storage purposes</a> given <var>request</var>'s
- <a for=request>client</a>.
+ <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then return
+ <var>request</var>'s <a for=request>client</a>.
 
  <li><p>Return null.
 </ol>


### PR DESCRIPTION
Partition Blob URL fetches by Storage Key

This change updates the spec to partition Blob URL fetches by Storage Key. This change is part of broader changes discussed in https://github.com/w3c/FileAPI/issues/153#issuecomment-2330085478. Specifically, we will also:
 - Partition Blob URL revocation by storage key - https://github.com/w3c/FileAPI/pull/201
 - Enforce noopener for cross-top-level-site Blob URLs - (Spec changes for this will follow)

I considered incorporating the Storage Key checks into the "resolve a blob URL" algorithm instead, but it seemed that this would require an environment settings object to be available as part of https://url.spec.whatwg.org/#url-parsing, and I'm not sure whether that is the case / a change we want.

- [x] At least two implementers are interested (and none opposed):
   * Firefox has already implemented this - https://github.com/w3c/FileAPI/issues/153#issuecomment-2332288047
   * Safari has implemented partitioning Blob URL fetches by top-level origin and is considering partitioning them by a site-based Storage Key (Storage Key specifics TBD) - https://github.com/w3c/FileAPI/issues/153#issuecomment-2332086739
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/5967596
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/40057646
   * Gecko: N/A
   * WebKit: N/A
   * Deno (not for CORS changes): N/A (it seems Deno does not partition storage or more generally implement the same-origin policy: https://docs.deno.com/runtime/reference/web_platform_apis/#spec-deviations)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/36542
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1783.html" title="Last updated on Dec 6, 2024, 11:17 PM UTC (ddae2dc)">Preview</a> | <a href="https://whatpr.org/fetch/1783/1dc1b03...ddae2dc.html" title="Last updated on Dec 6, 2024, 11:17 PM UTC (ddae2dc)">Diff</a>