### PR TITLE
Editorial: Move handling of request 'client' to its own steps

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4441,8 +4441,8 @@ the response. [[!HTTP-CACHING]]
 <div algorithm>
 <p>To <dfn>populate request from client</dfn> given a <a for=/>request</a> <var>request</var>:
 <ol>
- <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then set
- <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>,
+ <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then: set
+ <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>
  if <var>request</var>'s <a for=request>client</a>'s
  <a for="environment settings object">global object</a> is a {{Window}} object; otherwise
  "<code>no-window</code>".

--- a/fetch.bs
+++ b/fetch.bs
@@ -4279,6 +4279,8 @@ the response. [[!HTTP-CACHING]]
 
  <li><p>Let <var>crossOriginIsolatedCapability</var> be false.
 
+ <li><p><a>Populate request from client</a> given <var>request</var>.
+
  <li>
   <p>If <var>request</var>'s <a for=request>client</a> is non-null, then:
 
@@ -4324,16 +4326,6 @@ the response. [[!HTTP-CACHING]]
  <var>request</var>'s <a for=request>body</a> to <var>request</var>'s <a for=request>body</a>
  <a for="byte sequence">as a body</a>.
 
- <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then set
- <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>,
- if <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a> is a {{Window}} object; otherwise
- "<code>no-window</code>".
-
- <li><p>If <var>request</var>'s <a for=request>origin</a> is "<code>client</code>", then set
- <var>request</var>'s <a for=request>origin</a> to  <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">origin</a>.
-
  <li>
   <p>If all of the following conditions are true:
 
@@ -4375,19 +4367,6 @@ the response. [[!HTTP-CACHING]]
    <a for="fetch params">preloaded response candidate</a> to "<code>pending</code>".
   </ol>
  </li>
-
- <li>
-  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
-
-  <ol>
-   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set
-   <var>request</var>'s <a for=request>policy container</a> to a
-   <a lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s
-   <a for="environment settings object">policy container</a>. [[!HTML]]
-
-   <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new
-   <a for=/>policy container</a>.
-  </ol>
 
  <li>
   <p>If <var>request</var>'s <a for=request>header list</a>
@@ -4456,6 +4435,34 @@ the response. [[!HTTP-CACHING]]
  <li><p>Run <a>main fetch</a> given <var>fetchParams</var>.
 
  <li><p>Return <var>fetchParams</var>'s <a for="fetch params">controller</a>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn>populate request from client</dfn> given a <a for=/>request</a> <var>request</var>:
+<ol>
+ <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then set
+ <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>,
+ if <var>request</var>'s <a for=request>client</a>'s
+ <a for="environment settings object">global object</a> is a {{Window}} object; otherwise
+ "<code>no-window</code>".
+
+ <li><p>If <var>request</var>'s <a for=request>origin</a> is "<code>client</code>", then set
+ <var>request</var>'s <a for=request>origin</a> to  <var>request</var>'s <a for=request>client</a>'s
+ <a for="environment settings object">origin</a>.
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
+
+  <ol>
+   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set
+   <var>request</var>'s <a for=request>policy container</a> to a
+   <a lt="clone a policy container">clone</a> of <var>request</var>'s <a for=request>client</a>'s
+   <a for="environment settings object">policy container</a>. [[!HTML]]
+
+   <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new
+   <a for=/>policy container</a>.
+  </ol></div>
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4463,7 +4463,7 @@ the response. [[!HTTP-CACHING]]
 
    <li><p>Otherwise, set <var>request</var>'s <a for=request>policy container</a> to a new
    <a for=/>policy container</a>.
-  </ol></div>
+  </ol>
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4440,6 +4440,7 @@ the response. [[!HTTP-CACHING]]
 
 <div algorithm>
 <p>To <dfn>populate request from client</dfn> given a <a for=/>request</a> <var>request</var>:
+
 <ol>
  <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then: set
  <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -4452,7 +4452,7 @@ the response. [[!HTTP-CACHING]]
  <a for="environment settings object">origin</a>.
 
  <li>
-  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>", then:
+  <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>":
 
   <ol>
    <li><p>If <var>request</var>'s <a for=request>client</a> is non-null, then set


### PR DESCRIPTION
This doesn't have observable effects at the moment, but is a preparation for deferred fetching where populating the request
from client (specifically policy container) needs to happen before fetching.

(https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1793.html" title="Last updated on Dec 16, 2024, 11:32 AM UTC (708d8c1)">Preview</a> | <a href="https://whatpr.org/fetch/1793/0ce45ae...708d8c1.html" title="Last updated on Dec 16, 2024, 11:32 AM UTC (708d8c1)">Diff</a>