### PR TITLE
Improve "populate request from client" for null client cases

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4439,15 +4439,28 @@ the response. [[!HTTP-CACHING]]
 <p>To <dfn>populate request from client</dfn> given a <a for=/>request</a> <var>request</var>:
 
 <ol>
- <li><p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>", then: set
- <var>request</var>'s <a for=request>window</a> to <var>request</var>'s <a for=request>client</a>
- if <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">global object</a> is a {{Window}} object; otherwise
- "<code>no-window</code>".
+ <li>
+  <p>If <var>request</var>'s <a for=request>window</a> is "<code>client</code>":
 
- <li><p>If <var>request</var>'s <a for=request>origin</a> is "<code>client</code>", then set
- <var>request</var>'s <a for=request>origin</a> to  <var>request</var>'s <a for=request>client</a>'s
- <a for="environment settings object">origin</a>.
+  <ol>
+   <li><p>If <var>request</var>'s <a for=request>client</a> is non-null and <var>request</var>'s
+   <a for=request>client</a>'s <a for="environment settings object">global object</a> is a
+   {{Window}} object, then set <var>request</var>'s <a for=request>window</a> to
+   <var>request</var>'s <a for=request>client</a>'s
+   <a for="environment settings object">global object</a>.
+
+   <li><p>Otherwise, set <var>request</var>'s <a for=request>window</a> to "<code>no-window</code>".
+  </ol>
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>origin</a> is "<code>client</code>":
+
+  <ol>
+   <li><p><a>Assert</a>: <var>request</var>'s <a for=request>client</a> is non-null.
+
+   <li><p>Set <var>request</var>'s <a for=request>origin</a> to <var>request</var>'s
+   <a for=request>client</a>'s <a for="environment settings object">origin</a>.
+  </ol>
 
  <li>
   <p>If <var>request</var>'s <a for=request>policy container</a> is "<code>client</code>":


### PR DESCRIPTION
In particular, set request's window to "no-window". Also assert that origin is always set for such null-client cases.


Omitting the template as this is more of an obvious bug fix.

/cc @ADKaster @trflynn89 @shannonbooth as this is a supplement to https://github.com/whatwg/html/pull/11250 .