### PR TITLE
Editorial: make JSON parsing wording match Infra spec

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7395,7 +7395,7 @@ running <a for=Body>consume body</a> with <a>this</a> and the following steps gi
 
 <div algorithm>
 <p>The <dfn method for=Body><code>json()</code></dfn> method steps are to return the result
-of running <a for=Body>consume body</a> with <a>this</a> and <a>parse JSON from bytes</a>.
+of running <a for=Body>consume body</a> with <a>this</a> and <a>parse JSON bytes to a JavaScript value</a>.
 
 <p class="note">The above method can reject with a {{SyntaxError}}.
 </div>


### PR DESCRIPTION
It looks like the infra spec has changed in a way that broke the `parse JSON from bytes` reference. I noticed this as I was trying to build the spec: 
```
➜  ~/webdev/fetch git:(main) make
Error running preprocessor, returned code: 2.
LINK ERROR: No 'dfn' refs found for 'parse json from bytes'.
&lt;a bs-line-number="7398" data-link-type="dfn" data-lt="parse JSON from bytes">parse JSON from bytes&lt;/a>
 ✘  Did not generate, due to errors exceeding the allowed error level.
make: *** [remote] Error 22
```
This fixes the build by pointing to the new wording.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1787.html" title="Last updated on Nov 19, 2024, 3:04 AM UTC (954f7e4)">Preview</a> | <a href="https://whatpr.org/fetch/1787/bdb452e...954f7e4.html" title="Last updated on Nov 19, 2024, 3:04 AM UTC (954f7e4)">Diff</a>