### PR TITLE
Introduce "override fetch".

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4614,7 +4614,8 @@ steps:
      <li><p>Set <var>request</var>'s
      <a for=request>response tainting</a> to "<code>basic</code>".
 
-     <li><p>Return the result of running <a>scheme fetch</a> given <var>fetchParams</var>.
+     <li><p>Return the result of running <a>override fetch</a> given "<code>scheme fetch</code>",
+     and <var>fetchParams</var>.
     </ol>
 
     <p class=note>HTML assigns any documents and workers created from <a for=/>URLs</a> whose
@@ -4633,7 +4634,8 @@ steps:
 
      <li><p>Set <var>request</var>'s <a for=request>response tainting</a> to "<code>opaque</code>".
 
-     <li><p>Return the result of running <a>scheme fetch</a> given <var>fetchParams</var>.
+     <li><p>Return the result of running <a>override fetch</a> given "<code>scheme fetch</code>"
+     and <var>fetchParams</var>.
      <!-- file URLs end up here as they are not same-origin typically. -->
     </ol>
 
@@ -4652,8 +4654,8 @@ steps:
      <a for=request>response tainting</a> to
      "<code>cors</code>".
 
-     <li><p>Let <var>corsWithPreflightResponse</var> be the result of running <a>HTTP fetch</a>
-     given <var>fetchParams</var> and true.
+     <li><p>Let <var>corsWithPreflightResponse</var> be the result of running <a>override fetch</a>
+     given "<code>HTTP fetch</code>", <var>fetchParams</var>, and true.
 
      <li><p>If <var>corsWithPreflightResponse</var> is a <a>network error</a>, then
      <a>clear cache entries</a> using <var>request</var>.
@@ -4668,7 +4670,8 @@ steps:
      <a for=request>response tainting</a> to
      "<code>cors</code>".
 
-     <li><p>Return the result of running <a>HTTP fetch</a> given <var>fetchParams</var>.
+     <li><p>Return the result of running <a>override fetch</a> given "<code>HTTP fetch</code>" and
+     <var>fetchParams</var>.
     </ol>
   </dl>
 
@@ -4986,6 +4989,96 @@ steps:
    <var>fetchParams</var>'s <a for="fetch params">task destination</a>.
   </ol>
 </ol>
+</div>
+
+
+<h3 id=override-fetch>Override fetch</h3>
+
+<div algorithm>
+<p>To <dfn id=concept-override-fetch>override fetch</dfn>, given a <var>type</var> (which is either
+"<code>scheme fetch</code>" or "<code>http fetch</code>", a <a for=/>fetch params</a>
+<var>fetchParams</var>, and an optional boolean <var>makeCORSPreflight</var> (default false):
+
+<ol>
+ <li><p>Let <var>request</var> be <var>fetchParams</var>' <a for="fetch params">request</a>.
+
+ <li><p>Let <var>response</var> be the result of executing <a>Potentially override response for a
+ request</a> on <var>request</var>.
+
+ <li><p>If <var>response</var> is not null, return <var>response</var>.
+
+ <li><p>Switch on <var>type</var> and run the associated step:
+
+  <dl class=switch>
+   <dt>"<code>scheme fetch</code>"
+   <dd>
+    <p>Set <var>response</var> be the result of running <a>scheme fetch</a> given
+    <var>fetchParams</var>.
+
+   <dt>"<code>HTTP fetch</code>"
+   <dd>
+    <p>Set <var>response</var> be the result of running <a>HTTP fetch</a> given
+    <var>fetchParams</var> and <var>makeCORSPreflight</var>.
+  </dl>
+
+ <li><p>Return <var>response</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>The <dfn id=concept-potentially-override-response>potentially override response for a
+request</dfn> algorithm takes a <a for=/>request</a> <var>request</var>, and returns either a
+<a for=/>response</a> or null. Its behavior is <a>implementation-defined</a>, allowing user
+agents to intervene on the <a for=/>request</a> by returning a response directly, or allowing the
+request to proceed by returning null.
+
+<p>By default, the algorithm has the following trivial implementation:
+
+<ol>
+ <li><p>Return null.
+</ol>
+
+<div class=note>
+ <p>User agents will generally override this default implementation with a somewhat more complex
+ set of behaviors. For example, a user agent might decide that its users' safety is best preserved
+ by generally blocking requests to `https://unsafe.example/`, while synthesizing a shim for the
+ widely-used resource `https://unsafe.example/widget.js` to avoid breakage. That implementation
+ might look like the following:
+
+ <ol>
+  <li><p>If <var>request</var>'s <a for=request>current url</a>'s <a for=url>host</a>'s
+  <a for=host>registrable domain</a> is "<code>unsafe.example</code>":
+
+  <ol>
+   <li><p>If <var>request</var>'s <a for=request>current url</a>'s <a for=url>path</a> is
+   « "<code>widget.js</code>" », then:
+
+    <ol>
+     <li><p>Let <var>body</var> be [<em>insert a byte sequence representing the shimmed
+      content here</em>].
+
+     <li><p>Return a new <a for=/>response</a> with the following properties:
+
+      <dl>
+       <dt><a for=response>type</a>
+       <dd>"<code>cors</code>"
+
+       <dt><a for=response>status</a>
+       <dd>200</dd>
+
+       <dt>...
+       <dd>...
+
+       <dt><a for=response>body</a>
+       <dd>The result of getting <var>body</var> <a>as a body</a>.
+      </dl>
+     </ol>
+
+    <li><p>Return a <a>network error</a>.
+   </ol>
+  <li><p>Return null.
+ </ol>
+</div>
 </div>
 
 


### PR DESCRIPTION
This change aims to explain how and when user agents intervene against requests in order to protect users. It introduces a few stage in Fetching, which gives user agents a clear hook after a set of prerequisite checks (MIX, CSP, etc.) are performed in Main Fetch.

This was originally proposed (and is explained in a bit more detail) in https://explainers-by-googlers.github.io/script-blocking/, and the hook's details and exact positioning were informed by the discussion in https://github.com/explainers-by-googlers/script-blocking/issues/2.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Multiple browsers ship this kind of behavior (whether in the form of Safe Browsing, tracking protection, etc). The brief discussion in https://github.com/explainers-by-googlers/script-blocking/issues/2 suggests that there's interest in standardizing the broad strokes of the behavior by providing this implementation-defined hook.

- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The exact set of resources against which user agents intervene is not (and likely cannot be) standardized. https://explainers-by-googlers.github.io/script-blocking/#testing suggests one approach to testing which might allow vendors to verify that their interventions are consistently positioned within Fetch, but that infrastructure hasn't yet been built or agreed-upon. If there's interest in doing so, I'll happily file an issue against [web-platform-tests/rfcs](https://github.com/web-platform-tests/rfcs) to discuss.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * As above, all browsers currently ship something like this. In my (limited) testing, they all seem to agree on the broad strokes of when the check happens.
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed:
   * This seems unnecessary for this change, but I'm happy to put together documentation if it's deemed helpful.
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
