### PR TITLE
Update :protocol to webtransport-h3 for WebTransport over HTTP/3

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -126,6 +126,12 @@ urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
         "publisher": "IETF",
         "title": "WebTransport over HTTP/3"
     },
+    "WEBTRANSPORT-HTTP2": {
+        "authors": ["E. Kinnear"],
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2",
+        "publisher": "IETF",
+        "title": "WebTransport over HTTP/2"
+    },
     "SVCB": {
         "aliasOf": "RFC9460"
     }
@@ -6658,10 +6664,16 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
    <li>
     <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>",
+    <var>request</var>'s <a for=request>method</a> is `<code>CONNECT</code>`,
     <var>connection</var> is an HTTP/3 connection, and the "<code>:protocol</code>"
-    pseudo-header associated with <var>request</var>'s <a for=request>method</a> is
+    pseudo-header associated with <var>request</var> is
     "<code>webtransport</code>", then set the "<code>:protocol</code>" pseudo-header to
     "<code>webtransport-h3</code>". [[!WEBTRANSPORT-HTTP3]]
+
+    <div class=note>
+     "<code>webtransport</code>" remains the correct value for WebTransport over an HTTP/2
+     connection. [[WEBTRANSPORT-HTTP2]]
+    </div>
 
    <li>
     <p>Set <var>response</var> to the result of making an HTTP request over <var>connection</var>

--- a/fetch.bs
+++ b/fetch.bs
@@ -6657,6 +6657,13 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch params">cross-origin isolated capability</a>.
 
    <li>
+    <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>",
+    <var>connection</var> is an HTTP/3 connection, and the "<code>:protocol</code>"
+    pseudo-header associated with <var>request</var>'s <a for=request>method</a> is
+    "<code>webtransport</code>", then set the "<code>:protocol</code>" pseudo-header to
+    "<code>webtransport-h3</code>". [[!WEBTRANSPORT-HTTP3]]
+
+   <li>
     <p>Set <var>response</var> to the result of making an HTTP request over <var>connection</var>
     using <var>request</var> with the following caveats:
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -6663,17 +6663,24 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch params">cross-origin isolated capability</a>.
 
    <li>
-    <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>",
-    <var>request</var>'s <a for=request>method</a> is `<code>CONNECT</code>`,
-    <var>connection</var> is an HTTP/3 connection, and the "<code>:protocol</code>"
-    pseudo-header associated with <var>request</var> is
-    "<code>webtransport</code>", then set the "<code>:protocol</code>" pseudo-header to
-    "<code>webtransport-h3</code>". [[!WEBTRANSPORT-HTTP3]]
+    <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>", then:
 
-    <div class=note>
-     "<code>webtransport</code>" remains the correct value for WebTransport over an HTTP/2
-     connection. [[WEBTRANSPORT-HTTP2]]
-    </div>
+    <ol>
+     <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>method</a> is
+     `<code>CONNECT</code>`.
+
+     <li><p><a for=/>Assert</a>: the "<code>:protocol</code>" pseudo-header associated with
+     <var>request</var> is "<code>webtransport</code>".
+
+     <li><p>If <var>connection</var> is an HTTP/3 connection, then set the
+     "<code>:protocol</code>" pseudo-header to "<code>webtransport-h3</code>".
+     [[!WEBTRANSPORT-HTTP3]]
+
+     <div class=note>
+      "<code>webtransport</code>" remains the correct value for WebTransport over an HTTP/2
+      connection. [[WEBTRANSPORT-HTTP2]]
+     </div>
+    </ol>
 
    <li>
     <p>Set <var>response</var> to the result of making an HTTP request over <var>connection</var>

--- a/fetch.bs
+++ b/fetch.bs
@@ -6663,7 +6663,7 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
    <a for="fetch params">cross-origin isolated capability</a>.
 
    <li>
-    <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>", then:
+    <p>If <var>request</var>'s <a for=request>mode</a> is "<code>webtransport</code>":
 
     <ol>
      <li><p><a for=/>Assert</a>: <var>request</var>'s <a for=request>method</a> is
@@ -6672,14 +6672,12 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
      <li><p><a for=/>Assert</a>: the "<code>:protocol</code>" pseudo-header associated with
      <var>request</var> is "<code>webtransport</code>".
 
-     <li><p>If <var>connection</var> is an HTTP/3 connection, then set the
-     "<code>:protocol</code>" pseudo-header to "<code>webtransport-h3</code>".
-     [[!WEBTRANSPORT-HTTP3]]
+     <li>
+      <p>If <var>connection</var> is an HTTP/3 connection, then set the "<code>:protocol</code>"
+      pseudo-header to "<code>webtransport-h3</code>". [[!WEBTRANSPORT-HTTP3]]
 
-     <div class=note>
-      "<code>webtransport</code>" remains the correct value for WebTransport over an HTTP/2
-      connection. [[WEBTRANSPORT-HTTP2]]
-     </div>
+      <p class=note>"<code>webtransport</code>" remains the correct value for WebTransport over an
+      HTTP/2 connection. [[WEBTRANSPORT-HTTP2]]
     </ol>
 
    <li>


### PR DESCRIPTION
[WebTransport over HTTP/3 draft-15](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-15#name-creating-a-new-session:~:text=be%20set%20to-,webtransport%2Dh3,-.) renamed the extended-CONNECT `:protocol` pseudo-header value from `webtransport` to `webtransport-h3`. [WebTransport over HTTP/2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2-14#name-creating-a-new-session:~:text=to-,webtransport) keeps `webtransport`, making it depend on _connection_.

- [ ] At least two implementers are interested (and none opposed):
   * Firefox: implementing draft-15 in [bug 2033974](https://bugzil.la/2033974)
   * Chromium: …
   * WebKit: …
- [ ] Tested with web-platform-tests: WebTransport WPT exercises the H3 handshake; the draft-15 `:protocol` value is covered by the server update in [bug 2033974](https://bugzil.la/2033974).
- [ ] MDN issue / update: N/A (not author-observable).
- [x] The top of this comment includes a clear commit message.
- [ ] At least two implementers are interested (and none opposed):
   * …
   * …


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1930.html" title="Last updated on Jun 26, 2026, 12:18 PM UTC (eb06c09)">Preview</a> | <a href="https://whatpr.org/fetch/1930/301650c...eb06c09.html" title="Last updated on Jun 26, 2026, 12:18 PM UTC (eb06c09)">Diff</a>