### PR TITLE
Add WebDriver BiDi network logging with stable request IDs

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2225,6 +2225,11 @@ Unless stated otherwise, it is false.
 
 <p class=note>This is for exclusive use by HTML's navigate algorithm. [[!HTML]]
 
+<p>A <a for=/>request</a> has an associated <dfn export for=request>WebDriver navigation id</dfn>
+(null or a string). Unless stated otherwise, it is null.
+
+<p class=note>This is for exclusive use by HTML's navigate algorithm. [[!HTML]]
+
 <p>A <a for=/>request</a> has an associated boolean <dfn export for=request>render-blocking</dfn>.
 Unless stated otherwise, it is false.
 
@@ -2265,6 +2270,15 @@ otherwise, it is unset.
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
 <a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
 bookkeeping details by the <a for=/>fetch</a> algorithm.
+
+<p>A <a for=/>request</a> has an associated
+<dfn export for=request id=concept-webdriver-id>WebDriver id</dfn>
+which is a unique string automatically set when the <a for=/>request</a> is created.
+
+<p class=note>The [=request/WebDriver id=] is used by WebDriver-BiDi. It remains constant
+across all requests resulting from a redirect of an initial request. When a
+request is [=request/cloned=], the created request gets a unique
+[=request/WebDriver id=]. [[!WEBDRIVER-BIDI]]
 
 <hr>
 
@@ -2356,7 +2370,9 @@ is to return the result of <a>serializing a request origin</a> with <var>request
 
 <ol>
  <li><p>Let <var>newRequest</var> be a copy of <var>request</var>, except for its
- <a for=request>body</a>.
+ <a for=request>body</a> and <a for=request>WebDriver id</a>.
+
+ <li><p>Set <var>newRequest</var>'s <a for=request>WebDriver id</a> to a new unique string.
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is non-null, set <var>newRequest</var>'s
  <a for=request>body</a> to the result of <a lt=clone for=body>cloning</a> <var>request</var>'s
@@ -5128,6 +5144,11 @@ steps:
      <a for=request>URL</a>, <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>,
      <var>bodyInfo</var>, and <var>responseStatus</var>.
+
+     <li><p>If <var>response</var> is a <a>network error</a>, run
+     the <a>WebDriver BiDi fetch error</a> steps with <var>request</var>. Otherwise
+     run the <a>WebDriver BiDi response completed</a> steps with
+     <var>request</var> and <var>response</var>.
     </ol>
 
    <li>
@@ -5586,6 +5607,13 @@ these steps:
      <a>filtered response</a>; otherwise to <var>response</var>'s
      <a for="filtered response">internal response</a>.
 
+     <li><p>Run the [=WebDriver BiDi response started=] steps with
+     <var>request</var> and <var>response</var>.
+     <!-- Service Workers is responsible for emmitting the WebDriver BiDi
+          request events in this case. That's necessary to ensure that the events are
+          only generated if the service worker will handle the fetch, and to get the
+          correct event ordering in the case of network fallback -->
+
      <li>
       <p>If one of the following is true
 
@@ -5713,8 +5741,12 @@ these steps:
 
      <dt>"<code>follow</code>"
      <dd>
-      <ol><li><p>Set <var>response</var> to the result of running <a>HTTP-redirect fetch</a> given
-      <var>fetchParams</var> and <var>response</var>.</ol>
+      <ol>
+       <li>Run the <a>WebDriver BiDi response completed</a> steps with <var>request</var> and
+       <var>response</var>.
+       <li><p>Set <var>response</var> to the result of running <a>HTTP-redirect fetch</a> given
+       <var>fetchParams</var> and <var>response</var>.
+      </ol>
     </dl>
     <!-- not resetting internalResponse since it's no longer used anyway -->
   </ol>
@@ -6120,6 +6152,10 @@ run these steps:
     <p class=note>This intentionally does not depend on <var>httpRequest</var>'s
     <a for=request>credentials mode</a>.
 
+   <!-- After this point the request is not further modified before being either
+        retrieved from the cache or sent -->
+   <li><p>Run the <a>WebDriver BiDi before request sent</a> steps with <var>request</var>.
+
    <li><p>Set <var>httpCache</var> to the result of <a>determining the HTTP cache partition</a>,
    given <var>httpRequest</var>.
 
@@ -6215,6 +6251,8 @@ run these steps:
  <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
  <var>fetchParams</var>.
 
+ <li><p>If <var>response</var> is not null, run the <a>WebDriver BiDi response
+ started</a> steps with <var>request</var> and <var>response</var>.
 
  <!-- If response is still null, we require a forwarded request. -->
  <li>
@@ -6477,6 +6515,9 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
        HTTP/2 or response status line for HTTP/1.x).
 
        <li><p>Wait until all the HTTP response headers are transmitted.
+
+       <li><p>Run the [=WebDriver BiDi response started=] steps with
+       |request| and |response|.
 
        <li><p>Let <var>status</var> be the HTTP response's status code.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -5146,11 +5146,6 @@ steps:
      <a for=request>URL</a>, <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>initiator type</a>, <var>global</var>, <var>cacheState</var>,
      <var>bodyInfo</var>, and <var>responseStatus</var>.
-
-     <li><p>If <var>response</var> is a <a>network error</a>, run
-     the <a>WebDriver BiDi fetch error</a> steps with <var>request</var>. Otherwise
-     run the <a>WebDriver BiDi response completed</a> steps with
-     <var>request</var> and <var>response</var>.
     </ol>
 
    <li>
@@ -5186,6 +5181,11 @@ steps:
  <li><p>Let <var>internalResponse</var> be <var>response</var>, if <var>response</var> is a
  <a>network error</a>; otherwise <var>response</var>'s
  <a for="filtered response">internal response</a>.
+
+ <li><p>If <var>response</var> is a <a>network error</a>, run
+ the <a>WebDriver BiDi fetch error</a> steps with <var>request</var>. Otherwise
+ run the <a>WebDriver BiDi response completed</a> steps with
+ <var>request</var> and <var>response</var>.
 
  <li><p>If <var>internalResponse</var>'s <a for=response>body</a> is null, then run
  <var>processResponseEndOfBody</var>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -2276,8 +2276,8 @@ bookkeeping details by the <a for=/>fetch</a> algorithm.
 which is a unique string automatically set when the <a for=/>request</a> is created.
 
 <p class=note>The [=request/WebDriver id=] is used by WebDriver-BiDi. It remains constant
-across all requests resulting from a redirect of an initial request. When a
-request is [=request/cloned=], the created request gets a unique
+across redirects, authentication attempts, and CORS-preflight fetches of an initial request.
+When a request is [=request/cloned=], the created request gets a unique
 [=request/WebDriver id=]. [[!WEBDRIVER-BIDI]]
 
 <hr>
@@ -6835,8 +6835,9 @@ populates the <a>CORS-preflight cache</a> to minimize the number of these
   <a for=request>origin</a> is <var>request</var>'s <a for=request>origin</a>,
   <a for=request>referrer</a> is <var>request</var>'s <a for=request>referrer</a>,
   <a for=request>referrer policy</a> is <var>request</var>'s <a for=request>referrer policy</a>,
-  <a for=request>mode</a> is "<code>cors</code>", and
-  <a for=request>response tainting</a> is "<code>cors</code>".
+  <a for=request>mode</a> is "<code>cors</code>",
+  <a for=request>response tainting</a> is "<code>cors</code>", and
+  <a for=request>WebDriver id</a> is <var>request</var>'s <a for=request>WebDriver id</a>.
 
   <p class=note>The <a for=request>service-workers mode</a> of <var>preflight</var> does not matter
   as this algorithm uses <a>HTTP-network-or-cache fetch</a> rather than <a>HTTP fetch</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -5609,9 +5609,9 @@ these steps:
      <a>filtered response</a>; otherwise to <var>response</var>'s
      <a for="filtered response">internal response</a>.
 
-     <li><p>Run the [=WebDriver BiDi response started=] steps with
+     <li><p>Run the <a>WebDriver BiDi response started</a> steps with
      <var>request</var> and <var>response</var>.
-     <!-- Service Workers is responsible for emmitting the WebDriver BiDi
+     <!-- Service Workers are responsible for emitting the WebDriver BiDi
           request events in this case. That's necessary to ensure that the events are
           only generated if the service worker will handle the fetch, and to get the
           correct event ordering in the case of network fallback -->
@@ -6518,8 +6518,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p>Wait until all the HTTP response headers are transmitted.
 
-       <li><p>Run the [=WebDriver BiDi response started=] steps with
-       |request| and |response|.
+       <li><p>Run the <a>WebDriver BiDi response started</a> steps with
+       <var>request</var> and <var>response</var>.
 
        <li><p>Let <var>status</var> be the HTTP response's status code.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -4586,6 +4586,8 @@ the response. [[!HTTP-CACHING]]
  <var>request</var>'s <a for=request>body</a> to <var>request</var>'s <a for=request>body</a>
  <a for="byte sequence">as a body</a>.
 
+ <li><p>Run the <a>WebDriver BiDi clone network request body</a> steps with <var>request</var>.
+
  <li>
   <p>If all of the following conditions are true:
 
@@ -6690,6 +6692,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
  <li><p>Set <var>response</var>'s <a for=response>body</a> to a new <a for=/>body</a> whose
  <a for=body>stream</a> is <var>stream</var>.
+
+ <li><p>Run the <a>WebDriver BiDi clone network response body</a> steps with <var>request</var> and <var>response</var>.
 
  <li><p tracking-vector>If <var>includeCredentials</var> is true, then the user agent should
  <a>parse and store response `<code>Set-Cookie</code>` headers</a> given <var>request</var> and

--- a/fetch.bs
+++ b/fetch.bs
@@ -2273,7 +2273,8 @@ bookkeeping details by the <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-webdriver-id>WebDriver id</dfn>
-which is a unique string automatically set when the <a for=/>request</a> is created.
+which is the result of <a>generating a random UUID</a>, set when the <a for=/>request</a> is
+created. [[WEBCRYPTO]]
 
 <p class=note>The [=request/WebDriver id=] is used by WebDriver-BiDi. It remains constant
 across redirects, authentication attempts, and CORS-preflight fetches of an initial request.
@@ -2372,7 +2373,8 @@ is to return the result of <a>serializing a request origin</a> with <var>request
  <li><p>Let <var>newRequest</var> be a copy of <var>request</var>, except for its
  <a for=request>body</a> and <a for=request>WebDriver id</a>.
 
- <li><p>Set <var>newRequest</var>'s <a for=request>WebDriver id</a> to a new unique string.
+ <li><p>Set <var>newRequest</var>'s <a for=request>WebDriver id</a> to the result of
+ <a>generating a random UUID</a>. [[WEBCRYPTO]]
 
  <li><p>If <var>request</var>'s <a for=request>body</a> is non-null, set <var>newRequest</var>'s
  <a for=request>body</a> to the result of <a lt=clone for=body>cloning</a> <var>request</var>'s
@@ -5182,8 +5184,8 @@ steps:
  <a>network error</a>; otherwise <var>response</var>'s
  <a for="filtered response">internal response</a>.
 
- <li><p>If <var>response</var> is a <a>network error</a>, run
- the <a>WebDriver BiDi fetch error</a> steps with <var>request</var>. Otherwise
+ <li><p>If <var>response</var> is a <a>network error</a>, then run
+ the <a>WebDriver BiDi fetch error</a> steps with <var>request</var>. Otherwise,
  run the <a>WebDriver BiDi response completed</a> steps with
  <var>request</var> and <var>response</var>.
 
@@ -6253,7 +6255,7 @@ run these steps:
  <li><p><a>If aborted</a>, then return the <a for=/>appropriate network error</a> for
  <var>fetchParams</var>.
 
- <li><p>If <var>response</var> is not null, run the <a>WebDriver BiDi response
+ <li><p>If <var>response</var> is not null, then run the <a>WebDriver BiDi response
  started</a> steps with <var>request</var> and <var>response</var>.
 
  <!-- If response is still null, we require a forwarded request. -->


### PR DESCRIPTION
* [x]  At least two implementers are interested (and none opposed):
  * Changes landed in WebDriver-BiDi with agreement in Browser Testing and Tools WG.
* [x]  [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
  * https://wpt.fyi/results/webdriver/tests/bidi/network?label=experimental&label=master&aligned (there's no normative changes to fetch behaviour other than when WebDriver is enabled).
* [x]  [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
  * Chromium: https://github.com/GoogleChromeLabs/chromium-bidi/pull/506
  * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1790366 (and similarly for other events)
  * WebKit: https://bugs.webkit.org/show_bug.cgi?id=281936  
* [x]  [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
  * No WebDriver BiDi documentation on MDN yet.
        (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

This PR is based on the feedback on the existing PR #1540 as well as what was discussed in  w3c/webdriver-bidi#722

This introduces the concept of a stable webdriver id for requests, which is consistent across redirects, authentication attempts and CORS preflight.

This also triggers steps from the webdriver bidi specification to emit network events and trigger data collection mecanisms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1860.html" title="Last updated on Apr 21, 2026, 7:02 PM UTC (f3a2ae3)">Preview</a> | <a href="https://whatpr.org/fetch/1860/4775fcb...f3a2ae3.html" title="Last updated on Apr 21, 2026, 7:02 PM UTC (f3a2ae3)">Diff</a>