### PR TITLE
Feat/add nosniff examples

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -10216,6 +10216,7 @@ done only by navigations). The <a>fetch controller</a> is also used to
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>
 
 <p>Thanks to
+Sneha Lata
 Adam Barth,
 Adam Lavin,
 Alan Jeffrey,

--- a/fetch.bs
+++ b/fetch.bs
@@ -4306,6 +4306,14 @@ X-Content-Type-Options           = "nosniff" ; case-insensitive
 
  <li><p>Let <var>destination</var> be <var>request</var>'s <a for=request>destination</a>.
 
+<div class="example" id="example-nosniff-strict">
+ <p>The <code>X-Content-Type-Options</code> header requires a strict MIME type match. For
+ example, if a server returns a script with <code>X-Content-Type-Options</code> set to
+ "<code>nosniff</code>" but the <code>Content-Type</code> header is <code>text/plain</code> or
+ missing entirely, the user agent will block the response.
+</div>
+
+
  <li><p>If <var>destination</var> is <a for=request/destination>script-like</a> and
  <var>mimeType</var> is failure or is not a <a>JavaScript MIME type</a>, then return <b>blocked</b>.
 


### PR DESCRIPTION
Added a documentation example to the nosniff section to clarify that the user agent must block responses when a strict MIME type match is not met (eg : missing or incorrect Content- Type).This address the ambiguity discussed in the linked issue.

Fixes #636


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg/1925.html" title="Last updated on Apr 26, 2026, 12:42 PM UTC (38bfd9e)">Preview</a> | <a href="https://whatpr.org/fetch/1925/8099043...38bfd9e.html" title="Last updated on Apr 26, 2026, 12:42 PM UTC (38bfd9e)">Diff</a>