### PR TITLE
Bypass blob URL partitioning for top-level self fetches

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -5360,9 +5360,6 @@ returning a response directly, or allowing the request to proceed by returning n
      <li><p>Let <var>requestEnvironment</var> be the result of
      <a for=request>determining the environment</a> given <var>request</var>.
 
-     <li><p>Let <var>isTopLevelNavigation</var> be true if <var>request</var>'s
-     <a for=request>destination</a> is "<code>document</code>"; otherwise, false.
-
      <li><p>Let <var>isTopLevelSelfFetch</var> be false.
 
      <li>
@@ -5390,13 +5387,18 @@ returning a response directly, or allowing the request to proceed by returning n
         <p>then set <var>isTopLevelSelfFetch</var> to true.
       </ol>
 
-     <li><p>Let <var>stringOrEnvironment</var> be <var>requestEnvironment</var>.
+     <li>
+      <p>Let <var>stringOrEnvironment</var> be the result of these steps:
 
-     <li><p>If <var>isTopLevelNavigation</var> is true, then set <var>stringOrEnvironment</var>
-     to "<code>navigation</code>".
+      <ol>
+       <li><p>If <var>request</var>'s <a for=request>destination</a> is "<code>document</code>",
+       then return "<code>top-level-navigation</code>".
 
-     <li><p>Otherwise, if <var>isTopLevelSelfFetch</var> is true, then set
-     <var>stringOrEnvironment</var> to "<code>top-level-self-fetch</code>".
+       <li><p>If <var>isTopLevelSelfFetch</var> is true, then return
+       "<code>top-level-self-fetch</code>".
+
+       <li><p>Return <var>requestEnvironment</var>.
+      </ol>
 
      <li><p>Let <var>blob</var> be the result of <a>obtaining a blob object</a> given
      <var>blobURLEntry</var> and <var>stringOrEnvironment</var>.


### PR DESCRIPTION
Implements the fetch spec side of bypassing partitioning when a top-level blob URL document attempts to fetch itself. For more info see: https://github.com/w3c/FileAPI/issues/210

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Implemented in Chromium: https://crbug.com/426787402
   * Possibly support from Safari: https://github.com/w3c/FileAPI/issues/210#issuecomment-3001278531
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/7160405
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/426787402
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2000324
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=302558
   * Deno (not for CORS changes): N/A since Deno does not partition storage or more generally implement the same-origin policy: https://docs.deno.com/runtime/reference/web_platform_apis/#spec-deviations
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/773
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1879.html" title="Last updated on Dec 3, 2025, 3:07 PM UTC (f6f27e7)">Preview</a> | <a href="https://whatpr.org/fetch/1879/0e72db8...f6f27e7.html" title="Last updated on Dec 3, 2025, 3:07 PM UTC (f6f27e7)">Diff</a>