### PR TITLE
Only consider pending fetch-later requests for deferred fetch quota

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7517,6 +7517,9 @@ stated otherwise, it is 0.
     <a for="fetch group">deferred fetch records</a>:
 
     <ol>
+     <li><p>If <var>deferredRecord</var>'s <a for="deferred fetch record">invoke state</a>
+     is not "<code>pending</code>", then <a for=iteration>continue</a>.
+
      <li><p>Let <var>requestLength</var> be the <a>total request length</a> of
      <var>deferredRecord</var>'s <a for="deferred fetch record">request</a>.
 
@@ -9532,7 +9535,7 @@ method steps are:
 
  <li>
   <p>If <var>request</var>'s <a for=request>body</a> is not null, and <var>request</var>'s
-  <a for=request>body</a> <a for=body>length</a> is null, then throw a {{TypeError}}.
+  <a for=request>body</a> <a for=body>length</a> is null or zero, then throw a {{TypeError}}.
 
   <p class=note>Requests whose <a for=request>body</a> is a {{ReadableStream}} object cannot be
   deferred.

--- a/fetch.bs
+++ b/fetch.bs
@@ -9535,7 +9535,7 @@ method steps are:
 
  <li>
   <p>If <var>request</var>'s <a for=request>body</a> is not null, and <var>request</var>'s
-  <a for=request>body</a> <a for=body>length</a> is null or zero, then throw a {{TypeError}}.
+  <a for=request>body</a> <a for=body>length</a> is null, then throw a {{TypeError}}.
 
   <p class=note>Requests whose <a for=request>body</a> is a {{ReadableStream}} object cannot be
   deferred.


### PR DESCRIPTION
Quota computation shouldn't include aborted or already 
completed requests. WPT uses `AbortController` to ensure
quota is freed up. This also makes sense, since they are
no longer relevant. Therefore, only consider pending
deferred fetches when computing quota.

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Webkit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/fetch/fetch-later/quota/accumulated-oversized-payload.https.window.html?label=experimental&label=master&aligned
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: n/a already passing tests
   * Gecko: n/a no implementation yet
   * WebKit: n/a no implementation yet
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1902.html" title="Last updated on Apr 26, 2026, 1:25 PM UTC (6d1fd25)">Preview</a> | <a href="https://whatpr.org/fetch/1902/3bab31a...6d1fd25.html" title="Last updated on Apr 26, 2026, 1:25 PM UTC (6d1fd25)">Diff</a>