### PR TITLE
Add support for compression dictionary transport

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -82,9 +82,7 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
         "aliasOf": "RFC9111"
     },
     "HTTP-COMPRESSION-DICTIONARIES": {
-        "authors": ["Patrick Meenan", "Yoav Weiss"],
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/",
-        "title": "Compression Dictionary Transport"
+        "aliasOf": "RFC9842"
     },
     "HTTP1": {
         "aliasOf": "RFC9112"

--- a/fetch.bs
+++ b/fetch.bs
@@ -6582,8 +6582,14 @@ run these steps:
    <li><p>Let <var>compressionDictionaryCache</var> be the result of
    <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 
-   <li><p>If <var>compressionDictionaryCache</var> is null or <var>request</var>'s
-   <a for=request>response tainting</a> is "<code>opaque</code>", then return <var>response</var>.
+   <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
+
+   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+   <a for=response>header list</a>.
+
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
+   <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
    <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
 
@@ -6651,7 +6657,12 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
+ <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+ `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+ <a for=response>header list</a>.
+
+ <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>" and
+ <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return a
  <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -6638,8 +6638,34 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>Return the result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
- <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
+ <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
+ `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`, then
+ return <var>response</var>.
+
+ <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
+ <a>network error</a>.
+
+ <li><p>Let <var>availableDictionaryHash</var> be the result of <a>getting a structured field value</a>
+ given `<code>Available-Dictionary</code>`, "<code>bytestring</code>", and <var>request</var>'s
+ <a for=request>header list</a>.
+
+ <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the result
+ of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> with an
+ algorithm that verifies that the dictionary hash in the stream matches
+ <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
+ algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
+ the transformed stream must error.
+
+ <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
+
+ <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>Return <var>response</var>.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2314,14 +2314,9 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
-<p>A <a for=/>request</a> has an associated
-<dfn export for=request id=compression-dictionary-disallowed>compression dictionary disallowed flag</dfn>.
-Unless stated otherwise, it is unset.
-
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
-<a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
-<a for=request>compression dictionary disallowed flag</a> are used as
+<a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -5022,18 +5017,6 @@ steps:
     </ol>
   </dl>
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
- then:
-
- <ol>
-   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
-   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
-   <a for=response>header list</a>.
-
-   <li><p>If <var>corpPolicy</var> is not `<code>cross-origin</code>`, then set
-   <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>.
- </ol>
-
  <li><p>If <var>recursive</var> is true, then return <var>response</var>.
 
  <li>
@@ -6577,7 +6560,7 @@ run these steps:
  <var>request</var> and the given realm.
 
  <li>
-  <p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a> is not set
+  <p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>opaque</code>"
   and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
   `<code>Use-As-Dictionary</code>`:
   <!-- This is defined in [[!RFC9842]] -->
@@ -6669,8 +6652,8 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>
- is set, then return a <a>network error</a>.
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+ then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -1770,7 +1770,6 @@ processing requirements.
 "<code>audio</code>",
 "<code>beacon</code>",
 "<code>body</code>",
-"<code>compression-dictionary</code>",
 "<code>css</code>",
 "<code>early-hints</code>",
 "<code>embed</code>",
@@ -1978,7 +1977,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>compression-dictionary</code>"
    <td>"<code>compression-dictionary</code>"
-   <td><code>default-src</code> (no specific directive)
+   <td><code>default-src</code>
    <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
@@ -3333,6 +3332,22 @@ or an <a>implementation-defined</a> value.
  <li><p>If <var>key</var> is null, then return null.
 
  <li><p>Return the unique HTTP cache associated with <var>key</var>. [[!HTTP-CACHING]]
+</ol>
+</div>
+
+
+<h3 id=compression-dictionary-cache-partitions>Compression-dictionary cache partitions</h3>
+
+<div algorithm>
+<p>To <dfn>determine the compression-dictionary cache partition</dfn>, given a <a for=/>request</a> <var>request</var>:
+
+<ol>
+ <li><p>Let <var>key</var> be the result of <a for=request>determining the network partition key</a>
+ given <var>request</var>.
+
+ <li><p>If <var>key</var> is null, then return null.
+
+ <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!HTTP-COMPRESSION-DICTIONARIES]]
 </ol>
 </div>
 
@@ -6544,6 +6559,40 @@ run these steps:
 
  <li><p>If <var>isAuthenticationFetch</var> is true, then create an <a>authentication entry</a> for
  <var>request</var> and the given realm.
+
+ <li>
+  <p>If <var>response</var>'s <a for=response>header list</a>
+  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`, then:
+  <!-- This is defined in [[!HTTP-COMPRESSION-DICTIONARIES]] -->
+
+  <ol>
+   <li><p>Let <var>dictionaryValue</var> be the result of
+   <a for="header list">getting a structured field value</a> given `<code>Use-As-Dictionary</code>`,
+   "<code>dictionary</code>", and <var>response</var>'s <a for=response>header list</a>.
+
+   <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
+   does not <a for=map>exist</a>, then return <var>response</var>.
+
+   <li><p>Let <var>pattern</var> be the result of creating a URL pattern from
+   <var>dictionaryValue</var>["<code>match</code>"] and <var>request</var>'s
+   <a for=request>current URL</a>.
+
+   <li><p>If <var>pattern</var> is failure or <var>pattern</var> has regexp groups, then return
+   <var>response</var>.
+
+   <li><p>Let <var>compressionDictionaryCache</var> be the result of
+   <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
+
+   <li><p>If <var>compressionDictionaryCache</var> is null or <var>request</var>'s
+   <a for=request>response tainting</a> is "<code>opaque</code>", then return <var>response</var>.
+
+   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
+
+   <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
+
+   <li><p>Store <var>response</var> in <var>compressionDictionaryCache</var> with its associated
+   <var>dictionaryValue</var> and <var>expirationTime</var>.
+  </ol>
 
  <li><p>Return <var>response</var>. <span class=note>Typically <var>response</var>'s
  <a for=response>body</a>'s <a for=body>stream</a> is still being enqueued to after

--- a/fetch.bs
+++ b/fetch.bs
@@ -6410,8 +6410,9 @@ run these steps:
    <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is
    "<code>only-if-cached</code>", then return a <a>network error</a>.
 
-   <li><p>Let <var>forwardResponse</var> be the result of running <a>HTTP-network fetch</a> given
-   <var>httpFetchParams</var>, <var>includeCredentials</var>, and <var>isNewConnectionFetch</var>.
+   <li><p>Let <var>forwardResponse</var> be the result of running
+   <a>HTTP-network compression-dictionary fetch</a> given <var>httpFetchParams</var>,
+   <var>includeCredentials</var>, and <var>isNewConnectionFetch</var>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>method</a> is <a>unsafe</a> and
    <var>forwardResponse</var>'s <a for=response>status</a> is in the range 200 to 399, inclusive,
@@ -6600,6 +6601,47 @@ run these steps:
 </ol>
 </div>
 
+<h3 id=http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</h3>
+
+<div algorithm>
+<p>To <dfn>HTTP-network compression-dictionary fetch</dfn>, given a <a for=/>fetch params</a>
+<var>fetchParams</var>, an optional boolean <var>includeCredentials</var> (default false), and an
+optional boolean <var>forceNewConnection</var> (default false), run these steps:
+
+<ol>
+ <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
+
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the result of
+ running <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
+ <var>forceNewConnection</var>.
+
+ <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
+ result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Let <var>compressionDictionaryCache</var> be the result of
+ <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
+
+ <li><p>If <var>compressionDictionaryCache</var> is null, then return the result of running
+ <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
+ <var>forceNewConnection</var>.
+
+ <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
+ <var>compressionDictionaryCache</var> for <var>request</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+
+ <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
+ given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>` (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+
+ <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`) in <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p>Return the result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+</ol>
+</div>
 
 <h3 id=http-network-fetch>HTTP-network fetch</h3>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -81,9 +81,6 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
     "HTTP-CACHING": {
         "aliasOf": "RFC9111"
     },
-    "HTTP-COMPRESSION-DICTIONARIES": {
-        "aliasOf": "RFC9842"
-    },
     "HTTP1": {
         "aliasOf": "RFC9112"
     },
@@ -3345,7 +3342,7 @@ or an <a>implementation-defined</a> value.
 
  <li><p>If <var>key</var> is null, then return null.
 
- <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!HTTP-COMPRESSION-DICTIONARIES]]
+ <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!RFC9842]]
 </ol>
 </div>
 
@@ -6561,8 +6558,8 @@ run these steps:
 
  <li>
   <p>If <var>response</var>'s <a for=response>header list</a>
-  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`, then:
-  <!-- This is defined in [[!HTTP-COMPRESSION-DICTIONARIES]] -->
+  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`:
+  <!-- This is defined in [[!RFC9842]] -->
 
   <ol>
    <li><p>Let <var>dictionaryValue</var> be the result of
@@ -6596,7 +6593,7 @@ run these steps:
    <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
 
    <li><p>Store <var>response</var> in <var>compressionDictionaryCache</var> with its associated
-   <var>dictionaryValue</var> and <var>expirationTime</var>.
+   <var>pattern</var>, <var>dictionaryValue</var> and <var>expirationTime</var>.
   </ol>
 
  <li><p>Return <var>response</var>. <span class=note>Typically <var>response</var>'s
@@ -6633,14 +6630,14 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
 
  <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
  <var>compressionDictionaryCache</var> for <var>request</var> as defined in
- [[!HTTP-COMPRESSION-DICTIONARIES]].
+ [[!RFC9842]].
 
  <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
  given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
  <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>`
  (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
- [[!HTTP-COMPRESSION-DICTIONARIES]].
+ [[!RFC9842]].
 
  <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
  in <var>request</var>'s <a for=request>header list</a>.
@@ -6673,7 +6670,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
  with an algorithm that verifies that the dictionary hash in the stream matches
  <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
- algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
+ algorithm as defined in [[!RFC9842]]. If verification or decoding fails,
  the transformed stream must error.
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
@@ -6755,7 +6752,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-CACHING]]
-     [[!HTTP-COMPRESSION-DICTIONARIES]]
+     [[!RFC9842]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -66,6 +66,11 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
     url:name-retrieve-cookies;text:retrieve cookies
     url:name-serialize-cookies;text:serialize cookies
     url:name-garbage-collect-cookies;text:garbage collect cookies
+
+urlPrefix:https://urlpattern.spec.whatwg.org/#;type:dfn;spec:urlpattern
+    url:url-pattern-create;text:creating a URL pattern
+    url:url-pattern-has-regexp-groups;text:has regexp groups
+
 </pre>
 
 <pre class=biblio>
@@ -1804,7 +1809,6 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
-"<code>compression-dictionary</code>",
 "<code>download</code>",
 "<code>imageset</code>",
 "<code>manifest</code>",
@@ -1971,8 +1975,7 @@ not always relevant and might require different behavior.
    <td>HTML's <code>&lt;video></code> element
   <tr>
    <td>"<code>compression-dictionary</code>"
-   <td>"<code>compression-dictionary</code>"
-   <td><code>default-src</code>
+   <td><code>connect-src</code>
    <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
@@ -2299,6 +2302,11 @@ Unless stated otherwise, it is zero.
 <dfn export for=request id=concept-request-response-tainting>response tainting</dfn>,
 which is "<code>basic</code>", "<code>cors</code>", or "<code>opaque</code>".
 Unless stated otherwise, it is "<code>basic</code>".
+
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-corp-tainting>corp tainting</dfn>,
+which is "<code>allowed</code>", or "<code>blocked</code>".
+Unless stated otherwise, it is "<code>allowed</code>".
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=no-cache-prevent-cache-control>prevent no-cache cache-control header modification flag</dfn>.
@@ -6569,17 +6577,17 @@ run these steps:
    <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
    does not <a for=map>exist</a>, then return <var>response</var>.
 
-   <li><p>Let <var>pattern</var> be the result of creating a URL pattern from
-   <var>dictionaryValue</var>["<code>match</code>"] and <var>request</var>'s
-   <a for=request>current URL</a>.
-
-   <li><p>If <var>pattern</var> is failure or <var>pattern</var> has regexp groups, then return
-   <var>response</var>.
-
    <li><p>Let <var>compressionDictionaryCache</var> be the result of
    <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 
    <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
+
+   <li><p>Let <var>pattern</var> be the result of
+   <a for=/>creating a URL pattern</a> from <var>dictionaryValue</var>["<code>match</code>"]
+   and <var>request</var>'s <a for=request>current URL</a>.
+
+   <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
+   then return <var>response</var>.
 
    <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
    `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
@@ -6588,7 +6596,8 @@ run these steps:
    <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
    <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
-   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
+   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes
+   a <a>stale response</a>.
 
    <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -81,6 +81,11 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
     "HTTP-CACHING": {
         "aliasOf": "RFC9111"
     },
+    "HTTP-COMPRESSION-DICTIONARIES": {
+        "authors": ["Patrick Meenan", "Yoav Weiss"],
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/",
+        "title": "Compression Dictionary Transport"
+    },
     "HTTP1": {
         "aliasOf": "RFC9112"
     },
@@ -1765,6 +1770,7 @@ processing requirements.
 "<code>audio</code>",
 "<code>beacon</code>",
 "<code>body</code>",
+"<code>compression-dictionary</code>",
 "<code>css</code>",
 "<code>early-hints</code>",
 "<code>embed</code>",
@@ -1804,6 +1810,7 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
+"<code>compression-dictionary</code>",
 "<code>download</code>",
 "<code>imageset</code>",
 "<code>manifest</code>",
@@ -1818,6 +1825,7 @@ device to assist defining CSP and Mixed Content. It is not exposed to JavaScript
 <p>A <dfn export>destination type</dfn> is one of:
 the empty string,
 "<code>audio</code>",
+"<code>compression-dictionary</code>",
 "<code>audioworklet</code>",
 "<code>document</code>",
 "<code>embed</code>",
@@ -1967,6 +1975,11 @@ not always relevant and might require different behavior.
    <td>"<code>video</code>"
    <td><code>media-src</code>
    <td>HTML's <code>&lt;video></code> element
+  <tr>
+   <td>"<code>compression-dictionary</code>"
+   <td>"<code>compression-dictionary</code>"
+   <td><code>default-src</code> (no specific directive)
+   <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
    <td>""
@@ -2323,9 +2336,10 @@ When a request is [=request/cloned=], the created request gets a unique
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworklet</code>",
-"<code>font</code>", "<code>image</code>", "<code>json</code>", "<code>manifest</code>",
-"<code>paintworklet</code>", "<code>script</code>", "<code>style</code>", "<code>text</code>",
-"<code>track</code>", "<code>video</code>", "<code>xslt</code>", or the empty string.
+"<code>compression-dictionary</code>", "<code>font</code>", "<code>image</code>",
+"<code>json</code>", "<code>manifest</code>", "<code>paintworklet</code>", "<code>script</code>",
+"<code>style</code>", "<code>text</code>", "<code>track</code>", "<code>video</code>",
+"<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>non-subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>document</code>", "<code>embed</code>",
@@ -6608,6 +6622,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-CACHING]]
+     [[!HTTP-COMPRESSION-DICTIONARIES]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
@@ -8473,7 +8488,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "compression-dictionary", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -2304,11 +2304,6 @@ which is "<code>basic</code>", "<code>cors</code>", or "<code>opaque</code>".
 Unless stated otherwise, it is "<code>basic</code>".
 
 <p>A <a for=/>request</a> has an associated
-<dfn export for=request id=concept-request-corp-tainting>corp tainting</dfn>,
-which is "<code>allowed</code>", or "<code>blocked</code>".
-Unless stated otherwise, it is "<code>allowed</code>".
-
-<p>A <a for=/>request</a> has an associated
 <dfn export for=request id=no-cache-prevent-cache-control>prevent no-cache cache-control header modification flag</dfn>.
 Unless stated otherwise, it is unset.
 
@@ -2319,9 +2314,14 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=compression-dictionary-disallowed>compression dictionary disallowed flag</dfn>.
+Unless stated otherwise, it is unset.
+
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
-<a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
+<a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
+<a for=request>compression dictionary disallowed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -5022,6 +5022,18 @@ steps:
     </ol>
   </dl>
 
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+ then:
+
+ <ol>
+   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+   <a for=response>header list</a>.
+
+   <li><p>If <var>corpPolicy</var> is not `<code>cross-origin</code>`, then set
+   <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>.
+ </ol>
+
  <li><p>If <var>recursive</var> is true, then return <var>response</var>.
 
  <li>
@@ -6565,8 +6577,9 @@ run these steps:
  <var>request</var> and the given realm.
 
  <li>
-  <p>If <var>response</var>'s <a for=response>header list</a>
-  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`:
+  <p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a> is not set
+  and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
+  `<code>Use-As-Dictionary</code>`:
   <!-- This is defined in [[!RFC9842]] -->
 
   <ol>
@@ -6588,13 +6601,6 @@ run these steps:
 
    <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
    then return <var>response</var>.
-
-   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
-   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
-   <a for=response>header list</a>.
-
-   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
-   <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
    <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes
    a <a>stale response</a>.
@@ -6663,13 +6669,8 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
- `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
- <a for=response>header list</a>.
-
- <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>" and
- <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return a
- <a>network error</a>.
+ <li><p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>
+ is set, then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -6579,8 +6579,9 @@ run these steps:
    <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
 
    <li><p>Let <var>pattern</var> be the result of
-   <a for=/>creating a URL pattern</a> from <var>dictionaryValue</var>["<code>match</code>"]
-   and <var>request</var>'s <a for=request>current URL</a>.
+   <a for=/>creating a URL pattern</a> given the bare item of <var>dictionaryValue</var>["<code>match</code>"],
+   the <a lt="URL serializer">serialization</a> of <var>request</var>'s <a for=request>current URL</a>,
+   and an empty map.
 
    <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
    then return <var>response</var>.
@@ -6655,9 +6656,13 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
  then return a <a>network error</a>.
 
- <li><p>Let <var>availableDictionaryHash</var> be the result of
+ <li><p>Let <var>availableDictionaryItem</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,
- "<code>bytestring</code>", and <var>request</var>'s <a for=request>header list</a>.
+ "<code>item</code>", and <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p>If <var>availableDictionaryItem</var> is null, then return a <a>network error</a>.
+
+ <li><p>Let <var>availableDictionaryHash</var> be the bare item of <var>availableDictionaryItem</var>.
 
  <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the
  result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -6604,16 +6604,17 @@ run these steps:
 <h3 id=http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</h3>
 
 <div algorithm>
-<p>To <dfn>HTTP-network compression-dictionary fetch</dfn>, given a <a for=/>fetch params</a>
-<var>fetchParams</var>, an optional boolean <var>includeCredentials</var> (default false), and an
-optional boolean <var>forceNewConnection</var> (default false), run these steps:
+<p>To <dfn id=concept-http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</dfn>,
+given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
+<var>includeCredentials</var> (default false), and an optional boolean <var>forceNewConnection</var>
+(default false), run these steps:
 
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
- <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the result of
- running <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
- <var>forceNewConnection</var>.
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the
+ result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
  <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
  result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
@@ -6627,16 +6628,21 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <var>forceNewConnection</var>.
 
  <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
- <var>compressionDictionaryCache</var> for <var>request</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+ <var>compressionDictionaryCache</var> for <var>request</var> as defined in
+ [[!HTTP-COMPRESSION-DICTIONARIES]].
 
  <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
  given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
- <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>` (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+ <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>`
+ (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
+ [[!HTTP-COMPRESSION-DICTIONARIES]].
 
- <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`) in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
+ in <var>request</var>'s <a for=request>header list</a>.
 
- <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`)
+ in <var>request</var>'s <a for=request>header list</a>.
 
  <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
  <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
@@ -6644,26 +6650,27 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
  `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
- <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`, then
- return <var>response</var>.
+ <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
+ then return <var>response</var>.
 
  <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
  <a>network error</a>.
 
- <li><p>Let <var>availableDictionaryHash</var> be the result of <a>getting a structured field value</a>
- given `<code>Available-Dictionary</code>`, "<code>bytestring</code>", and <var>request</var>'s
- <a for=request>header list</a>.
+ <li><p>Let <var>availableDictionaryHash</var> be the result of
+ <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,
+ "<code>bytestring</code>", and <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the result
- of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> with an
- algorithm that verifies that the dictionary hash in the stream matches
+ <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the
+ result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+ with an algorithm that verifies that the dictionary hash in the stream matches
  <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
  algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
  the transformed stream must error.
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
 
- <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s <a for=response>header list</a>.
+ <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s
+ <a for=response>header list</a>.
 
  <li><p>Return <var>response</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1881,7 +1881,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=22>""
+   <td rowspan=23>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.

--- a/fetch.bs
+++ b/fetch.bs
@@ -84,6 +84,11 @@ urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
     "HTTP-CACHING": {
         "aliasOf": "RFC9111"
     },
+    "HTTP-COMPRESSION-DICTIONARIES": {
+        "authors": ["Patrick Meenan", "Yoav Weiss"],
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/",
+        "title": "Compression Dictionary Transport"
+    },
     "HTTP1": {
         "aliasOf": "RFC9112"
     },
@@ -1768,6 +1773,7 @@ processing requirements.
 "<code>audio</code>",
 "<code>beacon</code>",
 "<code>body</code>",
+"<code>compression-dictionary</code>",
 "<code>css</code>",
 "<code>early-hints</code>",
 "<code>embed</code>",
@@ -1807,6 +1813,7 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
+"<code>compression-dictionary</code>",
 "<code>download</code>",
 "<code>imageset</code>",
 "<code>manifest</code>",
@@ -1821,6 +1828,7 @@ device to assist defining CSP and Mixed Content. It is not exposed to JavaScript
 <p>A <dfn export>destination type</dfn> is one of:
 the empty string,
 "<code>audio</code>",
+"<code>compression-dictionary</code>",
 "<code>audioworklet</code>",
 "<code>document</code>",
 "<code>embed</code>",
@@ -1970,6 +1978,11 @@ not always relevant and might require different behavior.
    <td>"<code>video</code>"
    <td><code>media-src</code>
    <td>HTML's <code>&lt;video></code> element
+  <tr>
+   <td>"<code>compression-dictionary</code>"
+   <td>"<code>compression-dictionary</code>"
+   <td><code>default-src</code> (no specific directive)
+   <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
    <td>""
@@ -2326,9 +2339,10 @@ When a request is [=request/cloned=], the created request gets a unique
 
 <p>A <dfn export>subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>audio</code>", "<code>audioworklet</code>",
-"<code>font</code>", "<code>image</code>", "<code>json</code>", "<code>manifest</code>",
-"<code>paintworklet</code>", "<code>script</code>", "<code>style</code>", "<code>text</code>",
-"<code>track</code>", "<code>video</code>", "<code>xslt</code>", or the empty string.
+"<code>compression-dictionary</code>", "<code>font</code>", "<code>image</code>",
+"<code>json</code>", "<code>manifest</code>", "<code>paintworklet</code>", "<code>script</code>",
+"<code>style</code>", "<code>text</code>", "<code>track</code>", "<code>video</code>",
+"<code>xslt</code>", or the empty string.
 
 <p>A <dfn export>non-subresource request</dfn> is a <a for=/>request</a>
 whose <a for=request>destination</a> is "<code>document</code>", "<code>embed</code>",
@@ -6662,6 +6676,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-CACHING]]
+     [[!HTTP-COMPRESSION-DICTIONARIES]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s
@@ -8568,7 +8583,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "compression-dictionary", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -6621,8 +6621,9 @@ run these steps:
  <var>request</var> and the given realm.
 
  <li>
-  <p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>opaque</code>"
-  and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
+  <p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>opaque</code>",
+  <var>request</var>'s <a for=request>client</a> is a <a>secure context</a>, and
+  <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
   <a><code>Use-As-Dictionary</code></a>:
   <!-- This is defined in [[!RFC9842]] -->
 
@@ -6706,6 +6707,9 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  result of running <var>fallback</var>.
 
  <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
+ result of running <var>fallback</var>.
+
+ <li><p>If <var>request</var>'s <a for=request>client</a> is not a <a>secure context</a>, then return the
  result of running <var>fallback</var>.
 
  <li><p>Let <var>compressionDictionaryCache</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -16,6 +16,12 @@ Translate IDs: typedefdef-bodyinit bodyinit,dictdef-requestinit requestinit,type
 urlPrefix:https://httpwg.org/specs/rfc5861.html#;type:dfn;spec:stale-while-revalidate
     url:n-the-stale-while-revalidate-cache-control-extension;text:stale-while-revalidate lifetime
 
+urlPrefix:https://httpwg.org/specs/rfc9842.html#;type:dfn;spec:rfc9842
+    url:use-as-dictionary;text:Use-As-Dictionary
+    url:available-dictionary;text:Available-Dictionary
+    url:dictionary-id;text:Dictionary-ID
+    url:rfc.section.2.2;text:finding the best matching dictionary
+
 urlPrefix:https://httpwg.org/specs/rfc9651.html#;type:dfn;spec:rfc9651
     url:rfc.section.2;text:structured field value
     url:text-serialize;text:serializing structured fields
@@ -6617,12 +6623,12 @@ run these steps:
  <li>
   <p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>opaque</code>"
   and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
-  `<code>Use-As-Dictionary</code>`:
+  <a><code>Use-As-Dictionary</code></a>:
   <!-- This is defined in [[!RFC9842]] -->
 
   <ol>
    <li><p>Let <var>dictionaryValue</var> be the result of
-   <a for="header list">getting a structured field value</a> given `<code>Use-As-Dictionary</code>`,
+   <a for="header list">getting a structured field value</a> given <a><code>Use-As-Dictionary</code></a>,
    "<code>dictionary</code>", and <var>response</var>'s <a for=response>header list</a>.
 
    <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
@@ -6708,14 +6714,13 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>compressionDictionaryCache</var> is null, then return the result of running
  <var>fallback</var>.
 
- <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
- <var>compressionDictionaryCache</var> for <var>request</var> as defined in
- [[!RFC9842]] section 2.2.
+ <li><p>Let <var>bestMatch</var> be the result of <a>finding the best matching dictionary</a> in
+ <var>compressionDictionaryCache</var> for <var>request</var>.
 
  <li><p>If <var>bestMatch</var> is null, then return the result of running <var>fallback</var>.
 
- <li><p>Add the `<code>Available-Dictionary</code>` ([[!RFC9842]] section 2.2) and `<code>Dictionary-ID</code>`
- ([[!RFC9842]] section 2.3) (if applicable) headers to <var>request</var> using <var>bestMatch</var>.
+ <li><p>Add the <a><code>Available-Dictionary</code></a> and <a><code>Dictionary-ID</code></a>
+ (if applicable) headers to <var>request</var> using <var>bestMatch</var>.
 
  <li><p><a for="header list">append</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
  to <var>request</var>'s <a for=request>header list</a>.
@@ -6735,7 +6740,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryItem</var> be the result of
- <a for="header list">getting a structured field value</a> given `<code>Available-Dictionary</code>`,
+ <a for="header list">getting a structured field value</a> given <a><code>Available-Dictionary</code></a>,
  "<code>item</code>", and <var>request</var>'s <a for=request>header list</a>.
 
  <li><p>If <var>availableDictionaryItem</var> is null, then return a <a>network error</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2317,14 +2317,9 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
-<p>A <a for=/>request</a> has an associated
-<dfn export for=request id=compression-dictionary-disallowed>compression dictionary disallowed flag</dfn>.
-Unless stated otherwise, it is unset.
-
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
-<a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
-<a for=request>compression dictionary disallowed flag</a> are used as
+<a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -5076,18 +5071,6 @@ steps:
     </ol>
   </dl>
 
- <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
- then:
-
- <ol>
-   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
-   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
-   <a for=response>header list</a>.
-
-   <li><p>If <var>corpPolicy</var> is not `<code>cross-origin</code>`, then set
-   <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>.
- </ol>
-
  <li><p>If <var>recursive</var> is true, then return <var>response</var>.
 
  <li>
@@ -6631,7 +6614,7 @@ run these steps:
  <var>request</var> and the given realm.
 
  <li>
-  <p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a> is not set
+  <p>If <var>request</var>'s <a for=request>response tainting</a> is not "<code>opaque</code>"
   and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
   `<code>Use-As-Dictionary</code>`:
   <!-- This is defined in [[!RFC9842]] -->
@@ -6723,8 +6706,8 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>
- is set, then return a <a>network error</a>.
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+ then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -22,6 +22,7 @@ urlPrefix:https://httpwg.org/specs/rfc9651.html#;type:dfn;spec:rfc9651
     url:text-parse;text:parsing structured fields
     url:;text:structured header
     url:token;text:structured field token
+    url:parse-bare-item;text:bare item
 
 urlPrefix:https://httpwg.org/specs/rfc9110.html#;type:dfn;spec:http
     url:method.overview;text:method
@@ -6633,7 +6634,7 @@ run these steps:
    <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
 
    <li><p>Let <var>pattern</var> be the result of
-   <a for=/>creating a URL pattern</a> given the bare item of <var>dictionaryValue</var>["<code>match</code>"],
+   <a for=/>creating a URL pattern</a> given the <a>bare item</a> of <var>dictionaryValue</var>["<code>match</code>"],
    the <a lt="URL serializer">serialization</a> of <var>request</var>'s <a for=request>current URL</a>,
    and an empty map.
 
@@ -6666,31 +6667,34 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
+ <li>
+  <p>Let <var>fallback</var> be the following steps:
+
+  <ol>
+   <li><p>Return the result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+   <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+  </ol>
+
  <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the
- result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
- <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ result of running <var>fallback</var>.
 
  <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
- result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
- <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ result of running <var>fallback</var>.
 
  <li><p>Let <var>compressionDictionaryCache</var> be the result of
  <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 
  <li><p>If <var>compressionDictionaryCache</var> is null, then return the result of running
- <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
- <var>forceNewConnection</var>.
+ <var>fallback</var>.
 
  <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
  <var>compressionDictionaryCache</var> for <var>request</var> as defined in
- [[!RFC9842]].
+ [[!RFC9842]] section 2.2.
 
- <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
- given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ <li><p>If <var>bestMatch</var> is null, then return the result of running <var>fallback</var>.
 
- <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>`
- (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
- [[!RFC9842]].
+ <li><p>Add the `<code>Available-Dictionary</code>` ([[!RFC9842]] section 2.2) and `<code>Dictionary-ID</code>`
+ ([[!RFC9842]] section 2.3) (if applicable) headers to <var>request</var> using <var>bestMatch</var>.
 
  <li><p><a for="header list">append</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
  to <var>request</var>'s <a for=request>header list</a>.
@@ -6698,8 +6702,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p><a for="header list">append</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`)
  to <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
- <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ <li><p>Let <var>response</var> be the result of running <var>fallback</var>.
 
  <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
  `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
@@ -6716,7 +6719,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
 
  <li><p>If <var>availableDictionaryItem</var> is null, then return a <a>network error</a>.
 
- <li><p>Let <var>availableDictionaryHash</var> be the bare item of <var>availableDictionaryItem</var>.
+ <li><p>Let <var>availableDictionaryHash</var> be the <a>bare item</a> of <var>availableDictionaryItem</var>.
 
  <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the
  result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -6628,6 +6628,27 @@ run these steps:
    <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
    does not <a for=map>exist</a>, then return <var>response</var>.
 
+   <li><p>If <var>dictionaryValue</var>["<code>type</code>"] <a for=map>exists</a> and its
+   <a>bare item</a> is not an <a>implementation-defined</a> supported dictionary type, then return
+   <var>response</var>.
+
+   <li><p>If <var>dictionaryValue</var>["<code>id</code>"] <a for=map>exists</a> and its
+   <a>bare item</a>'s <a for=string>length</a> is greater than 1024, then <a for=map>remove</a>
+   <var>dictionaryValue</var>["<code>id</code>"].
+
+   <li>
+    <p>If <var>dictionaryValue</var>["<code>match-dest</code>"] <a for=map>exists</a>:
+
+    <ol>
+     <li><p>Let <var>matchDestList</var> be <var>dictionaryValue</var>["<code>match-dest</code>"][0].
+
+     <li><p>For each <var>dest</var> of <var>matchDestList</var>: if <var>dest</var>'s <a>bare item</a>
+     is not a <a for=request>destination</a> supported by the user agent, then remove <var>dest</var>
+     from <var>matchDestList</var>.
+
+     <li><p>If <var>matchDestList</var> is empty, then return <var>response</var>.
+    </ol>
+
    <li><p>Let <var>compressionDictionaryCache</var> be the result of
    <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6692,8 +6692,34 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>Return the result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
- <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+ <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
+ <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
+ `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`, then
+ return <var>response</var>.
+
+ <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
+ <a>network error</a>.
+
+ <li><p>Let <var>availableDictionaryHash</var> be the result of <a>getting a structured field value</a>
+ given `<code>Available-Dictionary</code>`, "<code>bytestring</code>", and <var>request</var>'s
+ <a for=request>header list</a>.
+
+ <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the result
+ of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> with an
+ algorithm that verifies that the dictionary hash in the stream matches
+ <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
+ algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
+ the transformed stream must error.
+
+ <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
+
+ <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>Return <var>response</var>.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -1773,7 +1773,6 @@ processing requirements.
 "<code>audio</code>",
 "<code>beacon</code>",
 "<code>body</code>",
-"<code>compression-dictionary</code>",
 "<code>css</code>",
 "<code>early-hints</code>",
 "<code>embed</code>",
@@ -1981,7 +1980,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>compression-dictionary</code>"
    <td>"<code>compression-dictionary</code>"
-   <td><code>default-src</code> (no specific directive)
+   <td><code>default-src</code>
    <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
@@ -3336,6 +3335,22 @@ or an <a>implementation-defined</a> value.
  <li><p>If <var>key</var> is null, then return null.
 
  <li><p>Return the unique HTTP cache associated with <var>key</var>. [[!HTTP-CACHING]]
+</ol>
+</div>
+
+
+<h3 id=compression-dictionary-cache-partitions>Compression-dictionary cache partitions</h3>
+
+<div algorithm>
+<p>To <dfn>determine the compression-dictionary cache partition</dfn>, given a <a for=/>request</a> <var>request</var>:
+
+<ol>
+ <li><p>Let <var>key</var> be the result of <a for=request>determining the network partition key</a>
+ given <var>request</var>.
+
+ <li><p>If <var>key</var> is null, then return null.
+
+ <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!HTTP-COMPRESSION-DICTIONARIES]]
 </ol>
 </div>
 
@@ -6598,6 +6613,40 @@ run these steps:
 
  <li><p>If <var>isAuthenticationFetch</var> is true, then create an <a>authentication entry</a> for
  <var>request</var> and the given realm.
+
+ <li>
+  <p>If <var>response</var>'s <a for=response>header list</a>
+  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`, then:
+  <!-- This is defined in [[!HTTP-COMPRESSION-DICTIONARIES]] -->
+
+  <ol>
+   <li><p>Let <var>dictionaryValue</var> be the result of
+   <a for="header list">getting a structured field value</a> given `<code>Use-As-Dictionary</code>`,
+   "<code>dictionary</code>", and <var>response</var>'s <a for=response>header list</a>.
+
+   <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
+   does not <a for=map>exist</a>, then return <var>response</var>.
+
+   <li><p>Let <var>pattern</var> be the result of creating a URL pattern from
+   <var>dictionaryValue</var>["<code>match</code>"] and <var>request</var>'s
+   <a for=request>current URL</a>.
+
+   <li><p>If <var>pattern</var> is failure or <var>pattern</var> has regexp groups, then return
+   <var>response</var>.
+
+   <li><p>Let <var>compressionDictionaryCache</var> be the result of
+   <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
+
+   <li><p>If <var>compressionDictionaryCache</var> is null or <var>request</var>'s
+   <a for=request>response tainting</a> is "<code>opaque</code>", then return <var>response</var>.
+
+   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
+
+   <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
+
+   <li><p>Store <var>response</var> in <var>compressionDictionaryCache</var> with its associated
+   <var>dictionaryValue</var> and <var>expirationTime</var>.
+  </ol>
 
  <li><p>Return <var>response</var>. <span class=note>Typically <var>response</var>'s
  <a for=response>body</a>'s <a for=body>stream</a> is still being enqueued to after

--- a/fetch.bs
+++ b/fetch.bs
@@ -6657,7 +6657,7 @@ run these steps:
    <li><p>Let <var>pattern</var> be the result of
    <a for=/>creating a URL pattern</a> given the <a>bare item</a> of <var>dictionaryValue</var>["<code>match</code>"],
    the <a lt="URL serializer">serialization</a> of <var>request</var>'s <a for=request>current URL</a>,
-   and an empty map.
+   and an empty map. If this throws an exception, then return <var>response</var>.
 
    <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
    then return <var>response</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2307,11 +2307,6 @@ which is "<code>basic</code>", "<code>cors</code>", or "<code>opaque</code>".
 Unless stated otherwise, it is "<code>basic</code>".
 
 <p>A <a for=/>request</a> has an associated
-<dfn export for=request id=concept-request-corp-tainting>corp tainting</dfn>,
-which is "<code>allowed</code>", or "<code>blocked</code>".
-Unless stated otherwise, it is "<code>allowed</code>".
-
-<p>A <a for=/>request</a> has an associated
 <dfn export for=request id=no-cache-prevent-cache-control>prevent no-cache cache-control header modification flag</dfn>.
 Unless stated otherwise, it is unset.
 
@@ -2322,9 +2317,14 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=compression-dictionary-disallowed>compression dictionary disallowed flag</dfn>.
+Unless stated otherwise, it is unset.
+
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
-<a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
+<a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
+<a for=request>compression dictionary disallowed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -5076,6 +5076,18 @@ steps:
     </ol>
   </dl>
 
+ <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
+ then:
+
+ <ol>
+   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+   <a for=response>header list</a>.
+
+   <li><p>If <var>corpPolicy</var> is not `<code>cross-origin</code>`, then set
+   <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>.
+ </ol>
+
  <li><p>If <var>recursive</var> is true, then return <var>response</var>.
 
  <li>
@@ -6619,8 +6631,9 @@ run these steps:
  <var>request</var> and the given realm.
 
  <li>
-  <p>If <var>response</var>'s <a for=response>header list</a>
-  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`:
+  <p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a> is not set
+  and <var>response</var>'s <a for=response>header list</a> <a for="header list">contains</a>
+  `<code>Use-As-Dictionary</code>`:
   <!-- This is defined in [[!RFC9842]] -->
 
   <ol>
@@ -6642,13 +6655,6 @@ run these steps:
 
    <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
    then return <var>response</var>.
-
-   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
-   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
-   <a for=response>header list</a>.
-
-   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
-   <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
    <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes
    a <a>stale response</a>.
@@ -6717,13 +6723,8 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
- `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
- <a for=response>header list</a>.
-
- <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>" and
- <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return a
- <a>network error</a>.
+ <li><p>If <var>request</var>'s <a for=request>compression dictionary disallowed flag</a>
+ is set, then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,

--- a/fetch.bs
+++ b/fetch.bs
@@ -84,9 +84,6 @@ urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
     "HTTP-CACHING": {
         "aliasOf": "RFC9111"
     },
-    "HTTP-COMPRESSION-DICTIONARIES": {
-        "aliasOf": "RFC9842"
-    },
     "HTTP1": {
         "aliasOf": "RFC9112"
     },
@@ -3348,7 +3345,7 @@ or an <a>implementation-defined</a> value.
 
  <li><p>If <var>key</var> is null, then return null.
 
- <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!HTTP-COMPRESSION-DICTIONARIES]]
+ <li><p>Return the unique compression-dictionary cache associated with <var>key</var>. [[!RFC9842]]
 </ol>
 </div>
 
@@ -6615,8 +6612,8 @@ run these steps:
 
  <li>
   <p>If <var>response</var>'s <a for=response>header list</a>
-  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`, then:
-  <!-- This is defined in [[!HTTP-COMPRESSION-DICTIONARIES]] -->
+  <a for="header list">contains</a> `<code>Use-As-Dictionary</code>`:
+  <!-- This is defined in [[!RFC9842]] -->
 
   <ol>
    <li><p>Let <var>dictionaryValue</var> be the result of
@@ -6650,7 +6647,7 @@ run these steps:
    <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
 
    <li><p>Store <var>response</var> in <var>compressionDictionaryCache</var> with its associated
-   <var>dictionaryValue</var> and <var>expirationTime</var>.
+   <var>pattern</var>, <var>dictionaryValue</var> and <var>expirationTime</var>.
   </ol>
 
  <li><p>Return <var>response</var>. <span class=note>Typically <var>response</var>'s
@@ -6687,14 +6684,14 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
 
  <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
  <var>compressionDictionaryCache</var> for <var>request</var> as defined in
- [[!HTTP-COMPRESSION-DICTIONARIES]].
+ [[!RFC9842]].
 
  <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
  given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
  <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>`
  (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
- [[!HTTP-COMPRESSION-DICTIONARIES]].
+ [[!RFC9842]].
 
  <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
  in <var>request</var>'s <a for=request>header list</a>.
@@ -6727,7 +6724,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
  with an algorithm that verifies that the dictionary hash in the stream matches
  <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
- algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
+ algorithm as defined in [[!RFC9842]]. If verification or decoding fails,
  the transformed stream must error.
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
@@ -6809,7 +6806,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
     <ul>
      <li><p>Follow the relevant requirements from HTTP. [[!HTTP]] [[!HTTP-CACHING]]
-     [[!HTTP-COMPRESSION-DICTIONARIES]]
+     [[!RFC9842]]
 
      <li>
       <p>If <var>request</var>'s <a for=request>body</a> is non-null, and <var>request</var>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -85,9 +85,7 @@ urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
         "aliasOf": "RFC9111"
     },
     "HTTP-COMPRESSION-DICTIONARIES": {
-        "authors": ["Patrick Meenan", "Yoav Weiss"],
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/",
-        "title": "Compression Dictionary Transport"
+        "aliasOf": "RFC9842"
     },
     "HTTP1": {
         "aliasOf": "RFC9112"

--- a/fetch.bs
+++ b/fetch.bs
@@ -6464,8 +6464,9 @@ run these steps:
    <li><p>If <var>httpRequest</var>'s <a for=request>cache mode</a> is
    "<code>only-if-cached</code>", then return a <a>network error</a>.
 
-   <li><p>Let <var>forwardResponse</var> be the result of running <a>HTTP-network fetch</a> given
-   <var>httpFetchParams</var>, <var>includeCredentials</var>, and <var>isNewConnectionFetch</var>.
+   <li><p>Let <var>forwardResponse</var> be the result of running
+   <a>HTTP-network compression-dictionary fetch</a> given <var>httpFetchParams</var>,
+   <var>includeCredentials</var>, and <var>isNewConnectionFetch</var>.
 
    <li><p>If <var>httpRequest</var>'s <a for=request>method</a> is <a>unsafe</a> and
    <var>forwardResponse</var>'s <a for=response>status</a> is in the range 200 to 399, inclusive,
@@ -6654,6 +6655,47 @@ run these steps:
 </ol>
 </div>
 
+<h3 id=http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</h3>
+
+<div algorithm>
+<p>To <dfn>HTTP-network compression-dictionary fetch</dfn>, given a <a for=/>fetch params</a>
+<var>fetchParams</var>, an optional boolean <var>includeCredentials</var> (default false), and an
+optional boolean <var>forceNewConnection</var> (default false), run these steps:
+
+<ol>
+ <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
+
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the result of
+ running <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
+ <var>forceNewConnection</var>.
+
+ <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
+ result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Let <var>compressionDictionaryCache</var> be the result of
+ <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
+
+ <li><p>If <var>compressionDictionaryCache</var> is null, then return the result of running
+ <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
+ <var>forceNewConnection</var>.
+
+ <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
+ <var>compressionDictionaryCache</var> for <var>request</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+
+ <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
+ given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+
+ <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>` (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+
+ <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`) in <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p>Return the result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
+</ol>
+</div>
 
 <h3 id=http-network-fetch>HTTP-network fetch</h3>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -67,6 +67,11 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
     url:name-serialize-cookies;text:serialize cookies
     url:name-garbage-collect-cookies;text:garbage collect cookies
 
+urlPrefix:https://urlpattern.spec.whatwg.org/#;type:dfn;spec:urlpattern
+    url:url-pattern-create;text:creating a URL pattern
+    url:url-pattern-has-regexp-groups;text:has regexp groups
+
+
 urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
     url:section-7.1;text:serialized-origin
 </pre>
@@ -1807,7 +1812,6 @@ is "<code>all</code>" or "<code>none</code>". Unless stated otherwise it is "<co
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-request-initiator>initiator</dfn>, which is
 the empty string,
-"<code>compression-dictionary</code>",
 "<code>download</code>",
 "<code>imageset</code>",
 "<code>manifest</code>",
@@ -1974,8 +1978,7 @@ not always relevant and might require different behavior.
    <td>HTML's <code>&lt;video></code> element
   <tr>
    <td>"<code>compression-dictionary</code>"
-   <td>"<code>compression-dictionary</code>"
-   <td><code>default-src</code>
+   <td><code>connect-src</code>
    <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
   <tr>
    <td>"<code>download</code>"
@@ -2302,6 +2305,11 @@ Unless stated otherwise, it is zero.
 <dfn export for=request id=concept-request-response-tainting>response tainting</dfn>,
 which is "<code>basic</code>", "<code>cors</code>", or "<code>opaque</code>".
 Unless stated otherwise, it is "<code>basic</code>".
+
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-request-corp-tainting>corp tainting</dfn>,
+which is "<code>allowed</code>", or "<code>blocked</code>".
+Unless stated otherwise, it is "<code>allowed</code>".
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=no-cache-prevent-cache-control>prevent no-cache cache-control header modification flag</dfn>.
@@ -6623,17 +6631,17 @@ run these steps:
    <li><p>If <var>dictionaryValue</var> is null or <var>dictionaryValue</var>["<code>match</code>"]
    does not <a for=map>exist</a>, then return <var>response</var>.
 
-   <li><p>Let <var>pattern</var> be the result of creating a URL pattern from
-   <var>dictionaryValue</var>["<code>match</code>"] and <var>request</var>'s
-   <a for=request>current URL</a>.
-
-   <li><p>If <var>pattern</var> is failure or <var>pattern</var> has regexp groups, then return
-   <var>response</var>.
-
    <li><p>Let <var>compressionDictionaryCache</var> be the result of
    <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 
    <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
+
+   <li><p>Let <var>pattern</var> be the result of
+   <a for=/>creating a URL pattern</a> from <var>dictionaryValue</var>["<code>match</code>"]
+   and <var>request</var>'s <a for=request>current URL</a>.
+
+   <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
+   then return <var>response</var>.
 
    <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
    `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
@@ -6642,7 +6650,8 @@ run these steps:
    <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
    <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
-   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
+   <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes
+   a <a>stale response</a>.
 
    <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6633,8 +6633,9 @@ run these steps:
    <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
 
    <li><p>Let <var>pattern</var> be the result of
-   <a for=/>creating a URL pattern</a> from <var>dictionaryValue</var>["<code>match</code>"]
-   and <var>request</var>'s <a for=request>current URL</a>.
+   <a for=/>creating a URL pattern</a> given the bare item of <var>dictionaryValue</var>["<code>match</code>"],
+   the <a lt="URL serializer">serialization</a> of <var>request</var>'s <a for=request>current URL</a>,
+   and an empty map.
 
    <li><p>If <var>pattern</var> is failure or <var>pattern</var> <a for=/>has regexp groups</a>,
    then return <var>response</var>.
@@ -6709,9 +6710,13 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>",
  then return a <a>network error</a>.
 
- <li><p>Let <var>availableDictionaryHash</var> be the result of
+ <li><p>Let <var>availableDictionaryItem</var> be the result of
  <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,
- "<code>bytestring</code>", and <var>request</var>'s <a for=request>header list</a>.
+ "<code>item</code>", and <var>request</var>'s <a for=request>header list</a>.
+
+ <li><p>If <var>availableDictionaryItem</var> is null, then return a <a>network error</a>.
+
+ <li><p>Let <var>availableDictionaryHash</var> be the bare item of <var>availableDictionaryItem</var>.
 
  <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the
  result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1884,7 +1884,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=22>""
+   <td rowspan=23>""
    <td>"<code>report</code>"
    <td rowspan=2>&mdash;
    <td>CSP, NEL reports.

--- a/fetch.bs
+++ b/fetch.bs
@@ -6636,8 +6636,14 @@ run these steps:
    <li><p>Let <var>compressionDictionaryCache</var> be the result of
    <a>determining the compression-dictionary cache partition</a> given <var>request</var>.
 
-   <li><p>If <var>compressionDictionaryCache</var> is null or <var>request</var>'s
-   <a for=request>response tainting</a> is "<code>opaque</code>", then return <var>response</var>.
+   <li><p>If <var>compressionDictionaryCache</var> is null, then return <var>response</var>.
+
+   <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+   `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+   <a for=response>header list</a>.
+
+   <li><p>If <var>request</var>'s <a for=request>response tainting</a> is "<code>opaque</code>" and
+   <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return <var>response</var>.
 
    <li><p>Let <var>expirationTime</var> be the time at which the <var>response</var> becomes stale.
 
@@ -6705,7 +6711,12 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
  then return <var>response</var>.
 
- <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
+ <li><p>Let <var>corpPolicy</var> be the result of <a for="header list">getting</a>
+ `<a http-header><code>Cross-Origin-Resource-Policy</code></a>` from <var>response</var>'s
+ <a for=response>header list</a>.
+
+ <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>" and
+ <var>corpPolicy</var> is not `<code>cross-origin</code>`, then return a
  <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryHash</var> be the result of

--- a/fetch.bs
+++ b/fetch.bs
@@ -6639,8 +6639,8 @@ run these steps:
    <var>response</var>.
 
    <li><p>If <var>dictionaryValue</var>["<code>id</code>"] <a for=map>exists</a> and its
-   <a>bare item</a>'s <a for=string>length</a> is greater than 1024, then <a for=map>remove</a>
-   <var>dictionaryValue</var>["<code>id</code>"].
+   <a>bare item</a>'s <a for=string>length</a> is greater than 1024, then return
+   <var>response</var>.
 
    <li>
     <p>If <var>dictionaryValue</var>["<code>match-dest</code>"] <a for=map>exists</a>:

--- a/fetch.bs
+++ b/fetch.bs
@@ -6658,16 +6658,17 @@ run these steps:
 <h3 id=http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</h3>
 
 <div algorithm>
-<p>To <dfn>HTTP-network compression-dictionary fetch</dfn>, given a <a for=/>fetch params</a>
-<var>fetchParams</var>, an optional boolean <var>includeCredentials</var> (default false), and an
-optional boolean <var>forceNewConnection</var> (default false), run these steps:
+<p>To <dfn id=concept-http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</dfn>,
+given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
+<var>includeCredentials</var> (default false), and an optional boolean <var>forceNewConnection</var>
+(default false), run these steps:
 
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
 
- <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the result of
- running <a>HTTP-network fetch</a> given <var>fetchParams</var>, <var>includeCredentials</var>, and
- <var>forceNewConnection</var>.
+ <li><p>If <var>request</var>'s <a for=request>mode</a> is "<code>no-cors</code>", then return the
+ result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
+ <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
  <li><p>If the user agent is configured to block cookies for <var>request</var>, then return the
  result of running <a>HTTP-network fetch</a> given <var>fetchParams</var>,
@@ -6681,16 +6682,21 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <var>forceNewConnection</var>.
 
  <li><p>Let <var>bestMatch</var> be the result of finding the best matching dictionary in
- <var>compressionDictionaryCache</var> for <var>request</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+ <var>compressionDictionaryCache</var> for <var>request</var> as defined in
+ [[!HTTP-COMPRESSION-DICTIONARIES]].
 
  <li><p>If <var>bestMatch</var> is null, then return the result of running <a>HTTP-network fetch</a>
  given <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
 
- <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>` (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in [[!HTTP-COMPRESSION-DICTIONARIES]].
+ <li><p>Add the `<code>Available-Dictionary</code>` and `<code>Dictionary-ID</code>`
+ (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
+ [[!HTTP-COMPRESSION-DICTIONARIES]].
 
- <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`) in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
+ in <var>request</var>'s <a for=request>header list</a>.
 
- <li><p><a>Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`) in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`)
+ in <var>request</var>'s <a for=request>header list</a>.
 
  <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
  <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
@@ -6698,26 +6704,27 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
  <li><p>Let <var>codings</var> be the result of <a>extracting header list values</a> given
  `<code>Content-Encoding</code>` and <var>response</var>'s <a for=response>header list</a>.
 
- <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`, then
- return <var>response</var>.
+ <li><p>If <var>codings</var> is null or does not contain `<code>dcb</code>` or `<code>dcz</code>`,
+ then return <var>response</var>.
 
  <li><p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>", then return a
  <a>network error</a>.
 
- <li><p>Let <var>availableDictionaryHash</var> be the result of <a>getting a structured field value</a>
- given `<code>Available-Dictionary</code>`, "<code>bytestring</code>", and <var>request</var>'s
- <a for=request>header list</a>.
+ <li><p>Let <var>availableDictionaryHash</var> be the result of
+ <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,
+ "<code>bytestring</code>", and <var>request</var>'s <a for=request>header list</a>.
 
- <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the result
- of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a> with an
- algorithm that verifies that the dictionary hash in the stream matches
+ <li><p>Let <var>newBody</var> be a new <a for=/>body</a> whose <a for=body>stream</a> is the
+ result of transforming <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>
+ with an algorithm that verifies that the dictionary hash in the stream matches
  <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
  algorithm as defined in [[!HTTP-COMPRESSION-DICTIONARIES]]. If verification or decoding fails,
  the transformed stream must error.
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
 
- <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s <a for=response>header list</a>.
+ <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s
+ <a for=response>header list</a>.
 
  <li><p>Return <var>response</var>.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1826,8 +1826,8 @@ device to assist defining CSP and Mixed Content. It is not exposed to JavaScript
 <p>A <dfn export>destination type</dfn> is one of:
 the empty string,
 "<code>audio</code>",
-"<code>compression-dictionary</code>",
 "<code>audioworklet</code>",
+"<code>compression-dictionary</code>",
 "<code>document</code>",
 "<code>embed</code>",
 "<code>font</code>",
@@ -1979,7 +1979,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>compression-dictionary</code>"
    <td><code>connect-src</code>
-   <td>HTML's <code>&lt;link rel=compression-dictionary&gt;</code>
+   <td>HTML's <code>&lt;link rel=compression-dictionary></code>
   <tr>
    <td>"<code>download</code>"
    <td>""
@@ -6646,7 +6646,7 @@ run these steps:
    <li><p>If <var>expirationTime</var> is not in the future, then return <var>response</var>.
 
    <li><p>Store <var>response</var> in <var>compressionDictionaryCache</var> with its associated
-   <var>pattern</var>, <var>dictionaryValue</var> and <var>expirationTime</var>.
+   <var>pattern</var>, <var>dictionaryValue</var>, and <var>expirationTime</var>.
   </ol>
 
  <li><p>Return <var>response</var>. <span class=note>Typically <var>response</var>'s
@@ -6661,7 +6661,7 @@ run these steps:
 <p>To <dfn id=concept-http-network-compression-dictionary-fetch>HTTP-network compression-dictionary fetch</dfn>,
 given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
 <var>includeCredentials</var> (default false), and an optional boolean <var>forceNewConnection</var>
-(default false), run these steps:
+(default false):
 
 <ol>
  <li><p>Let <var>request</var> be <var>fetchParams</var>'s <a for="fetch params">request</a>.
@@ -6692,11 +6692,11 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  (if applicable) headers to <var>request</var> using <var>bestMatch</var> as defined in
  [[!RFC9842]].
 
- <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
- in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">append</a> (`<code>Accept-Encoding</code>`, `<code>dcb</code>`)
+ to <var>request</var>'s <a for=request>header list</a>.
 
- <li><p><a for="header list">Combine</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`)
- in <var>request</var>'s <a for=request>header list</a>.
+ <li><p><a for="header list">append</a> (`<code>Accept-Encoding</code>`, `<code>dcz</code>`)
+ to <var>request</var>'s <a for=request>header list</a>.
 
  <li><p>Let <var>response</var> be the result of running <a>HTTP-network fetch</a> given
  <var>fetchParams</var>, <var>includeCredentials</var>, and <var>forceNewConnection</var>.
@@ -6711,7 +6711,7 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  then return a <a>network error</a>.
 
  <li><p>Let <var>availableDictionaryItem</var> be the result of
- <a>getting a structured field value</a> given `<code>Available-Dictionary</code>`,
+ <a for="header list">getting a structured field value</a> given `<code>Available-Dictionary</code>`,
  "<code>item</code>", and <var>request</var>'s <a for=request>header list</a>.
 
  <li><p>If <var>availableDictionaryItem</var> is null, then return a <a>network error</a>.
@@ -6723,11 +6723,11 @@ given a <a for=/>fetch params</a> <var>fetchParams</var>, an optional boolean
  with an algorithm that verifies that the dictionary hash in the stream matches
  <var>availableDictionaryHash</var> and decodes the rest of the stream with the applicable
  algorithm as defined in [[!RFC9842]]. If verification or decoding fails,
- the transformed stream must error.
+ error the transformed stream.
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to <var>newBody</var>.
 
- <li><p><a>Delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s
+ <li><p><a for="header list">delete</a> `<code>Content-Encoding</code>` from <var>response</var>'s
  <a for=response>header list</a>.
 
  <li><p>Return <var>response</var>.


### PR DESCRIPTION
Add processing steps for handling [HTTP Compression Dictionary Transport](https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/) content encoding and dictionary negotiation (RFC pending publication).

This adds a processing layer between the HTTP cache and network fetch that handles most of the dictionary-based content encoding (including matching dictionaries to outgoing requests).

Additionally, it adds processing above the HTTP cache for storing the dictionaries for future use and defines the "compression-dictionary" initiator and destination (the matching HTML spec update is in-process).

Support for clearing the caches through clear-site-data is in [this PR](https://github.com/w3c/webappsec-clear-site-data/pull/94).

Fix #1739, #1839

- [x] At least two implementers are interested (and none opposed):
   * [Chrome](https://chromestatus.com/feature/5124977788977152)
   * [Firefox](https://github.com/WebKit/standards-positions/issues/160)
   * [Safari](https://github.com/WebKit/standards-positions/issues/160)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/tree/master/fetch/compression-dictionary
   * PR for removal of "tentative": https://github.com/web-platform-tests/wpt/pull/54532
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1413922
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1882979
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=295249
   * Deno (not for CORS changes): https://github.com/denoland/deno/issues/30533
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression_dictionary_transport
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1854.html" title="Last updated on Jun 10, 2026, 9:38 PM UTC (4d3401a)">Preview</a> | <a href="https://whatpr.org/fetch/1854/30140d0...4d3401a.html" title="Last updated on Jun 10, 2026, 9:38 PM UTC (4d3401a)">Diff</a>