### PR TITLE
Editorial: parsing application/x-www-form-urlencoded never fails

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7418,8 +7418,6 @@ running <a for=Body>consume body</a> with <a>this</a> and the following steps gi
      <li><p>Let <var>entries</var> be the result of  <a lt="urlencoded parser">parsing</a>
      <var>bytes</var>.
 
-     <li><p>If <var>entries</var> is failure, then <a>throw</a> a {{TypeError}}.
-
      <li><p>Return a new {{FormData}} object whose <a for=FormData>entry list</a> is
      <var>entries</var>.
     </ol>


### PR DESCRIPTION
Fixes #1798.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1799.html" title="Last updated on Dec 18, 2024, 7:21 AM UTC (a5fa148)">Preview</a> | <a href="https://whatpr.org/fetch/1799/c8a0408...a5fa148.html" title="Last updated on Dec 18, 2024, 7:21 AM UTC (a5fa148)">Diff</a>