### PR TITLE
Handle `Unencoded-Digest` assertions.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4508,19 +4508,19 @@ represent a digest of the response produced via the specified algorithm. [[!UNEN
 <a>byte sequence</a> <var>bytes</var> and a <a for=/>header list</a> <var>list</var>:
 
 <ol>
- <li><p>Let <var>header</var> be the result of
+ <li><p>Let <var>value</var> be the result of
  <a for="header list" lt="get a structured field value">getting</a> the
  `<a http-header><code>Unencoded-Digest</code></a>` header as a "<code>dictionary</code>" from
  <var>list</var>.
 
- <li><p>If <var>header</var> is null, then return <b>verified</b>.
+ <li><p>If <var>value</var> is null, then return <b>verified</b>.
 
  <li>
-  <p><a for="list">For each</a> <var>alg</var> → <var>digest</var> of <var>header</var>:
+  <p><a for="list">For each</a> <var>algorithm</var> → <var>digest</var> of <var>value</var>:
 
   <ol>
    <li>
-    <p>Switch on <var>alg</var>:
+    <p>Switch on <var>algorithm</var>:
 
     <dl class=switch>
      <dt>"<code>sha-256</code>"
@@ -4529,7 +4529,7 @@ represent a digest of the response produced via the specified algorithm. [[!UNEN
        <li><p>Let <var>body digest</var> be the result of executing the SHA-256 algorithm on
        <var>bytes</var>. [[!FIPS-180-4]]
 
-       <li><p>If <var>body digest</var> matches <var>digest</var>, <a for="iteration">continue</a>.
+       <li><p>If <var>body digest</var> is <var>digest</var>, <a for="iteration">continue</a>.
       </ol>
 
      <dt>"<code>sha-512</code>"
@@ -4538,7 +4538,7 @@ represent a digest of the response produced via the specified algorithm. [[!UNEN
        <li><p>Let <var>body digest</var> be the result of executing the SHA-512 algorithm on
        <var>bytes</var>. [[!FIPS-180-4]]
 
-       <li><p>If <var>body digest</var> matches <var>digest</var>, <a for="iteration">continue</a>.
+       <li><p>If <var>body digest</var> is <var>digest</var>, <a for="iteration">continue</a>.
       </ol>
 
      <dt><b>Otherwise</b>


### PR DESCRIPTION
Signature-based Integrity [1] relies on user agents properly handling `Unencoded-Digest` headers [2] which deliver a server's assertions about the integrity of a given response's body.

This patch extracts the relevant algorithms from [1], spelling out the processing model for the header, and verifying response integrity at the end of Main Fetch, alongside SRI's existing check.

This is one step of the Signature-based Integrity upstreaming work detailed in [3].

[1]: https://wicg.github.io/signature-based-sri/
[2]: https://httpwg.org/http-extensions/draft-ietf-httpbis-unencoded-digest.html
[3]: https://github.com/WICG/signature-based-sri/issues/49


- [X] At least two implementers are interested (and none opposed):
   * Chromium [shipped support](https://chromestatus.com/feature/5032324620877824) for this functionality in M141.
   * WebKit expressed support in https://github.com/WebKit/standards-positions/issues/434
   * Mozilla's opinions have been solicited in https://github.com/mozilla/standards-positions/issues/1139
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/subresource-integrity/unencoded-digest/tentative?label=experimental&label=master&aligned
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1867.html" title="Last updated on Nov 19, 2025, 8:22 AM UTC (307d393)">Preview</a> | <a href="https://whatpr.org/fetch/1867/0e72db8...307d393.html" title="Last updated on Nov 19, 2025, 8:22 AM UTC (307d393)">Diff</a>