### PR TITLE
Define ABNF for `origin-or-null.

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -3604,9 +3604,57 @@ request <a for=/>header</a> indicates where a
 <!-- Ian Hickson told me Adam Barth researched that -->
 
 <p>Its possible <a for=header>values</a> are all the return values of
-<a>byte-serializing a request origin</a>, given a <a for=/>request</a>.
+<a>byte-serializing a request origin</a>, given a <a for=/>request</a>. These are represented by
+the following <a>ABNF</a>:
 
-<p class=note>This supplants the definition in <cite>The Web Origin Concept</cite>. [[ORIGIN]]
+<pre><code class=lang-abnf>
+<dfn export>serialized-ipv4</dfn> = <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a>
+<dfn export>dec-octet</dfn>       = DIGIT                 ; 0-9
+                / %x31-39 DIGIT         ; 10-99
+                / "1" 2DIGIT            ; 100-199
+                / "2" %x30-34 DIGIT     ; 200-249
+                / "25" %x30-35          ; 250-255
+
+<dfn export>serialized-ipv6</dfn> =                       7( h16 ":" ) h16
+                /                       "::" 5( h16 ":" ) h16
+                / [               h16 ] "::" 4( h16 ":" ) h16
+                / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) h16
+                / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) h16
+                / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   h16
+                / [ *4( h16 ":" ) h16 ] "::"              h16
+                / [ *5( h16 ":" ) h16 ] "::"
+<dfn export>h16</dfn>             = "0" / ( non-zero-hex 0*3hex )
+<dfn export>non-zero-hex</dfn>    = %x31-39 / %x61-66 ; '1'-'9' or lowercase 'a'-'f'
+<dfn export>hex</dfn>             = %x30-39 / %x61-66 ; '0'-'9' or lowercase 'a'-'f
+
+<dfn export>lower-ascii</dfn>       = %x61-7A
+<dfn export>serialized-domain</dfn> = 1*( <a>lower-ascii</a> / DIGIT / "-" / "." / "_" )
+
+<dfn export>serialized-scheme</dfn> = lower-ascii *( lower-ascii / DIGIT / "+" / "-" / "." )
+<dfn export>serialized-host</dfn>   = <a>serialized-ipv4</a> / <a>serialized-ipv6</a> / <a>serialized-domain</a>
+<dfn export>serialized-port</dfn>   = *DIGIT
+
+<dfn export>serialized-origin</dfn> = <a>serialized-scheme</a> "://" <a>serialized-host</a> [ ":" <a>serialized-port</a> ]
+<dfn export>origin-or-null</dfn>    = <a>serialized-origin</a> / %s"null" ; case-sensitive
+
+Origin = <a>origin-or-null</a>
+</code></pre>
+
+<div class=note>
+<p>This supplants the definition in <cite>The Web Origin Concept</cite>. [[ORIGIN]]
+
+<p>The origin serialization defined here is more constrained than [[RFC3986]]'s grammar in two
+substantial ways. First, scheme and domains serializations are all lower case ASCII, without
+percent encoding. Second, following the recommendations of [[URL#host-serializing]] and [[RFC5952]],
+IPv6 addresses are limited as follows:
+
+<ul class=brief>
+  <li>The least-significant digits cannot be represented as an IPv4 address.
+  <li>Leading zeros are forbidden.
+  <li>All hex characters are lowercase.
+  <li>"::" can't elide only a single "0" block, so we allow at most 6 blocks when "::" is present.
+</ul>
+</div>
 
 <hr>
 
@@ -3819,7 +3867,6 @@ tactics can differ between the response to the <a>CORS-preflight request</a> and
 Access-Control-Request-Method    = <a spec=http>method</a>
 Access-Control-Request-Headers   = 1#<a spec=http>field-name</a>
 
-<dfn export>origin-or-null</dfn>                   = <a spec=rfc6454>serialized-origin</a> / %s"null" ; case-sensitive
 <dfn export>wildcard</dfn>                         = "*"
 Access-Control-Allow-Origin      = <a>origin-or-null</a> / <a>wildcard</a>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3627,12 +3627,14 @@ the following <a>ABNF</a>:
 <dfn export>non-zero-hex</dfn>      = %x31-39 / %x61-66 ; '1'-'9' or lowercase 'a'-'f'
 <dfn export>hex</dfn>               = %x30-39 / %x61-66 ; '0'-'9' or lowercase 'a'-'f
 
-<dfn export>lower-ascii</dfn>       = %x61-7A
-<dfn export>serialized-domain</dfn> = 1*( <a>lower-ascii</a> / DIGIT / "-" / "." / "_" )
+<dfn export>lower-alpha</dfn>       = %x61-7A
+<dfn export>lower-alphanum</dfn>    = <a>lower-alpha</a> / DIGIT
+<dfn export>domain-label</dfn>      = <dfn export>lower-alphanum</dfn> / ( <dfn export>lower-alphanum</dfn> *( <dfn export>lower-alphanum</dfn> / "-" ) <dfn export>lower-alphanum</dfn> )
+<dfn export>serialized-domain</dfn> = *( <a>domain-label</a> "." ) <a>domain-label</a>
 
-<dfn export>serialized-scheme</dfn> = lower-ascii *( lower-ascii / DIGIT / "+" / "-" / "." )
+<dfn export>serialized-scheme</dfn> = <a>lower-alpha</a> *( <a>lower-alphanum</a> / "+" / "-" / "." )
 <dfn export>serialized-host</dfn>   = <a>serialized-ipv4</a> / "[" <a>serialized-ipv6</a> "]" / <a>serialized-domain</a>
-<dfn export>serialized-port</dfn>   = 1*DIGIT
+<dfn export>serialized-port</dfn>   = 1*5DIGIT
 
 <dfn export>serialized-origin</dfn> = <a>serialized-scheme</a> "://" <a>serialized-host</a> [ ":" <a>serialized-port</a> ]
 <dfn export>origin-or-null</dfn>    = <a>serialized-origin</a> / %s"null" ; case-sensitive

--- a/fetch.bs
+++ b/fetch.bs
@@ -3608,31 +3608,31 @@ request <a for=/>header</a> indicates where a
 the following <a>ABNF</a>:
 
 <pre><code class=lang-abnf>
-<dfn export>serialized-ipv4</dfn> = <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a>
-<dfn export>dec-octet</dfn>       = DIGIT                 ; 0-9
-                / %x31-39 DIGIT         ; 10-99
-                / "1" 2DIGIT            ; 100-199
-                / "2" %x30-34 DIGIT     ; 200-249
-                / "25" %x30-35          ; 250-255
+<dfn export>serialized-ipv4</dfn>   = <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a> "." <a>dec-octet</a>
+<dfn export>dec-octet</dfn>         = DIGIT                 ; 0-9
+                  / %x31-39 DIGIT         ; 10-99
+                  / "1" 2DIGIT            ; 100-199
+                  / "2" %x30-34 DIGIT     ; 200-249
+                  / "25" %x30-35          ; 250-255
 
-<dfn export>serialized-ipv6</dfn> =                       7( h16 ":" ) h16
-                /                       "::" 5( h16 ":" ) h16
-                / [               h16 ] "::" 4( h16 ":" ) h16
-                / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) h16
-                / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) h16
-                / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   h16
-                / [ *4( h16 ":" ) h16 ] "::"              h16
-                / [ *5( h16 ":" ) h16 ] "::"
-<dfn export>h16</dfn>             = "0" / ( non-zero-hex 0*3hex )
-<dfn export>non-zero-hex</dfn>    = %x31-39 / %x61-66 ; '1'-'9' or lowercase 'a'-'f'
-<dfn export>hex</dfn>             = %x30-39 / %x61-66 ; '0'-'9' or lowercase 'a'-'f
+<dfn export>serialized-ipv6</dfn>   =                            7( h16 ":" ) h16
+                  /                       "::" 5( h16 ":" ) h16
+                  / [               h16 ] "::" 4( h16 ":" ) h16
+                  / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) h16
+                  / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) h16
+                  / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   h16
+                  / [ *4( h16 ":" ) h16 ] "::"              h16
+                  / [ *5( h16 ":" ) h16 ] "::"
+<dfn export>h16</dfn>               = "0" / ( non-zero-hex 0*3hex )
+<dfn export>non-zero-hex</dfn>      = %x31-39 / %x61-66 ; '1'-'9' or lowercase 'a'-'f'
+<dfn export>hex</dfn>               = %x30-39 / %x61-66 ; '0'-'9' or lowercase 'a'-'f
 
 <dfn export>lower-ascii</dfn>       = %x61-7A
 <dfn export>serialized-domain</dfn> = 1*( <a>lower-ascii</a> / DIGIT / "-" / "." / "_" )
 
 <dfn export>serialized-scheme</dfn> = lower-ascii *( lower-ascii / DIGIT / "+" / "-" / "." )
-<dfn export>serialized-host</dfn>   = <a>serialized-ipv4</a> / <a>serialized-ipv6</a> / <a>serialized-domain</a>
-<dfn export>serialized-port</dfn>   = *DIGIT
+<dfn export>serialized-host</dfn>   = <a>serialized-ipv4</a> / "[" <a>serialized-ipv6</a> "]" / <a>serialized-domain</a>
+<dfn export>serialized-port</dfn>   = 1*DIGIT
 
 <dfn export>serialized-origin</dfn> = <a>serialized-scheme</a> "://" <a>serialized-host</a> [ ":" <a>serialized-port</a> ]
 <dfn export>origin-or-null</dfn>    = <a>serialized-origin</a> / %s"null" ; case-sensitive

--- a/fetch.bs
+++ b/fetch.bs
@@ -3629,7 +3629,7 @@ the following <a>ABNF</a>:
 
 <dfn export>lower-alpha</dfn>       = %x61-7A
 <dfn export>lower-alphanum</dfn>    = <a>lower-alpha</a> / DIGIT
-<dfn export>domain-label</dfn>      = <dfn export>lower-alphanum</dfn> / ( <dfn export>lower-alphanum</dfn> *( <dfn export>lower-alphanum</dfn> / "-" ) <dfn export>lower-alphanum</dfn> )
+<dfn export>domain-label</dfn>      = <a>lower-alphanum</a> / ( <a>lower-alphanum</a> *( <a>lower-alphanum</a> / "-" ) <a>lower-alphanum</a> )
 <dfn export>serialized-domain</dfn> = *( <a>domain-label</a> "." ) <a>domain-label</a>
 
 <dfn export>serialized-scheme</dfn> = <a>lower-alpha</a> *( <a>lower-alphanum</a> / "+" / "-" / "." )

--- a/fetch.bs
+++ b/fetch.bs
@@ -66,6 +66,9 @@ urlPrefix:https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cooki
     url:name-retrieve-cookies;text:retrieve cookies
     url:name-serialize-cookies;text:serialize cookies
     url:name-garbage-collect-cookies;text:garbage collect cookies
+
+urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
+    url:section-7.1;text:serialized-origin
 </pre>
 
 <pre class=biblio>
@@ -3816,8 +3819,10 @@ tactics can differ between the response to the <a>CORS-preflight request</a> and
 Access-Control-Request-Method    = <a spec=http>method</a>
 Access-Control-Request-Headers   = 1#<a spec=http>field-name</a>
 
-wildcard                         = "*"
-Access-Control-Allow-Origin      = origin-or-null / wildcard
+<dfn export>origin-or-null</dfn>                   = <a spec=rfc6454>serialized-origin</a> / %s"null" ; case-sensitive
+<dfn export>wildcard</dfn>                         = "*"
+Access-Control-Allow-Origin      = <a>origin-or-null</a> / <a>wildcard</a>
+
 Access-Control-Allow-Credentials = %s"true" ; case-sensitive
 Access-Control-Expose-Headers    = #<a spec=http>field-name</a>
 Access-Control-Max-Age           = <a spec=http-caching>delta-seconds</a>


### PR DESCRIPTION
The ABNF for `Access-Control-Allow-Origin` relies upon the `origin-or-null` syntax, which doesn't exist in RFC6454 (see https://www.rfc-editor.org/errata/eid3249). This patch defines the intended syntax.

This is intended to be an editorial change without any change in behavior, but adding grammar is somewhat normative? Idunno.

This patch also takes a normative dependency on RFC6454 for the `serialized-origin` grammar, which might not be ideal. We could copy it here if you'd prefer.

WDYT?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1924.html" title="Last updated on Apr 29, 2026, 9:11 AM UTC (0d064b9)">Preview</a> | <a href="https://whatpr.org/fetch/1924/dfdd250...0d064b9.html" title="Last updated on Apr 29, 2026, 9:11 AM UTC (0d064b9)">Diff</a>