### PR TITLE
Expose `fetchLater` only in a SecureContext

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -9269,7 +9269,7 @@ interface FetchLaterResult {
 };
 
 partial interface Window {
-  [NewObject] FetchLaterResult fetchLater(RequestInfo input, optional DeferredRequestInit init = {});
+  [NewObject, SecureContext] FetchLaterResult fetchLater(RequestInfo input, optional DeferredRequestInit init = {});
 };
 </pre>
 


### PR DESCRIPTION
Tested per https://github.com/web-platform-tests/wpt/blob/c009ca2fa7d311b1a257222aa0f9fd7706ffa4d6/fetch/fetch-later/non-secure.window.js