### PR TITLE
Update script destination CSP directive mapping

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1932,7 +1932,7 @@ not always relevant and might require different behavior.
    <td><code>CSS.paintWorklet.addModule()</code>
   <tr>
    <td>"<code>script</code>"
-   <td><code>script-src</code>
+   <td><code>script-src-elem</code>
    <td>HTML's <code>&lt;script></code>, <code>importScripts()</code>
   <tr>
    <td>"<code>serviceworker</code>"


### PR DESCRIPTION
Fixes #1466

Updates the request destination / CSP directive mapping
for `script` to reflect CSP Level 3 terminology.

Changes:
- `script-src` → `script-src-elem`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1928.html" title="Last updated on May 14, 2026, 8:42 PM UTC (929ee2c)">Preview</a> | <a href="https://whatpr.org/fetch/1928/301650c...929ee2c.html" title="Last updated on May 14, 2026, 8:42 PM UTC (929ee2c)">Diff</a>