### PR TITLE
Remove "font" from initiator type value list

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1716,7 +1716,6 @@ processing requirements.
 "<code>early-hints</code>",
 "<code>embed</code>",
 "<code>fetch</code>",
-"<code>font</code>",
 "<code>frame</code>",
 "<code>iframe</code>",
 "<code>image</code>",


### PR DESCRIPTION
`font` is no longer a valid "initaitor type" value from resource timing (see the next comment); therefore, it's removed.

Bug: https://github.com/w3c/resource-timing/issues/364


<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
      Chrome/Edge, Firefox, and Safari all implemented "initiator type" feature.
      The test result for the test listed below can be found here:
      https://wpt.fyi/results/resource-timing/initiator-type/style.html?label=master&label=experimental&aligned&q=style.html
      Chrome/Edge and Safari all pass the test, returning "css".  Firefox fails the test, returning "other".
      In conclusion, none of them returns "font".
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/resource-timing/initiator-type/style.html;l=42;drc=1d0cf3905ce74eae85ec01cffcb5a438bb042257
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A, already implemented
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: Already completed: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType, and this PR is to reconcile the MDN, fetch spec and resource timing spec.
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

***
<a href="https://whatpr.org/fetch/1837.html" title="Last updated on Jun 26, 2025, 10:54 PM UTC (c7ad5ca)">Preview</a> | <a href="https://whatpr.org/fetch/1837/5261b51...c7ad5ca.html" title="Last updated on Jun 26, 2025, 10:54 PM UTC (c7ad5ca)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1837.html" title="Last updated on Jul 2, 2025, 5:56 PM UTC (c7ad5ca)">Preview</a> | <a href="https://whatpr.org/fetch/1837/5261b51...c7ad5ca.html" title="Last updated on Jul 2, 2025, 5:56 PM UTC (c7ad5ca)">Diff</a>