### PR TITLE
Add webtransport-hashes to request, wired down to create a connection

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2252,7 +2252,7 @@ Unless stated otherwise, it is false.
 <a for=/>WebTransport-hash list</a>). Unless stated otherwise it is « ».
 
 <p>A <dfn export>WebTransport-hash list</dfn> is a <a for=/>list</a> of zero or more
-<a for=/>WebTransport-hashes</a>. It is initially « ».
+<a for=/>WebTransport-hashes</a>.
 
 <p>A <dfn export id=concept-WebTransport-hash>WebTransport-hash</dfn> is a <a for=/>tuple</a>
 consisting of an <dfn export for=WebTransport-hash>algorithm</dfn> (a <a for=/>string</a>) and a
@@ -3020,7 +3020,7 @@ steps:
 <dfn export for="obtain a connection"><var>requireUnreliable</var></dfn> (default false), and an
 optional <a for=/>WebTransport-hash list</a>
 <dfn export for="obtain a connection"><var>webTransportHashes</var></dfn> (default « »):
-<!-- new's "yes-and-dedicated", requireUnreliable and webTransportHashes have been added for WebTransport -->
+<!-- new's "yes-and-dedicated", requireUnreliable, and webTransportHashes have been added for WebTransport -->
 
 <ol>
  <li>


### PR DESCRIPTION
Add an associated webtransport-hashes (a webtransport-hash list) to request, and wire it down to create a connection. For use by WebTransport and CSP https://github.com/w3c/webappsec-csp/pull/791.

Fixes #1880.

- [x] At least two implementers are interested (and none opposed):
   * Chrome, Firefox, Safari
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * PR aims to be behavior neutral with existing tests in https://wpt.fyi/results/webtransport
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: none revealed as of yet from this change
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: None planned (aims to be behavior neutral)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1896.html" title="Last updated on Jan 13, 2026, 1:43 AM UTC (b868e22)">Preview</a> | <a href="https://whatpr.org/fetch/1896/3bc9b2b...b868e22.html" title="Last updated on Jan 13, 2026, 1:43 AM UTC (b868e22)">Diff</a>