### PR TITLE
Add quota/requested info to the QuotaExceededError

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -9538,8 +9538,7 @@ method steps are:
   deferred.
 
  <li><p>Let <var>quota</var> be the <a>available deferred-fetch quota</a> given <var>request</var>'s
- <a for=request>client</a> and <var>request</var>'s <a for=request>URL</a>'s
- <a for=url>origin</a>.
+ <a for=request>client</a> and <var>request</var>'s <a for=request>URL</a>'s <a for=url>origin</a>.
 
  <li><p>Let <var>requested</var> be <var>request</var>'s <a>total request length</a>.
 


### PR DESCRIPTION
`QuotaExceededError` now supplies the requested/quota info when caught.
This change supplies this information when this error is thrown due to an exceeded quota for deferred fetching (`fetchLater`).

Closes #1903

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x]] At least two implementers are interested (and none opposed):
   * Chromium
   * Webkit 
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * fetch/fetch-later/quota/accumulated-oversized-payload.https.window.js
   * https://github.com/web-platform-tests/wpt/pull/57078
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/473585680
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1936180 (main `fetchLater` bug, not implemented yet)
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=284347 (main `fetchLater` bug, not implemented yet)
   * Deno (not for CORS changes): …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1904.html" title="Last updated on Jan 12, 2026, 11:27 AM UTC (457c55b)">Preview</a> | <a href="https://whatpr.org/fetch/1904/3bab31a...457c55b.html" title="Last updated on Jan 12, 2026, 11:27 AM UTC (457c55b)">Diff</a>