### PR TITLE
Correct Response's statusText check

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8273,8 +8273,8 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <li><p>If <var>init</var>["{{ResponseInit/status}}"] is not in the range 200 to 599, inclusive,
  then <a>throw</a> a {{RangeError}}.
 
- <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] does not match the
- <a spec=http1>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
+ <li><p>If <var>init</var>["{{ResponseInit/statusText}}"] is not the empty string and does not match
+ the <a>reason-phrase</a> token production, then <a>throw</a> a {{TypeError}}.
 
  <li><p>Set <var>response</var>'s <a for=Response>response</a>'s <a for=response>status</a> to
  <var>init</var>["{{ResponseInit/status}}"].
@@ -9072,14 +9072,14 @@ Alexey Proskuryakov,
 Andreas Kling,
 Andrés Gutiérrez,
 Andrew Sutherland,
-Andrew Williams,<!-- recvfrom; GitHub -->
+Andrew Williams<!-- recvfrom; GitHub -->,
 Ángel González,
 Anssi Kostiainen,
 Arkadiusz Michalski,
 Arne Johannessen,
 Artem Skoretskiy,
 Arthur Barstow,
-Arthur Sonzogni, <!-- ArthurSonzogni; GitHub -->
+Arthur Sonzogni<!-- ArthurSonzogni; GitHub -->,
 Asanka Herath,
 Axel Rauschmayer,
 Ben Kelly,
@@ -9118,6 +9118,7 @@ Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,
 Eric Orth,
+Feng Yu<!-- F3n67u; GitHub -->,
 François Marier,
 Frank Ellerman,
 Frederick Hirsch,


### PR DESCRIPTION
This has been wrong for a decade (see 38647562f94d396b77c62f77b4024ee21a1bb400) and nobody noticed until now.

Fixes #1794.

---

Omitting template as this has been implemented "correctly" for a decade as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1795.html" title="Last updated on Dec 12, 2024, 8:08 AM UTC (75893d9)">Preview</a> | <a href="https://whatpr.org/fetch/1795/0ce45ae...75893d9.html" title="Last updated on Dec 12, 2024, 8:08 AM UTC (75893d9)">Diff</a>