### PR TITLE
Encourage web browser User-Agent value to start with `Mozilla/5.0 (`

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1416,6 +1416,10 @@ downloads. This format of range header value can be set using <a>add a range hea
 <a>implementation-defined</a> <a for=/>header value</a> for the `<code>User-Agent</code>`
 <a for=/>header</a>.
 
+<p class=note>For unfortunate web compatibility reasons, web browsers are strongly encouraged to
+have this value start with `<code>Mozilla/5.0 (</code>` and be generally modeled after other web
+browsers.
+
 <p>The <dfn>document `<code>Accept</code>` header value</dfn> is
 `<code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code>`.
 


### PR DESCRIPTION
This matches what all major web browsers already do and navigator.appVersion relies on this to a fault. See https://github.com/whatwg/html/issues/11630 for context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1855.html" title="Last updated on Sep 9, 2025, 4:31 PM UTC (c560ab5)">Preview</a> | <a href="https://whatpr.org/fetch/1855/79b4314...c560ab5.html" title="Last updated on Sep 9, 2025, 4:31 PM UTC (c560ab5)">Diff</a>