### PR TITLE
Skip unnecessary checks when we have a preloaded response candidate in main fetch

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4478,23 +4478,23 @@ steps:
  <li><p>Let <var>response</var> be null.
 
  <li>
-   <p>If <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> is null:
+  <p>If <var>fetchParams</var>'s <a for="fetch params">preloaded response candidate</a> is null:
 
-   <ol>
-    <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
-    <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
-    <a>network error</a>.
+  <ol>
+   <li><p>If <var>request</var>'s <a>local-URLs-only flag</a> is set and <var>request</var>'s
+   <a for=request>current URL</a> is not <a lt="is local">local</a>, then set <var>response</var> to a
+   <a>network error</a>.
 
-    <li><p>Run <a>report Content Security Policy violations for <var>request</var></a>.
+   <li><p>Run <a>report Content Security Policy violations for <var>request</var></a>.
 
-    <li><p><a>Upgrade <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
+   <li><p><a>Upgrade <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
-    <li><p><a>Upgrade a mixed content <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
+   <li><p><a>Upgrade a mixed content <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
-    <li><p>If <a lt="block bad port">should <var>request</var> be blocked due to a bad port</a> or
-    <a lt="should request be blocked by Content Security Policy?">should <var>request</var> be blocked by Content Security Policy</a>
-    returns <b>blocked</b>, then set <var>response</var> to a <a>network error</a>.
-   </ol>
+   <li><p>If <a lt="block bad port">should <var>request</var> be blocked due to a bad port</a> or
+   <a lt="should request be blocked by Content Security Policy?">should <var>request</var> be blocked by Content Security Policy</a>
+   returns <b>blocked</b>, then set <var>response</var> to a <a>network error</a>.
+  </ol>
 
  <li><p>If
  <a lt="should fetching request be blocked as mixed content?">should fetching <var>request</var> be blocked as mixed content</a>


### PR DESCRIPTION
This PR skips checks that are not needed when we have a preloaded response candidate in the [main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch) algorithm. We talked about this offline at the last TPAC, but the main motivation behind this is to optimize reusing preloaded content where possible.

The main observable difference due to this change is that once a preload is made with a certain CSP policy, a subsequent request for the same resource will get the same response. This means that dynamically setting the CSP policy will not affect the ability to use preloaded content.

We could maybe argue the same for mixed content checks, but it seems better to respond to live changes in user preferences to block insecure content. Although, I'm open to thoughts and could see an argument either way.

This PR also skips all the irrelevant checks for clarity and ease of implementation, but another approach would be to only skip the observable checks in the spec.

@annevk @domenic Could you please take a look? Thank you!

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/50204 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1803.html" title="Last updated on Jan 22, 2025, 4:33 AM UTC (02993ff)">Preview</a> | <a href="https://whatpr.org/fetch/1803/07662d3...02993ff.html" title="Last updated on Jan 22, 2025, 4:33 AM UTC (02993ff)">Diff</a>