### PR TITLE
Move full timing info setting outside of processResponseEndOfBody steps.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4843,16 +4843,16 @@ steps:
   <p>The user agent may decide to expose `<code>Server-Timing</code>` headers to non-secure contexts
   requests as well.
 
+ <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
+ <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
+ <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
+ <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
+
  <li>
   <p>Let <var>processResponseEndOfBody</var> be the following steps:
 
   <ol>
    <li><p>Let <var>unsafeEndTime</var> be the <a>unsafe shared current time</a>.
-
-   <li><p>If <var>fetchParams</var>'s <a for="fetch params">request</a>'s
-   <a for=request>destination</a> is "<code>document</code>", then set <var>fetchParams</var>'s
-   <a for="fetch params">controller</a>'s <a for="fetch controller">full timing info</a> to
-   <var>fetchParams</var>'s <a for="fetch params">timing info</a>.
 
    <li>
     <p>Set <var>fetchParams</var>'s <a for="fetch params">controller</a>'s


### PR DESCRIPTION
The full timing info is there for navigation timing, which is already available at document creation (which happens right after the handover).

This is a spec bug, while implementations/WPT test the right behavior.


- [x] At least two implementers are interested (and none opposed):
   Already implemented
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/navigation-timing/nav2-test-instance-accessible-from-the-start.html?label=experimental&label=master&aligned
- [x [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A
- [x [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1842.html" title="Last updated on Jul 15, 2025, 7:20 PM UTC (dae71a0)">Preview</a> | <a href="https://whatpr.org/fetch/1842/5261b51...dae71a0.html" title="Last updated on Jul 15, 2025, 7:20 PM UTC (dae71a0)">Diff</a>