### PR TITLE
Build a bridge for "cookie default path"

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -58,6 +58,7 @@ urlPrefix:https://tc39.es/ecma262/#;type:dfn;spec:ecma-262
     url:current-realm;text:current realm
 
 urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cookies#;type:dfn;spec:cookies
+    url:name-cookie-default-path;text:cookie default path
     url:name-cookie-store-and-limits;text:cookie store
     url:name-parse-and-store-a-cookie;text:parse and store a cookie
     url:name-parse-a-cookie;text:parse a cookie
@@ -3498,6 +3499,20 @@ them conveniently here. [[COOKIES]].
  return "<code>unset-or-less</code>".
 
  <li><p>Return "<code>strict-or-less</code>".
+</ol>
+</div>
+
+<div algorithm>
+<p>To obtain a <dfn export>serialized cookie default path</dfn> given a <a for=/>URL</a>
+<var>url</var>:
+
+<ol>
+ <li><p>Let <var>cloneURL</var> be a clone of <var>url</var>.
+
+ <li><p>Set <var>cloneURL</var>'s <a for=url>path</a> to the <a>cookie default path</a> of
+ <var>cloneURL</var>'s <a for=url>path</a>.
+
+ <li><p>Return the <a lt="URL path serializer">URL path serialization</a> of <var>cloneURL</var>.
 </ol>
 </div>
 


### PR DESCRIPTION
This is needed to properly solve https://github.com/whatwg/cookiestore/issues/242. https://github.com/httpwg/http-extensions/issues/3194 has been filed to eventually document this dependency.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1848.html" title="Last updated on Aug 12, 2025, 3:15 PM UTC (796180e)">Preview</a> | <a href="https://whatpr.org/fetch/1848/d8d820b...796180e.html" title="Last updated on Aug 12, 2025, 3:15 PM UTC (796180e)">Diff</a>