### PR TITLE
Throw `SecurityError` on non-trustworthy URLs in `fetchLater`

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -9440,7 +9440,7 @@ method steps are:
  <a>HTTP(S) scheme</a>, then throw a {{TypeError}}.
 
  <li><p>If <var>request</var>'s <a for=request>URL</a> is not a <a>potentially trustworthy URL</a>,
- then throw a {{TypeError}}.
+ then throw a {{SecurityError}}.
 
  <li>
   <p>If <var>request</var>'s <a for=request>body</a> is not null, and <var>request</var>'s


### PR DESCRIPTION
Per https://github.com/web-platform-tests/wpt/blob/c009ca2fa7d311b1a257222aa0f9fd7706ffa4d6/fetch/fetch-later/basic.https.window.js#L54-L59 it should not throw a `TypeError`, but a `SecurityError` instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1858.html" title="Last updated on Sep 28, 2025, 8:54 AM UTC (e869c75)">Preview</a> | <a href="https://whatpr.org/fetch/1858/5a015d1...e869c75.html" title="Last updated on Sep 28, 2025, 8:54 AM UTC (e869c75)">Diff</a>