### PR TITLE
Add TAO destination check for navigation redirect chains

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2308,8 +2308,8 @@ Unless stated otherwise, it is unset.
 otherwise, it is unset.
 
 <p>A <a for=/>request</a> has an associated
-<dfn for=request>navigation timing allow check set</dfn> (a <a for=/>list</a> of zero or
-more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn for=request>navigation timing allow check set</dfn> (an <a for=/>ordered set</a> of zero
+or more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
 
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
@@ -2614,8 +2614,8 @@ the response of a redirect has to be set if it was set for previous responses in
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response>navigation timing allow check set</dfn> (a <a for=/>list</a> of zero or
-more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn export for=response>navigation timing allow check set</dfn> (an <a for=/>ordered set</a> of
+zero or more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
 
 <p class=note>This is used by <a for=/>responses</a> to <a>navigation requests</a> so that
 callers can determine, once the navigation's destination origin is known, whether that origin is
@@ -5119,7 +5119,7 @@ steps:
 
  <li><p>If <var>request</var> is a <a>navigation request</a>, then set
  <var>internalResponse</var>'s <a for=response>navigation timing allow check set</a> to a
- <a for=list>clone</a> of <var>request</var>'s
+ <a for=set>clone</a> of <var>request</var>'s
  <a for=request>navigation timing allow check set</a>.
 
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
@@ -5903,7 +5903,7 @@ these steps:
 
   <ol>
    <li><p>If <var>request</var> is a <a>navigation request</a>, then
-   <a>update a request's navigation timing allow check set</a> given <var>request</var> and
+   <a>restrict a request's navigation timing allow check set</a> given <var>request</var> and
    <var>internalResponse</var>.
 
    <li>
@@ -7334,7 +7334,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 </div>
 
 <div algorithm>
-<p>To <dfn>update a request's navigation timing allow check set</dfn>, given a
+<p>To <dfn>restrict a request's navigation timing allow check set</dfn>, given a
 <a for=/>request</a> <var>request</var> and a <a for=/>response</a> <var>response</var>, run these
 steps:
 
@@ -7348,33 +7348,35 @@ steps:
  <li><p>If <var>taoValues</var> is null, then set <var>taoValues</var> to « ».
 
  <li><p>If <var>taoValues</var> <a for=list>contains</a> "<code>*</code>", then return.
+ <p class="note">If the current response contains "*", it does not further restrict the chain.
 
  <li><p>Let <var>currentSet</var> be <var>request</var>'s
  <a for=request>navigation timing allow check set</a>.
 
- <li><p>Let <var>newSet</var> be « ».
+ <li><p>Let <var>newSet</var> be a new <a for=/>ordered set</a>.
 
  <li>
-  <p>If <var>currentSet</var> <a for=list>contains</a> "<code>*</code>", then:
+  <p>If <var>currentSet</var> <a for=set>contains</a> "<code>*</code>", then:
+
+  <p class=note>If all previous responses in the chain contained "<code>*</code>", the current
+  response's values can be taken as is.
 
   <ol>
-   <li>
-    <p><a for=list>For each</a> <var>taoValue</var> of <var>taoValues</var>:
+   <li><p><a for=list>For each</a> <var>taoValue</var> of <var>taoValues</var>,
+   <a for=set>append</a> <var>taoValue</var> to <var>newSet</var>.
 
-    <ol>
-     <li><p>If <var>newSet</var> <a for=list>contains</a> <var>taoValue</var>, then
-     <a for=iteration>continue</a>.
+   <li><p>Set <var>request</var>'s <a for=request>navigation timing allow check set</a> to
+   <var>newSet</var>.
 
-     <li><p><a for=list>Append</a> <var>taoValue</var> to <var>newSet</var>.
-    </ol>
+   <li><p>Return.
   </ol>
 
  <li>
-  <p>Otherwise, <a for=list>for each</a> <var>allowedOrigin</var> of <var>currentSet</var>:
+  <p><a for=set>For each</a> <var>allowedOrigin</var> of <var>currentSet</var>:
 
   <ol>
    <li><p>If <var>taoValues</var> <a for=list>contains</a> <var>allowedOrigin</var>, then
-   <a for=list>append</a> <var>allowedOrigin</var> to <var>newSet</var>.
+   <a for=set>append</a> <var>allowedOrigin</var> to <var>newSet</var>.
   </ol>
 
  <li><p>Set <var>request</var>'s <a for=request>navigation timing allow check set</a> to
@@ -7389,10 +7391,10 @@ steps:
 
 <ol>
  <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
- <a for=list>contains</a> "<code>*</code>", then return success.
+ <a for=set>contains</a> "<code>*</code>", then return success.
 
  <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
- <a for=list>contains</a> <var>destinationOrigin</var>,
+ <a for=set>contains</a> <var>destinationOrigin</var>,
  <a lt="ASCII serialization of an origin">serialized</a>, then return success.
 
  <li><p>Return failure.

--- a/fetch.bs
+++ b/fetch.bs
@@ -135,6 +135,7 @@ urlPrefix:https://www.rfc-editor.org/rfc/rfc6454;type:dfn;spec:RFC6454
 <pre class=link-defaults>
 spec:dom; type:dfn; text:element
 spec:infra; type:dfn; text:implementation-defined
+spec:infra; type:dfn; text:success
 </pre>
 
 
@@ -2308,17 +2309,17 @@ Unless stated otherwise, it is unset.
 otherwise, it is unset.
 
 <p>A <a for=/>request</a> has an associated
-<dfn for=request>navigation timing allow check list</dfn> (a <a for=/>list</a> of
+<dfn for=request>navigation timing allow values list</dfn> (a <a for=/>list</a> of
 <a for=/>lists</a> of <a for=/>strings</a>). Unless stated otherwise, it is « ».
 
-<p class=note>Each <a for=list>item</a> in the <a for=request>navigation timing allow check list</a>
+<p class=note>Each <a for=list>item</a> in the <a for=request>navigation timing allow values list</a>
 holds the `<code>Timing-Allow-Origin</code>` values of one redirect <a for=/>response</a> in a
 navigation's redirect chain.
 
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
 <a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
-<a for=request>navigation timing allow check list</a> are used as bookkeeping details by the
+<a for=request>navigation timing allow values list</a> are used as bookkeeping details by the
 <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -2618,7 +2619,7 @@ the response of a redirect has to be set if it was set for previous responses in
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response>navigation timing allow check list</dfn> (a <a for=/>list</a> of
+<dfn export for=response>navigation timing allow values list</dfn> (a <a for=/>list</a> of
 <a for=/>lists</a> of <a for=/>strings</a>). Unless stated otherwise, it is « ».
 
 <p class=note>This holds the `<code>Timing-Allow-Origin</code>` values of each redirect
@@ -5123,9 +5124,9 @@ steps:
  <a for=request>redirect-taint</a>.
 
  <li><p>If <var>request</var> is a <a>navigation request</a>, then set
- <var>internalResponse</var>'s <a for=response>navigation timing allow check list</a> to a
+ <var>internalResponse</var>'s <a for=response>navigation timing allow values list</a> to a
  <a for=list>clone</a> of <var>request</var>'s
- <a for=request>navigation timing allow check list</a>.
+ <a for=request>navigation timing allow values list</a>.
 
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
@@ -5908,7 +5909,7 @@ these steps:
 
   <ol>
    <li><p>If <var>request</var> is a <a>navigation request</a>, then
-   <a>append to a request's navigation timing allow check list</a> given <var>request</var> and
+   <a>append to a request's navigation timing allow values list</a> given <var>request</var> and
    <var>internalResponse</var>.
 
    <li>
@@ -7339,9 +7340,8 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 </div>
 
 <div algorithm>
-<p>To <dfn>append to a request's navigation timing allow check list</dfn>, given a
-<a for=/>request</a> <var>request</var> and a <a for=/>response</a> <var>response</var>, run these
-steps:
+<p>To <dfn>append to a request's navigation timing allow values list</dfn>, given a
+<a for=/>request</a> <var>request</var> and a <a for=/>response</a> <var>response</var>:
 
 <ol>
  <li><p><a for=/>Assert</a>: <var>request</var> is a <a>navigation request</a>.
@@ -7353,19 +7353,19 @@ steps:
  <li><p>If <var>taoValues</var> is null, then set <var>taoValues</var> to « ».
 
  <li><p><a for=list>Append</a> <var>taoValues</var> to <var>request</var>'s
- <a for=request>navigation timing allow check list</a>.
+ <a for=request>navigation timing allow values list</a>.
 </ol>
 </div>
 
 <div algorithm>
-<p>To perform a <dfn export id=concept-navigation-tao-check>navigation TAO check</dfn> for a
+<p>To perform a <dfn export>navigation TAO check</dfn> for a
 <a for=/>response</a> <var>response</var> and an <a for=/>origin</a>
-<var>destinationOrigin</var>, run these steps:
+<var>destinationOrigin</var>:
 
 <ol>
  <li>
   <p><a for=list>For each</a> <var>taoValues</var> of <var>response</var>'s
-  <a for=response>navigation timing allow check list</a>:
+  <a for=response>navigation timing allow values list</a>:
 
   <ol>
    <li><p>If <var>taoValues</var> <a for=list>contains</a> "<code>*</code>", then
@@ -7374,10 +7374,10 @@ steps:
    <li><p>If <var>taoValues</var> <a for=list>contains</a> <var>destinationOrigin</var>,
    <a lt="ASCII serialization of an origin">serialized</a>, then <a for=iteration>continue</a>.
 
-   <li><p>Return failure.
+   <li><p>Return <a for=/>failure</a>.
   </ol>
 
- <li><p>Return success.
+ <li><p>Return <a for=/>success</a>.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -7378,17 +7378,17 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 <div algorithm>
 <p>To perform a <dfn export id=concept-navigation-tao-check>navigation TAO check</dfn> for a
 <a for=/>response</a> <var>response</var> and an <a for=/>origin</a>
-<var>destinationOrigin</var>, run these steps. They return a boolean.
+<var>destinationOrigin</var>, run these steps:
 
 <ol>
  <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
- "<code>*</code>", then return true.
+ "<code>*</code>", then return success.
 
  <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
  <var>destinationOrigin</var>, <a lt="ASCII serialization of an origin">serialized</a>, then return
- true.
+ success.
 
- <li><p>Return false.
+ <li><p>Return failure.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2307,10 +2307,15 @@ Unless stated otherwise, it is unset.
 <dfn export for=request id=timing-allow-failed>timing allow failed flag</dfn>. Unless stated
 otherwise, it is unset.
 
+<p>A <a for=/>request</a> has an associated
+<dfn for=request>timing allow check set</dfn> (a <a for=/>list</a> of zero or more
+<a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
-<a for=request>done flag</a>, and <a for=request>timing allow failed flag</a> are used as
-bookkeeping details by the <a for=/>fetch</a> algorithm.
+<a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
+<a for=request>timing allow check set</a> are used as bookkeeping details by the
+<a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
 <dfn export for=request id=concept-webdriver-id>WebDriver id</dfn>
@@ -2607,6 +2612,14 @@ initially unset.
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
 the response of a redirect has to be set if it was set for previous responses in the redirect chain,
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
+
+<p>A <a for=/>response</a> has an associated
+<dfn export for=response>timing allow check set</dfn> (a <a for=/>list</a> of zero or more
+<a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+
+<p class=note>This is used by <a for=/>responses</a> to <a>navigation requests</a> so that
+callers can determine, once the navigation's destination origin is known, whether that origin is
+allowed by every redirect in the redirect chain.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-body-info>body info</dfn>
@@ -5104,6 +5117,10 @@ steps:
  <li><p>Set <var>internalResponse</var>'s <a for=response>redirect taint</a> to <var>request</var>'s
  <a for=request>redirect-taint</a>.
 
+ <li><p>If <var>request</var> is a <a>navigation request</a>, then set
+ <var>internalResponse</var>'s <a for=response>timing allow check set</a> to a <a for=list>clone</a>
+ of <var>request</var>'s <a for=request>timing allow check set</a>.
+
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
 
@@ -5884,6 +5901,10 @@ these steps:
   <p>If <var>internalResponse</var>'s <a for=response>status</a> is a <a>redirect status</a>:
 
   <ol>
+   <li><p>If <var>request</var> is a <a>navigation request</a>, then
+   <a>update a request's timing allow check set</a> given <var>request</var> and
+   <var>internalResponse</var>.
+
    <li>
     <p>If <var>internalResponse</var>'s <a for=response>status</a> is not 303, <var>request</var>'s
     <a for=request>body</a> is non-null, and the <a>connection</a> uses HTTP/2, then user agents
@@ -7308,6 +7329,66 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
  return success.
 
  <li><p>Return failure.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn>update a request's timing allow check set</dfn>, given a <a for=/>request</a>
+<var>request</var> and a <a for=/>response</a> <var>response</var>, run these steps:
+
+<ol>
+ <li><p><a for=/>Assert</a>: <var>request</var> is a <a>navigation request</a>.
+
+ <li><p>Let <var>values</var> be the result of
+ <a for="header list">getting, decoding, and splitting</a> `<code>Timing-Allow-Origin</code>` from
+ <var>response</var>'s <a for=response>header list</a>.
+
+ <li><p>If <var>values</var> is null, then set <var>values</var> to « ».
+
+ <li><p>Let <var>newSet</var> be « ».
+
+ <li>
+  <p><a for=list>For each</a> <var>value</var> of <var>request</var>'s
+  <a for=request>timing allow check set</a>:
+
+  <ol>
+   <li><p>If <var>values</var> <a for=list>contains</a> <var>value</var>, or
+   <var>values</var> <a for=list>contains</a> "<code>*</code>", then <a for=list>append</a>
+   <var>value</var> to <var>newSet</var>.
+  </ol>
+
+ <li>
+  <p>If <var>request</var>'s <a for=request>timing allow check set</a> <a for=list>contains</a>
+  "<code>*</code>", then <a for=list>for each</a> <var>value</var> of <var>values</var>:
+
+  <ol>
+   <li><p>If <var>newSet</var> <a for=list>contains</a> <var>value</var>, then
+   <a for=iteration>continue</a>.
+
+   <li><p><a for=list>Append</a> <var>value</var> to <var>newSet</var>.
+  </ol>
+
+ <li><p>If <var>values</var> <a for=list>contains</a> "<code>*</code>" is false, then
+ <a for=list>remove</a> "<code>*</code>" from <var>newSet</var>.
+
+ <li><p>Set <var>request</var>'s <a for=request>timing allow check set</a> to <var>newSet</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To perform a <dfn export id=concept-navigation-tao-check>navigation TAO check</dfn> for a
+<a for=/>response</a> <var>response</var> and an <a for=/>origin</a>
+<var>destinationOrigin</var>, run these steps. They return a boolean.
+
+<ol>
+ <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
+ "<code>*</code>", then return true.
+
+ <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
+ <var>destinationOrigin</var>, <a lt="ASCII serialization of an origin">serialized</a>, then return
+ true.
+
+ <li><p>Return false.
 </ol>
 </div>
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -2308,13 +2308,13 @@ Unless stated otherwise, it is unset.
 otherwise, it is unset.
 
 <p>A <a for=/>request</a> has an associated
-<dfn for=request>timing allow check set</dfn> (a <a for=/>list</a> of zero or more
-<a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn for=request>navigation timing allow check set</dfn> (a <a for=/>list</a> of zero or
+more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
 
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
 <a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
-<a for=request>timing allow check set</a> are used as bookkeeping details by the
+<a for=request>navigation timing allow check set</a> are used as bookkeeping details by the
 <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -2614,8 +2614,8 @@ the response of a redirect has to be set if it was set for previous responses in
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response>timing allow check set</dfn> (a <a for=/>list</a> of zero or more
-<a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn export for=response>navigation timing allow check set</dfn> (a <a for=/>list</a> of zero or
+more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
 
 <p class=note>This is used by <a for=/>responses</a> to <a>navigation requests</a> so that
 callers can determine, once the navigation's destination origin is known, whether that origin is
@@ -5118,8 +5118,9 @@ steps:
  <a for=request>redirect-taint</a>.
 
  <li><p>If <var>request</var> is a <a>navigation request</a>, then set
- <var>internalResponse</var>'s <a for=response>timing allow check set</a> to a <a for=list>clone</a>
- of <var>request</var>'s <a for=request>timing allow check set</a>.
+ <var>internalResponse</var>'s <a for=response>navigation timing allow check set</a> to a
+ <a for=list>clone</a> of <var>request</var>'s
+ <a for=request>navigation timing allow check set</a>.
 
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
@@ -5902,7 +5903,7 @@ these steps:
 
   <ol>
    <li><p>If <var>request</var> is a <a>navigation request</a>, then
-   <a>update a request's timing allow check set</a> given <var>request</var> and
+   <a>update a request's navigation timing allow check set</a> given <var>request</var> and
    <var>internalResponse</var>.
 
    <li>
@@ -7333,45 +7334,51 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 </div>
 
 <div algorithm>
-<p>To <dfn>update a request's timing allow check set</dfn>, given a <a for=/>request</a>
-<var>request</var> and a <a for=/>response</a> <var>response</var>, run these steps:
+<p>To <dfn>update a request's navigation timing allow check set</dfn>, given a
+<a for=/>request</a> <var>request</var> and a <a for=/>response</a> <var>response</var>, run these
+steps:
 
 <ol>
  <li><p><a for=/>Assert</a>: <var>request</var> is a <a>navigation request</a>.
 
- <li><p>Let <var>values</var> be the result of
+ <li><p>Let <var>taoValues</var> be the result of
  <a for="header list">getting, decoding, and splitting</a> `<code>Timing-Allow-Origin</code>` from
  <var>response</var>'s <a for=response>header list</a>.
 
- <li><p>If <var>values</var> is null, then set <var>values</var> to « ».
+ <li><p>If <var>taoValues</var> is null, then set <var>taoValues</var> to « ».
+
+ <li><p>If <var>taoValues</var> <a for=list>contains</a> "<code>*</code>", then return.
+
+ <li><p>Let <var>currentSet</var> be <var>request</var>'s
+ <a for=request>navigation timing allow check set</a>.
 
  <li><p>Let <var>newSet</var> be « ».
 
  <li>
-  <p><a for=list>For each</a> <var>value</var> of <var>request</var>'s
-  <a for=request>timing allow check set</a>:
+  <p>If <var>currentSet</var> <a for=list>contains</a> "<code>*</code>", then:
 
   <ol>
-   <li><p>If <var>values</var> <a for=list>contains</a> <var>value</var>, or
-   <var>values</var> <a for=list>contains</a> "<code>*</code>", then <a for=list>append</a>
-   <var>value</var> to <var>newSet</var>.
+   <li>
+    <p><a for=list>For each</a> <var>taoValue</var> of <var>taoValues</var>:
+
+    <ol>
+     <li><p>If <var>newSet</var> <a for=list>contains</a> <var>taoValue</var>, then
+     <a for=iteration>continue</a>.
+
+     <li><p><a for=list>Append</a> <var>taoValue</var> to <var>newSet</var>.
+    </ol>
   </ol>
 
  <li>
-  <p>If <var>request</var>'s <a for=request>timing allow check set</a> <a for=list>contains</a>
-  "<code>*</code>", then <a for=list>for each</a> <var>value</var> of <var>values</var>:
+  <p>Otherwise, <a for=list>for each</a> <var>allowedOrigin</var> of <var>currentSet</var>:
 
   <ol>
-   <li><p>If <var>newSet</var> <a for=list>contains</a> <var>value</var>, then
-   <a for=iteration>continue</a>.
-
-   <li><p><a for=list>Append</a> <var>value</var> to <var>newSet</var>.
+   <li><p>If <var>taoValues</var> <a for=list>contains</a> <var>allowedOrigin</var>, then
+   <a for=list>append</a> <var>allowedOrigin</var> to <var>newSet</var>.
   </ol>
 
- <li><p>If <var>values</var> <a for=list>contains</a> "<code>*</code>" is false, then
- <a for=list>remove</a> "<code>*</code>" from <var>newSet</var>.
-
- <li><p>Set <var>request</var>'s <a for=request>timing allow check set</a> to <var>newSet</var>.
+ <li><p>Set <var>request</var>'s <a for=request>navigation timing allow check set</a> to
+ <var>newSet</var>.
 </ol>
 </div>
 
@@ -7381,12 +7388,12 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 <var>destinationOrigin</var>, run these steps:
 
 <ol>
- <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
- "<code>*</code>", then return success.
+ <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
+ <a for=list>contains</a> "<code>*</code>", then return success.
 
- <li><p>If <var>response</var>'s <a for=response>timing allow check set</a> <a for=list>contains</a>
- <var>destinationOrigin</var>, <a lt="ASCII serialization of an origin">serialized</a>, then return
- success.
+ <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
+ <a for=list>contains</a> <var>destinationOrigin</var>,
+ <a lt="ASCII serialization of an origin">serialized</a>, then return success.
 
  <li><p>Return failure.
 </ol>

--- a/fetch.bs
+++ b/fetch.bs
@@ -2308,13 +2308,17 @@ Unless stated otherwise, it is unset.
 otherwise, it is unset.
 
 <p>A <a for=/>request</a> has an associated
-<dfn for=request>navigation timing allow check set</dfn> (an <a for=/>ordered set</a> of zero
-or more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn for=request>navigation timing allow check list</dfn> (a <a for=/>list</a> of
+<a for=/>lists</a> of <a for=/>strings</a>). Unless stated otherwise, it is « ».
+
+<p class=note>Each <a for=list>item</a> in the <a for=request>navigation timing allow check list</a>
+holds the `<code>Timing-Allow-Origin</code>` values of one redirect <a for=/>response</a> in a
+navigation's redirect chain.
 
 <p class=note>A <a for=/>request</a>'s <a for=request>URL list</a>, <a for=request>current URL</a>,
 <a for=request>redirect count</a>, <a for=request>response tainting</a>,
 <a for=request>done flag</a>, <a for=request>timing allow failed flag</a>, and
-<a for=request>navigation timing allow check set</a> are used as bookkeeping details by the
+<a for=request>navigation timing allow check list</a> are used as bookkeeping details by the
 <a for=/>fetch</a> algorithm.
 
 <p>A <a for=/>request</a> has an associated
@@ -2614,12 +2618,13 @@ the response of a redirect has to be set if it was set for previous responses in
 this is also tracked internally using the request's <a for=request>timing allow failed flag</a>.
 
 <p>A <a for=/>response</a> has an associated
-<dfn export for=response>navigation timing allow check set</dfn> (an <a for=/>ordered set</a> of
-zero or more <a for=/>strings</a>). Unless stated otherwise, it is « "<code>*</code>" ».
+<dfn export for=response>navigation timing allow check list</dfn> (a <a for=/>list</a> of
+<a for=/>lists</a> of <a for=/>strings</a>). Unless stated otherwise, it is « ».
 
-<p class=note>This is used by <a for=/>responses</a> to <a>navigation requests</a> so that
-callers can determine, once the navigation's destination origin is known, whether that origin is
-allowed by every redirect in the redirect chain.
+<p class=note>This holds the `<code>Timing-Allow-Origin</code>` values of each redirect
+<a for=/>response</a> in a navigation's redirect chain. It is used so that callers can determine,
+once the navigation's destination origin is known, whether that origin is allowed by every redirect
+in the redirect chain.
 
 <p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-body-info>body info</dfn>
@@ -5118,9 +5123,9 @@ steps:
  <a for=request>redirect-taint</a>.
 
  <li><p>If <var>request</var> is a <a>navigation request</a>, then set
- <var>internalResponse</var>'s <a for=response>navigation timing allow check set</a> to a
- <a for=set>clone</a> of <var>request</var>'s
- <a for=request>navigation timing allow check set</a>.
+ <var>internalResponse</var>'s <a for=response>navigation timing allow check list</a> to a
+ <a for=list>clone</a> of <var>request</var>'s
+ <a for=request>navigation timing allow check list</a>.
 
  <li><p>If <var>request</var>'s <a for=request>timing allow failed flag</a> is unset, then set
  <var>internalResponse</var>'s <a for=response>timing allow passed flag</a>.
@@ -5903,7 +5908,7 @@ these steps:
 
   <ol>
    <li><p>If <var>request</var> is a <a>navigation request</a>, then
-   <a>restrict a request's navigation timing allow check set</a> given <var>request</var> and
+   <a>append to a request's navigation timing allow check list</a> given <var>request</var> and
    <var>internalResponse</var>.
 
    <li>
@@ -7334,7 +7339,7 @@ agent's <a>CORS-preflight cache</a> for which there is a <a>cache entry match</a
 </div>
 
 <div algorithm>
-<p>To <dfn>restrict a request's navigation timing allow check set</dfn>, given a
+<p>To <dfn>append to a request's navigation timing allow check list</dfn>, given a
 <a for=/>request</a> <var>request</var> and a <a for=/>response</a> <var>response</var>, run these
 steps:
 
@@ -7347,40 +7352,8 @@ steps:
 
  <li><p>If <var>taoValues</var> is null, then set <var>taoValues</var> to « ».
 
- <li><p>If <var>taoValues</var> <a for=list>contains</a> "<code>*</code>", then return.
- <p class="note">If the current response contains "*", it does not further restrict the chain.
-
- <li><p>Let <var>currentSet</var> be <var>request</var>'s
- <a for=request>navigation timing allow check set</a>.
-
- <li><p>Let <var>newSet</var> be a new <a for=/>ordered set</a>.
-
- <li>
-  <p>If <var>currentSet</var> <a for=set>contains</a> "<code>*</code>", then:
-
-  <p class=note>If all previous responses in the chain contained "<code>*</code>", the current
-  response's values can be taken as is.
-
-  <ol>
-   <li><p><a for=list>For each</a> <var>taoValue</var> of <var>taoValues</var>,
-   <a for=set>append</a> <var>taoValue</var> to <var>newSet</var>.
-
-   <li><p>Set <var>request</var>'s <a for=request>navigation timing allow check set</a> to
-   <var>newSet</var>.
-
-   <li><p>Return.
-  </ol>
-
- <li>
-  <p><a for=set>For each</a> <var>allowedOrigin</var> of <var>currentSet</var>:
-
-  <ol>
-   <li><p>If <var>taoValues</var> <a for=list>contains</a> <var>allowedOrigin</var>, then
-   <a for=set>append</a> <var>allowedOrigin</var> to <var>newSet</var>.
-  </ol>
-
- <li><p>Set <var>request</var>'s <a for=request>navigation timing allow check set</a> to
- <var>newSet</var>.
+ <li><p><a for=list>Append</a> <var>taoValues</var> to <var>request</var>'s
+ <a for=request>navigation timing allow check list</a>.
 </ol>
 </div>
 
@@ -7390,14 +7363,21 @@ steps:
 <var>destinationOrigin</var>, run these steps:
 
 <ol>
- <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
- <a for=set>contains</a> "<code>*</code>", then return success.
+ <li>
+  <p><a for=list>For each</a> <var>taoValues</var> of <var>response</var>'s
+  <a for=response>navigation timing allow check list</a>:
 
- <li><p>If <var>response</var>'s <a for=response>navigation timing allow check set</a>
- <a for=set>contains</a> <var>destinationOrigin</var>,
- <a lt="ASCII serialization of an origin">serialized</a>, then return success.
+  <ol>
+   <li><p>If <var>taoValues</var> <a for=list>contains</a> "<code>*</code>", then
+   <a for=iteration>continue</a>.
 
- <li><p>Return failure.
+   <li><p>If <var>taoValues</var> <a for=list>contains</a> <var>destinationOrigin</var>,
+   <a lt="ASCII serialization of an origin">serialized</a>, then <a for=iteration>continue</a>.
+
+   <li><p>Return failure.
+  </ol>
+
+ <li><p>Return success.
 </ol>
 </div>
 


### PR DESCRIPTION
As part of the [WebPerfWG discussion](https://w3c.github.io/web-performance/meetings/2026/2026-06-04/index.html) on [re-exposing redirectCount for opted-in cross-origin redirects](https://github.com/whatwg/html/pull/12513), we discussed the fact that TAO currently only opts-in "backwards" in terms of origins, and doesn't constitute an opt-in to the destination origin, which is the appropriate opt-in for navigations (contrary to subresources).

This PR adds the mechanisms that can enable such "forward" opt-in, and can enable a response to a redirect chain to know that the redirect chain opted in to expose the redirects to its origin.

Once this lands, we'd use the relevant algorithms in the related HTML PR.

- [x] At least two implementers are interested (and none opposed):
   * Chromium: https://github.com/whatwg/fetch/pull/1931#issuecomment-4660492429
   * WebKit: https://github.com/whatwg/fetch/pull/1931#pullrequestreview-4560631006
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/60823
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/521861828
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2049166
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=316647
   * Deno (not for CORS changes): N/A as it doesn't do navigations.
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/841
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1931.html" title="Last updated on Jun 24, 2026, 9:51 AM UTC (48b86d4)">Preview</a> | <a href="https://whatpr.org/fetch/1931/301650c...48b86d4.html" title="Last updated on Jun 24, 2026, 9:51 AM UTC (48b86d4)">Diff</a>