### PR TITLE
docs: add example for X-Content-Type-Options header

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4202,6 +4202,23 @@ Content-Type:
 
 
 <h3 id=x-content-type-options-header>`<code>X-Content-Type-Options</code>` header</h3>
+<div class=example>
+  <p>Example: Using the <code>X-Content-Type-Options</code> header to prevent MIME type sniffing.</p>
+  <pre><code>HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+X-Content-Type-Options: nosniff
+
+&lt;!doctype html&gt;
+&lt;html&gt;
+  &lt;head&gt;&lt;title&gt;Secure Page&lt;/title&gt;&lt;/head&gt;
+  &lt;body&gt;
+    &lt;script src="data:text/plain,alert('This script will be blocked')">&lt;/script&gt;
+  &lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+  <p>This prevents browsers from interpreting resources as a different MIME type than declared, 
+  helping to mitigate certain types of cross-site scripting attacks.</p>
+</div>
 
 <p>The
 `<dfn export http-header id=http-x-content-type-options><code>X-Content-Type-Options</code></dfn>`


### PR DESCRIPTION
This PR adds an example demonstrating the use of the `X-Content-Type-Options: nosniff` header.
It includes a simple HTML and response snippet to show how browsers handle MIME type mismatches.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1872.html" title="Last updated on Oct 22, 2025, 11:30 AM UTC (8bb912d)">Preview</a> | <a href="https://whatpr.org/fetch/1872/0e72db8...8bb912d.html" title="Last updated on Oct 22, 2025, 11:30 AM UTC (8bb912d)">Diff</a>