### PR TITLE
Add note that `signal` is always initialized

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8254,7 +8254,7 @@ interface Request {
   readonly attribute boolean keepalive;
   readonly attribute boolean isReloadNavigation;
   readonly attribute boolean isHistoryNavigation;
-  readonly attribute AbortSignal signal;
+  readonly attribute AbortSignal? signal;
   readonly attribute RequestDuplex duplex;
 
   [NewObject] Request clone();

--- a/fetch.bs
+++ b/fetch.bs
@@ -8748,7 +8748,7 @@ constructor steps are:
  <li><p>Let <var>signals</var> be « <var>signal</var> » if <var>signal</var> is non-null; otherwise
  « ».
 
- <li><p>Set <a>this</a>'s <a for=Request>signal</a> to the result of
+ <li id="signal-initialized-in-constructor"><p>Set <a>this</a>'s <a for=Request>signal</a> to the result of
  <a>creating a dependent abort signal</a> from <var>signals</var>, using {{AbortSignal}} and
  <a>this</a>'s <a>relevant realm</a>.
 
@@ -8919,9 +8919,9 @@ set; otherwise false.
 <p>The <dfn attribute for=Request><code>signal</code></dfn> getter steps are to return <a>this</a>'s
 <a for="Request">signal</a>.
 
-<p class="note"><a>this</a>'s <a for="Request">signal</a> is always initialized in the
-<a href="#ref-for-request-signal②">constructor</a> and when
-<a href="#ref-for-request-signal⑤">cloning</a>.
+<p class="note"><a>This</a>'s <a for="Request">signal</a> is always initialized in the
+<a href="#signal-initialized-in-constructor">constructor</a> and when
+<a href="#signal-initialized-when-cloning">cloning</a>.
 
 <p>The <dfn attribute for=Request><code>duplex</code></dfn> getter steps are to return
 "<code>half</code>".
@@ -8937,7 +8937,7 @@ set; otherwise false.
  <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a>
  <a>this</a>'s <a for=Request>request</a>.
 
- <li><p><a for=/>Assert</a>: <a>this</a>'s <a for=Request>signal</a> is non-null.
+ <li id="signal-initialized-when-cloning"><p><a for=/>Assert</a>: <a>this</a>'s <a for=Request>signal</a> is non-null.
 
  <li><p>Let <var>clonedSignal</var> be the result of <a>creating a dependent abort signal</a> from
  « <a>this</a>'s <a for=Request>signal</a> », using {{AbortSignal}} and <a>this</a>'s

--- a/fetch.bs
+++ b/fetch.bs
@@ -8254,7 +8254,7 @@ interface Request {
   readonly attribute boolean keepalive;
   readonly attribute boolean isReloadNavigation;
   readonly attribute boolean isHistoryNavigation;
-  readonly attribute AbortSignal? signal;
+  readonly attribute AbortSignal signal;
   readonly attribute RequestDuplex duplex;
 
   [NewObject] Request clone();
@@ -8918,6 +8918,10 @@ set; otherwise false.
 
 <p>The <dfn attribute for=Request><code>signal</code></dfn> getter steps are to return <a>this</a>'s
 <a for="Request">signal</a>.
+
+<p class="note"><a>this</a>'s <a for="Request">signal</a> is always initialized in the
+<a href="#ref-for-request-signal②">constructor</a> and when
+<a href="#ref-for-request-signal⑤>cloning</a>.
 
 <p>The <dfn attribute for=Request><code>duplex</code></dfn> getter steps are to return
 "<code>half</code>".

--- a/fetch.bs
+++ b/fetch.bs
@@ -8921,7 +8921,7 @@ set; otherwise false.
 
 <p class="note"><a>this</a>'s <a for="Request">signal</a> is always initialized in the
 <a href="#ref-for-request-signal②">constructor</a> and when
-<a href="#ref-for-request-signal⑤>cloning</a>.
+<a href="#ref-for-request-signal⑤">cloning</a>.
 
 <p>The <dfn attribute for=Request><code>duplex</code></dfn> getter steps are to return
 "<code>half</code>".

--- a/fetch.bs
+++ b/fetch.bs
@@ -8937,9 +8937,9 @@ set; otherwise false.
  <li><p>Let <var>clonedRequest</var> be the result of <a lt=clone for=request>cloning</a>
  <a>this</a>'s <a for=Request>request</a>.
 
- <li id="signal-initialized-when-cloning"><p><a for=/>Assert</a>: <a>this</a>'s <a for=Request>signal</a> is non-null.
+ <li><p><a for=/>Assert</a>: <a>this</a>'s <a for=Request>signal</a> is non-null.
 
- <li><p>Let <var>clonedSignal</var> be the result of <a>creating a dependent abort signal</a> from
+ <li id="signal-initialized-when-cloning"><p>Let <var>clonedSignal</var> be the result of <a>creating a dependent abort signal</a> from
  « <a>this</a>'s <a for=Request>signal</a> », using {{AbortSignal}} and <a>this</a>'s
  <a>relevant realm</a>.
 


### PR DESCRIPTION
The getter steps [1] specify to return `this.signal`. Its signal is nullable [2], but it is always initialized in the constructor and when cloning.

[1]: https://fetch.spec.whatwg.org/#dom-request-signal
[2]: https://fetch.spec.whatwg.org/#request-signal


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1856.html" title="Last updated on Sep 18, 2025, 1:54 PM UTC (f275bd3)">Preview</a> | <a href="https://whatpr.org/fetch/1856/e28f9a5...f275bd3.html" title="Last updated on Sep 18, 2025, 1:54 PM UTC (f275bd3)">Diff</a>