### PR TITLE
WebDriver BiDi emulated user-agent

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5889,6 +5889,21 @@ run these steps:
    the <a data-lt="structured field token">token</a> <code>prefetch</code>) in
    <var>httpRequest</var>'s <a for=request>header list</a>.
 
+   <li>
+    <p>If <var>httpRequest</var>'s <a for=request>header list</a> <a for="header list">does not
+    contain</a> `<code>User-Agent</code>`, then:
+
+    <ol>
+     <li><p>Let <var>userAgent</var> be the result of running the [=WebDriver BiDi emulated
+     User-Agent=] with <var>httpRequest</var>'s <a for=request>client</a>.
+
+     <li><p>If <var>userAgent</var> is null, set <var>userAgent</var> to <a>default
+     `<code>User-Agent</code>` value</a>.
+
+     <li><p><a for="header list">Append</a> (`<code>User-Agent</code>`, <var>userAgent</var>) to
+     <var>httpRequest</var>'s <a for=request>header list</a>.
+    </ol>
+
    <li><p>If <var>httpRequest</var>'s <a for=request>header list</a>
    <a for="header list">does not contain</a> `<code>User-Agent</code>`, then user agents should
    <a for="header list">append</a> (`<code>User-Agent</code>`,


### PR DESCRIPTION
Support for user-agent emulations. WebDriver BiDi specification: https://github.com/w3c/webdriver-bidi/pull/947

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
