### PR TITLE
Return a `content-encoding` header for resource timing and more

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6329,8 +6329,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
          <li><p>Otherwise, if <var>codings</var>'s <a for=list>size</a> is greater than 1, then set
          <var>filteredCoding</var> to "<code>multiple</code>".
 
-         <li><p>Otherwise, if <var>codings</var>[0] is the empty string, or it is supported by the user agent,
-         and is a <a>byte-case-insensitive</a> match for an entry listed in the
+         <li><p>Otherwise, if <var>codings</var>[0] is the empty string, or it is supported by the
+         user agent, and is a <a>byte-case-insensitive</a> match for an entry listed in the
          <cite>HTTP Content Coding Registry</cite>, then set <var>filteredCoding</var> to the result
          of <a lt=byte-lowercased>byte-lowercasing</a> <var>codings</var>[0]. [[!IANA-HTTP-PARAMS]]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

The major change is to add `content-encoding` to response header list. This PR also adds description on how `content-encoding` is determined. (content negotiation) 

The purpose is to pass such value to resource timing. Further details are available at
https://github.com/w3c/resource-timing/issues/381.

Note: Per discussion at 12/05/2024 webPerWG call (https://docs.google.com/document/d/1mpFDrAWuV6IgvJ1KiL9sgIlcboC5uArtF8r_oqS1Sco/edit?tab=t.0#heading=h.af6v74wysf4m), we decided to allow arbitrary "content-encoding" value at "fetch". We only filter such value at client side, before passing the value to resource timing.

Related PR to modify resource timing specification:
https://github.com/w3c/resource-timing/pull/411

- [ ] At least two implementers are interested (and none opposed):
Likely,  Discussed and agreed at Feb 29, 2024 [W3C WebPerf call](https://docs.google.com/document/d/1qPPCtpg1MyVw3GGmd6VKZCdCyqoDub6Xgc8ANnq8SRI/edit#heading=h.wkdzwqaypyq6), Chromium already receiving content-encoding through fetch. But not sure about other browsers.

- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
[to be updated with a new link] https://chromium-review.googlesource.com/c/chromium/src/+/5958411

- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
Chromium: https://issues.chromium.org/issues/327941462
Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1886107
WebKit: https://bugs.webkit.org/show_bug.cgi?id=271632
Deno (not for CORS changes): …
[MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed:
https://github.com/mdn/content/issues/32823

- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

Bug: https://github.com/w3c/resource-timing/issues/381


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1796.html" title="Last updated on May 22, 2025, 4:49 PM UTC (8b79c02)">Preview</a> | <a href="https://whatpr.org/fetch/1796/07662d3...8b79c02.html" title="Last updated on May 22, 2025, 4:49 PM UTC (8b79c02)">Diff</a>