### PR TITLE
Block 416 alongside 206

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1465,6 +1465,8 @@ worked on in <a href=https://github.com/whatwg/fetch/issues/1156>issue #1156</a>
 
 <p>An <dfn export>ok status</dfn> is a <a for=/>status</a> in the range 200 to 299, inclusive.
 
+<p>A <dfn export>range status</dfn> is a <a for=/>status</a> that is 206 or 416.
+
 <p>A <dfn export>redirect status</dfn> is a <a for=/>status</a> that is 301, 302, 303, 307, or 308.
 
 
@@ -5017,15 +5019,16 @@ steps:
 
  <li>
   <p>If <var>response</var>'s <a for=response>type</a> is "<code>opaque</code>",
-  <var>internalResponse</var>'s <a for=response>status</a> is 206, <var>internalResponse</var>'s
-  <a for=response>range-requested flag</a> is set, and <var>request</var>'s
-  <a for=request>header list</a> <a for="header list">does not contain</a> `<code>Range</code>`,
-  then set <var>response</var> and <var>internalResponse</var> to a <a>network error</a>.
+  <var>internalResponse</var>'s <a for=response>status</a> is a <a>range status</a>,
+  <var>internalResponse</var>'s <a for=response>range-requested flag</a> is set, and
+  <var>request</var>'s <a for=request>header list</a> <a for="header list">does not contain</a>
+  `<code>Range</code>`, then set <var>response</var> and <var>internalResponse</var> to a
+  <a>network error</a>.
 
   <div class=note>
    <p>Traditionally, APIs accept a ranged response even if a range was not requested. This prevents
-   a partial response from an earlier ranged request being provided to an API that did not make a
-   range request.
+   a partial response or a range not satisfiable response from an earlier ranged request being
+   provided to an API that did not make a range request.
 
    <details>
     <summary>Further details</summary>
@@ -10328,6 +10331,7 @@ Wayne Carr,
 Xabier Rodríguez,
 Yehuda Katz,
 Yoav Weiss,
+Yoshisato Yanagisawa<!-- yoshisatoyanagisawa; GitHub -->,
 Youenn Fablet<!-- youennf; GitHub -->,
 Yoichi Osato,
 平野裕 (Yutaka Hirano), and


### PR DESCRIPTION
While it is less likely you can attack a 416, it's probably good to stay consistent.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium presumably
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/57225
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A (doesn't pass the test, but has yet to do work in this general area)
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=305548
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1907.html" title="Last updated on Jan 14, 2026, 7:26 AM UTC (866083c)">Preview</a> | <a href="https://whatpr.org/fetch/1907/3d04edb...866083c.html" title="Last updated on Jan 14, 2026, 7:26 AM UTC (866083c)">Diff</a>