### PR TITLE
Add "webtransport" request mode (integration)

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -6429,9 +6429,8 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <var>request</var>'s <a for=request>current URL</a>.
 
    <dt>"<code>webtransport</code>"
-   <dd><p>Let <var>connection</var> be the result of
-   <a lt="obtain a WebTransport connection">obtaining a WebTransport connection</a>, given   
-   <var>networkPartitionKey</var> and <var>request</var>.
+   <dd><p>Let <var>connection</var> be the result of <a>obtaining a WebTransport connection</a>,
+   given <var>networkPartitionKey</var> and <var>request</var>.
 
    <dt>Otherwise
    <dd><p>Let <var>connection</var> be the result of


### PR DESCRIPTION
Add a "webtransport" request mode modeled on "websocket" to integrate WebTransport in a manner similar (but not identical) to WebSockets. Not exposed.
 
Fixes #1808.

- [x] At least two implementers are interested (and none opposed):
   * Chrome, Firefox, Safari
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * PR aims to be behavior neutral with existing tests in https://wpt.fyi/results/webtransport
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: none revealed as of yet from this change
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: None planned (fetch is under the hood; [mdn websocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) does not mention it either)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1873.html" title="Last updated on Nov 19, 2025, 8:56 AM UTC (224407e)">Preview</a> | <a href="https://whatpr.org/fetch/1873/0e72db8...224407e.html" title="Last updated on Nov 19, 2025, 8:56 AM UTC (224407e)">Diff</a>