### PR TITLE
[Editorial] Shift SVCB to reference RFC9460.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -107,10 +107,7 @@ urlPrefix:https://tc39.es/ecma262/#;type:dfn;spec:ecma-262
         "title": "WebTransport over HTTP/3"
     },
     "SVCB": {
-        "authors": ["Ben Schwartz", "Mike Bishop", "Erik Nygren"],
-        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https",
-        "publisher": "IETF",
-        "title": "Service binding and parameter specification via the DNS (DNS SVCB and HTTPS RRs)"
+        "aliasOf": "RFC9460"
     }
 }
 </pre>


### PR DESCRIPTION
Rather than linking to a draft of DNS SVCB, it seems ideal to link to the published RFC now that it's available. This is an editorial change, as I don't believe there were any meaningful changes between -12 and the published RFC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1830.html" title="Last updated on May 26, 2025, 6:11 AM UTC (70d1951)">Preview</a> | <a href="https://whatpr.org/fetch/1830/97f308e...70d1951.html" title="Last updated on May 26, 2025, 6:11 AM UTC (70d1951)">Diff</a>