### PR TITLE
Editorial: define stream variable before using it

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6243,8 +6243,10 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
   <p class="note">This represents an internal buffer inside the network layer of the user agent.
 
+ <li><p>Let <var>stream</var> be a <a>new</a> {{ReadableStream}}.
+
  <li>
-  <p>Let |pullAlgorithm| be the followings steps:
+  <p>Let |pullAlgorithm| be the following steps:
 
   <ol>
    <li><p>Let |promise| be [=a new promise=].
@@ -6278,8 +6280,6 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>cancelAlgorithm</var> be an algorithm that <a for="fetch controller">aborts</a>
  <var>fetchParams</var>'s <a for="fetch params">controller</a> with <var>reason</var>, given
  <var>reason</var>.
-
- <li><p>Let <var>stream</var> be a <a>new</a> {{ReadableStream}}.
 
  <li><p>[=ReadableStream/set up with byte reading support|Set up=] |stream| with byte reading
  support with <var>[=ReadableStream/set up/pullAlgorithm=]</var> set to |pullAlgorithm|,


### PR DESCRIPTION
*pullAlgorithm* refers to *stream*, so we should define *stream* first.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1817.html" title="Last updated on Mar 27, 2025, 12:11 PM UTC (dbdabea)">Preview</a> | <a href="https://whatpr.org/fetch/1817/07662d3...dbdabea.html" title="Last updated on Mar 27, 2025, 12:11 PM UTC (dbdabea)">Diff</a>