### PR TITLE
Editorial: fix typo for inputBody

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8868,7 +8868,7 @@ constructor steps are:
   <p>If <var>initBody</var> is null and <var>inputBody</var> is non-null, then:
 
   <ol>
-   <li><p>If <var>input</var> is <a for=Body>unusable</a>, then <a>throw</a> a {{TypeError}}.
+   <li><p>If <var>inputBody</var> is <a for=Body>unusable</a>, then <a>throw</a> a {{TypeError}}.
 
    <!-- Any steps after this must not throw. -->
 


### PR DESCRIPTION
`input` is either a string or a request. Since this links to body, it was probably meant to be `inputBody` instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1857.html" title="Last updated on Sep 25, 2025, 7:16 PM UTC (382cdaa)">Preview</a> | <a href="https://whatpr.org/fetch/1857/ed04423...382cdaa.html" title="Last updated on Sep 25, 2025, 7:16 PM UTC (382cdaa)">Diff</a>