### PR TITLE
Added example for X-Content-Type-Options in Fetch Standard

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3975,10 +3975,20 @@ these steps:
 <p>Web developers and conformance checkers must use the following <a for=header>value</a>
 <a>ABNF</a> for `<a http-header><code>X-Content-Type-Options</code></a>`:
 
+<pre class="example" id="example-x-content-type-options">
+ // Example of using X-Content-Type-Options in a Fetch request
+ fetch("https://example.com/api/data", {
+     headers: {
+         "X-Content-Type-Options": "nosniff"
+     }
+ }).then(response => response.json())
+   .then(data => console.log(data))
+   .catch(error => console.error("Fetch error:", error));
+</pre>
+
 <pre><code class=lang-abnf>
 X-Content-Type-Options           = "nosniff" ; case-insensitive
 </code></pre>
-
 
 <div algorithm="should response to request be blocked due to nosniff">
 <h4 lt="should response to request be blocked due to nosniff" dfn id=should-response-to-request-be-blocked-due-to-nosniff?>Should


### PR DESCRIPTION
### Summary
This PR adds an example demonstrating how to use the `X-Content-Type-Options` HTTP header with the Fetch API.

### Why This Change?
- The `X-Content-Type-Options` header prevents MIME-type sniffing, improving web security.
- The Fetch Standard currently lacks a practical example for this header.
- This addition helps web developers skimming the spec to understand how to use it in real-world scenarios.

### Changes Made
- Added a `<pre class="example">` block with a Fetch API usage example.
- Assigned a unique `id="example-x-content-type-options"` for Bikeshed validation.
- Placed the example before the ABNF definition, following standard spec structure.

---

### **Checklist (N/A for This PR)**
Since this is an **editorial change**, some checklist items are **not applicable**:
- [ ] At least two implementers are interested (**N/A: Editorial Example**)
- [ ] Tests are written (**N/A: No functionality changes**)
- [ ] Implementation bugs are filed (**N/A: No browser changes**)
- [ ] MDN issue is filed (**Can be considered after PR merge**)
- [x] The commit message is clear

This PR is purely editorial, and no implementation changes are needed. Happy to adjust if maintainers have feedback! 🚀


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg-fetch/1809.html" title="Last updated on Feb 12, 2025, 5:34 AM UTC (67a4987)">Preview</a> | <a href="https://whatpr.org/fetch/1809/07662d3...67a4987.html" title="Last updated on Feb 12, 2025, 5:34 AM UTC (67a4987)">Diff</a>