### PR TITLE
Add .trailers to Response/Request

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1651,6 +1651,74 @@ these steps:
 </div>
 
 
+<h4 id=trailer-states>Trailer state</h4>
+
+<p>A <dfn export>trailer state</dfn> is a <a for=/>struct</a> used to represent
+HTTP trailer fields received after a response body
+([[HTTP]], <a href="https://httpwg.org/specs/rfc9110.html#trailers">Section 6.5</a>).
+It has:
+
+<ul>
+ <li><p>A <dfn for="trailer state">header list</dfn> (a <a for=/>header list</a>),
+ initially « ».
+
+ <li><p>A <dfn for="trailer state">state</dfn>
+ ("<code>pending</code>", "<code>complete</code>", or "<code>errored</code>"),
+ initially "<code>pending</code>".
+
+ <li><p>An <dfn for="trailer state">error</dfn> (null or a value), initially null.
+
+ <li><p>An <dfn for="trailer state">observers</dfn> (a <a for=/>list</a> of
+ algorithms), initially « ».
+</ul>
+
+<p class=note>A <a>trailer state</a> is shared by reference between a
+<a for=/>response</a> and its <a for=response lt=clone>clones</a>.
+
+<div algorithm>
+<p>To <dfn>complete a trailer state</dfn> given a <a>trailer state</a>
+<var>trailerState</var>:
+
+<ol>
+ <li><p>If <var>trailerState</var>'s <a for="trailer state">state</a> is not
+ "<code>pending</code>", then return.
+
+ <li><p>Set <var>trailerState</var>'s <a for="trailer state">state</a> to
+ "<code>complete</code>".
+
+ <li><p>For each <var>observer</var> of
+ <var>trailerState</var>'s <a for="trailer state">observers</a>:
+ run <var>observer</var>.
+
+ <li><p><a for=list>Empty</a> <var>trailerState</var>'s
+ <a for="trailer state">observers</a>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn>error a trailer state</dfn> given a <a>trailer state</a>
+<var>trailerState</var> and a value <var>reason</var>:
+
+<ol>
+ <li><p>If <var>trailerState</var>'s <a for="trailer state">state</a> is not
+ "<code>pending</code>", then return.
+
+ <li><p>Set <var>trailerState</var>'s <a for="trailer state">state</a> to
+ "<code>errored</code>".
+
+ <li><p>Set <var>trailerState</var>'s <a for="trailer state">error</a> to
+ <var>reason</var>.
+
+ <li><p>For each <var>observer</var> of
+ <var>trailerState</var>'s <a for="trailer state">observers</a>:
+ run <var>observer</var>.
+
+ <li><p><a for=list>Empty</a> <var>trailerState</var>'s
+ <a for="trailer state">observers</a>.
+</ol>
+</div>
+
+
 <h4 id=requests>Requests</h4>
 
 <p class=note>This section documents how requests work in detail. To get started, see
@@ -2580,6 +2648,18 @@ message as HTTP/2 does not support them.
 <a for=/>response</a>'s <a for=response>body</a> are always null.
 
 <p>A <a for=/>response</a> has an associated
+<dfn export for=response id=concept-response-trailer-state>trailer state</dfn>
+(a <a>trailer state</a>). Unless stated otherwise it is a new <a>trailer state</a>.
+
+<p>A <a for=/>response</a>'s
+<dfn export for=response id=concept-response-trailer-header-list>trailer header list</dfn>
+is its <a for=response>trailer state</a>'s <a for="trailer state">header list</a>.
+
+<p class=note>The <a for=response>trailer state</a> is shared by reference between a
+response and its clones (see <a for=response>clone</a>), ensuring trailer fields
+received after cloning are visible to all copies.
+
+<p>A <a for=/>response</a> has an associated
 <dfn export for=response id=concept-response-cache-state>cache state</dfn> (the empty string,
 "<code>local</code>", or "<code>validated</code>"). Unless stated otherwise, it is the empty
 string.
@@ -2692,21 +2772,35 @@ of defining the concrete types of <a for=/>filtered responses</a>.)
 
 <p>A <dfn export id=concept-filtered-response-basic>basic filtered response</dfn> is a
 <a>filtered response</a> whose
-<a for=response>type</a> is "<code>basic</code>" and
+<a for=response>type</a> is "<code>basic</code>",
 <a for=response>header list</a> excludes any
 <a for=/>headers</a> in
 <a for="filtered response">internal response</a>'s
 <a for=response>header list</a> whose
 <a for=header>name</a> is a
+<a>forbidden response-header name</a>, and
+<a for=response>trailer header list</a> excludes any
+<a for=/>headers</a> in
+<a for="filtered response">internal response</a>'s
+<a for=response>trailer header list</a> whose
+<a for=header>name</a> is a
 <a>forbidden response-header name</a>.
 
 <p>A <dfn export id=concept-filtered-response-cors>CORS filtered response</dfn> is a
 <a>filtered response</a> whose
-<a for=response>type</a> is "<code>cors</code>" and
+<a for=response>type</a> is "<code>cors</code>",
 <a for=response>header list</a> excludes any
 <a for=/>headers</a> in
 <a for="filtered response">internal response</a>'s
 <a for=response>header list</a> whose
+<a for=header>name</a> is <em>not</em> a
+<a>CORS-safelisted response-header name</a>, given
+<a for="filtered response">internal response</a>'s
+<a for=response>CORS-exposed header-name list</a>, and
+<a for=response>trailer header list</a> excludes any
+<a for=/>headers</a> in
+<a for="filtered response">internal response</a>'s
+<a for=response>trailer header list</a> whose
 <a for=header>name</a> is <em>not</em> a
 <a>CORS-safelisted response-header name</a>, given
 <a for="filtered response">internal response</a>'s
@@ -2719,6 +2813,7 @@ of defining the concrete types of <a for=/>filtered responses</a>.)
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
 <a for=response>header list</a> is « »,
+<a for=response>trailer header list</a> is « »,
 <a for=response>body</a> is null, and
 <a for=response>body info</a> is a new <a for=/>response body info</a>.
 
@@ -2729,6 +2824,7 @@ is a <a>filtered response</a> whose
 <a for=response>status</a> is 0,
 <a for=response>status message</a> is the empty byte sequence,
 <a for=response>header list</a> is « »,
+<a for=response>trailer header list</a> is « »,
 <a for=response>body</a> is null, and
 <a for=response>body info</a> is a new <a for=/>response body info</a>.
 
@@ -2781,7 +2877,10 @@ console.log((await fetch("/surprise-me", { redirect: "manual" })).type); // "opa
  <a for="filtered response">internal response</a>.
 
  <li><p>Let <var>newResponse</var> be a copy of <var>response</var>, except for its
- <a for=response>body</a>.
+ <a for=response>body</a> and <a for=response>trailer state</a>.
+
+ <li><p>Set <var>newResponse</var>'s <a for=response>trailer state</a> to
+ <var>response</var>'s <a for=response>trailer state</a>.
 
  <li><p>If <var>response</var>'s <a for=response>body</a> is non-null, then set
  <var>newResponse</var>'s <a for=response>body</a> to the result of <a lt=clone for=body>cloning</a>
@@ -5310,6 +5409,9 @@ steps:
      <li><p>Set <var>fetchParams</var>'s <a for="fetch params">request</a>'s
      <a for=request>done flag</a>.
 
+     <li><p><a>Complete a trailer state</a> given <var>response</var>'s
+     <a for=response>trailer state</a>.
+
      <li><p>If <var>fetchParams</var>'s <a for="fetch params">process response end-of-body</a> is
      non-null, then run <var>fetchParams</var>'s
      <a for="fetch params">process response end-of-body</a> given <var>response</var>.
@@ -5360,13 +5462,34 @@ steps:
    <a for="TransformStream/set up"><i>flushAlgorithm</i></a> set to
    <var>processResponseEndOfBody</var>.
 
-   <li><p>Set <var>internalResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a> to the
-   result of <var>internalResponse</var>'s <a for=response>body</a>'s <a for=body>stream</a>
-   <a for=ReadableStream>piped through</a> <var>transformStream</var>.
+   <li><p>Let <var>readable</var> be <var>transformStream</var>'s
+   <a attribute for=TransformStream>readable</a>.
+
+   <li><p>Let <var>pipePromise</var> be the result of
+   <a for=ReadableStream>piping</a> <var>internalResponse</var>'s
+   <a for=response>body</a>'s <a for=body>stream</a> to
+   <var>transformStream</var>'s <a attribute for=TransformStream>writable</a>.
+
+   <li><p>Set <var>internalResponse</var>'s <a for=response>body</a>'s
+   <a for=body>stream</a> to <var>readable</var>.
+
+   <li>
+    <p><a for=/>Upon rejection</a> of <var>pipePromise</var> with
+    <var>reason</var>:
+
+    <ol>
+     <li><p><a>Error a trailer state</a> given <var>response</var>'s
+     <a for=response>trailer state</a> and <var>reason</var>.
+    </ol>
   </ol>
 
-  <p class=note>This {{TransformStream}} is needed for the purpose of receiving a notification when
-  the stream reaches its end, and is otherwise an <a>identity transform stream</a>.
+  <p class=note>The {{TransformStream}} receives a notification when the body
+  stream reaches its end (via the flush algorithm) or when it errors (via the
+  pipe promise rejection). On successful completion,
+  <var>processResponseEndOfBody</var> <a lt="complete a trailer state">completes</a>
+  the <a for=response>trailer state</a>. On error, the trailer state is
+  <a lt="error a trailer state">errored</a>, which rejects any pending
+  {{Response/trailers}} promises.
 
  <li>
   <p>If <var>fetchParams</var>'s <a for="fetch params">process response consume body</a> is
@@ -6760,6 +6883,21 @@ optional boolean <var>forceNewConnection</var> (default false), run these steps:
 
        <li><p><a for=iteration>Break</a>.
       </ol>
+
+     <li>
+      <p>If the HTTP response includes trailer fields
+      ([[HTTP]], <a href="https://httpwg.org/specs/rfc9110.html#trailers">Section 6.5</a>),
+      then, after the response body has been fully transmitted, set
+      <var>response</var>'s <a for=response>trailer header list</a> to a
+      <a for=/>header list</a> containing each received trailer field as a
+      <a for=/>header</a>.
+
+      <p class=note>Trailer fields are received after the response body. The HTTP
+      layer is responsible for omitting trailer fields prohibited by HTTP semantics
+      (e.g., fields used in transfer codings, content framing, or routing). The
+      <a for=response>trailer header list</a> is populated before
+      <a lt="complete a trailer state">completing</a> the <a for=response>trailer state</a>
+      in the <a>fetch response handover</a> steps.
     </ul>
 
     <p class=note>The exact layering between Fetch and HTTP still needs to be sorted through and
@@ -8616,6 +8754,7 @@ interface Request {
   readonly attribute boolean isHistoryNavigation;
   readonly attribute AbortSignal signal;
   readonly attribute RequestDuplex duplex;
+  readonly attribute Promise&lt;Headers> trailers;
 
   [NewObject] Request clone();
 };
@@ -8662,6 +8801,9 @@ used or observed from JavaScript.
 
 <p>A {{Request}} object has an associated <dfn for=Request>signal</dfn> (null or an {{AbortSignal}}
 object), initially null.
+
+<p>A {{Request}} object has an associated
+<dfn for=Request>trailers promise</dfn> (null or a {{Promise}}), initially null.
 
 <p>A {{Request}} object's <a for=Body>body</a> is its
 <a for=Request>request</a>'s
@@ -8814,6 +8956,10 @@ object), initially null.
  response before sending the entire request) to indicate that the fetch will be full-duplex.
  <span class=note>See <a href="https://github.com/whatwg/fetch/issues/1254">issue #1254</a> for
  defining "<code>full</code>".</span>
+
+ <dt><code><var>request</var> . <a attribute for=Request>trailers</a></code>
+ <dd><p>Returns a promise that resolves to an empty immutable {{Headers}} object. Client-side
+ requests do not support sending trailer fields.
 
  <dt><code><var>request</var> . <a method for=Request>clone</a>()</code>
  <dd><p>Returns a clone of <var>request</var>.
@@ -9287,6 +9433,32 @@ set; otherwise false.
 <p>The <dfn attribute for=Request><code>duplex</code></dfn> getter steps are to return
 "<code>half</code>".
 
+<div algorithm>
+<p>The <dfn attribute for=Request><code>trailers</code></dfn> getter steps are:
+
+<ol>
+ <li>
+  <p>If <a>this</a>'s <a for=Request>trailers promise</a> is null, then:
+
+  <ol>
+   <li><p>Let <var>promise</var> be <a>a new promise</a>.
+
+   <li><p><a for=/>Resolve</a> <var>promise</var> with a new {{Headers}} object
+   whose <a for=Headers>header list</a> is « » and whose <a for=Headers>guard</a> is
+   "<code>immutable</code>".
+
+   <li><p>Set <a>this</a>'s <a for=Request>trailers promise</a> to <var>promise</var>.
+  </ol>
+
+ <li><p>Return <a>this</a>'s <a for=Request>trailers promise</a>.
+</ol>
+</div>
+
+<p class=note>Client-side requests do not support sending trailer fields. The
+{{Request/trailers}} attribute always returns a promise that resolves to empty
+immutable {{Headers}}. This does not foreclose future extension to support sending
+trailer fields.
+
 <hr>
 
 <div algorithm>
@@ -9331,6 +9503,7 @@ interface Response {
   readonly attribute boolean ok;
   readonly attribute ByteString statusText;
   [SameObject] readonly attribute Headers headers;
+  readonly attribute Promise&lt;Headers> trailers;
 
   [NewObject] Response clone();
 };
@@ -9351,6 +9524,9 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
 
 <p>A {{Response}} object also has an associated <dfn for=Response export>headers</dfn> (null or a
 {{Headers}} object), initially null.
+
+<p>A {{Response}} object has an associated
+<dfn for=Response>trailers promise</dfn> (null or a {{Promise}}), initially null.
 
 <p>A {{Response}} object's <a for=Body>body</a> is its
 <a for=Response>response</a>'s <a for=response>body</a>.
@@ -9394,8 +9570,20 @@ enum ResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredire
  <dt><code><var>response</var> . <a attribute for=Response>headers</a></code>
  <dd><p>Returns <var>response</var>'s headers as {{Headers}}.
 
+ <dt><code><var>response</var> . <a attribute for=Response>trailers</a></code>
+ <dd>
+  <p>Returns a promise that resolves to {{Headers}} containing the response's trailer fields.
+
+  <p>For responses obtained from {{WindowOrWorkerGlobalScope/fetch()}}, the promise resolves after the
+  response body has been fully received. For synthetically constructed responses (via the
+  {{Response/Response()}} constructor, {{Response/error()}}, {{Response/redirect()}}, or
+  {{Response/json()}}), the promise resolves immediately to empty immutable {{Headers}}.
+
+  <p>If the response body stream errors, the promise is rejected.
+
  <dt><code><var>response</var> . <a method for=Response>clone</a>()</code>
- <dd><p>Returns a clone of <var>response</var>.
+ <dd><p>Returns a clone of <var>response</var>. The clone shares the same
+ <a for=response>trailer state</a>, so both will receive the same trailer fields.
 </dl>
 
 <hr>
@@ -9486,12 +9674,25 @@ constructor steps are:
 
  <li><p>Perform <a>initialize a response</a> given <a>this</a>, <var>init</var>, and
  <var>bodyWithType</var>.
+
+ <li><p><a>Complete a trailer state</a> given <a>this</a>'s <a for=Response>response</a>'s
+ <a for=response>trailer state</a>.
 </ol>
 </div>
 
-<p>The static <dfn method for=Response><code>error()</code></dfn> method steps are to return the
-result of <a for=Response>creating</a> a {{Response}} object, given a new <a>network error</a>,
-"<code>immutable</code>", and the <a>current realm</a>.
+<div algorithm>
+<p>The static <dfn method for=Response><code>error()</code></dfn> method steps are:
+
+<ol>
+ <li><p>Let <var>responseObject</var> be the result of <a for=Response>creating</a> a {{Response}}
+ object, given a new <a>network error</a>, "<code>immutable</code>", and the <a>current realm</a>.
+
+ <li><p><a>Complete a trailer state</a> given <var>responseObject</var>'s
+ <a for=Response>response</a>'s <a for=response>trailer state</a>.
+
+ <li><p>Return <var>responseObject</var>.
+</ol>
+</div>
 
 <div algorithm>
 <p>The static
@@ -9518,6 +9719,9 @@ are:
  <li><p><a for="header list">Append</a> (`<code>Location</code>`, <var>value</var>) to
  <var>responseObject</var>'s <a for=Response>response</a>'s <a for=response>header list</a>.
 
+ <li><p><a>Complete a trailer state</a> given <var>responseObject</var>'s
+ <a for=Response>response</a>'s <a for=response>trailer state</a>.
+
  <li><p>Return <var>responseObject</var>.
 </ol>
 </div>
@@ -9539,6 +9743,9 @@ are:
 
  <li><p>Perform <a>initialize a response</a> given <var>responseObject</var>, <var>init</var>, and
  (<var>body</var>, "<code>application/json</code>").
+
+ <li><p><a>Complete a trailer state</a> given <var>responseObject</var>'s
+ <a for=Response>response</a>'s <a for=response>trailer state</a>.
 
  <li><p>Return <var>responseObject</var>.
 </ol>
@@ -9573,6 +9780,72 @@ otherwise false.
 
 <p>The <dfn attribute for=Response><code>headers</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Response>headers</a>.
+
+<div algorithm>
+<p>The <dfn attribute for=Response><code>trailers</code></dfn> getter steps are:
+
+<ol>
+ <li><p>If <a>this</a>'s <a for=Response>trailers promise</a> is null, then:
+
+ <ol>
+  <li><p>Let <var>response</var> be <a>this</a>'s <a for=Response>response</a>.
+
+  <li><p>Let <var>trailerState</var> be <var>response</var>'s
+  <a for=response>trailer state</a>.
+
+  <li><p>Let <var>promise</var> be <a>a new promise</a>.
+
+  <li>
+   <p>If <var>trailerState</var>'s <a for="trailer state">state</a> is
+   "<code>complete</code>", then:
+
+   <ol>
+    <li><p>Let <var>headers</var> be a new {{Headers}} object whose
+    <a for=Headers>header list</a> is <var>response</var>'s
+    <a for=response>trailer header list</a> and whose <a for=Headers>guard</a> is
+    "<code>immutable</code>".
+
+    <li><p><a for=/>Resolve</a> <var>promise</var> with <var>headers</var>.
+   </ol>
+
+  <li>
+   <p>Otherwise, if <var>trailerState</var>'s <a for="trailer state">state</a> is
+   "<code>errored</code>", then <a for=/>reject</a> <var>promise</var> with
+   <var>trailerState</var>'s <a for="trailer state">error</a>.
+
+  <li>
+   <p>Otherwise (<var>trailerState</var>'s <a for="trailer state">state</a> is
+   "<code>pending</code>"):
+
+   <ol>
+    <li>
+     <p><a for=list>Append</a> the following steps to <var>trailerState</var>'s
+     <a for="trailer state">observers</a>:
+
+     <ol>
+      <li><p>If <var>trailerState</var>'s <a for="trailer state">state</a> is
+      "<code>complete</code>", then:
+
+      <ol>
+       <li><p>Let <var>headers</var> be a new {{Headers}} object whose
+       <a for=Headers>header list</a> is <var>response</var>'s
+       <a for=response>trailer header list</a> and whose <a for=Headers>guard</a> is
+       "<code>immutable</code>".
+
+       <li><p><a for=/>Resolve</a> <var>promise</var> with <var>headers</var>.
+      </ol>
+
+      <li><p>Otherwise, <a for=/>reject</a> <var>promise</var> with
+      <var>trailerState</var>'s <a for="trailer state">error</a>.
+     </ol>
+   </ol>
+
+  <li><p>Set <a>this</a>'s <a for=Response>trailers promise</a> to <var>promise</var>.
+ </ol>
+
+ <li><p>Return <a>this</a>'s <a for=Response>trailers promise</a>.
+</ol>
+</div>
 
 <hr>
 
@@ -9741,6 +10014,9 @@ with a <var>promise</var>, <var>request</var>, <var>responseObject</var>, and an
  <li><p>If <var>response</var>'s <a for=response>body</a> is non-null and is
  <a for=ReadableStream>readable</a>, then <a for=ReadableStream>error</a> <var>response</var>'s
  <a for=response>body</a> with <var>error</var>.
+
+ <li><p><a>Error a trailer state</a> given <var>response</var>'s
+ <a for=response>trailer state</a> and <var>error</var>.
 </ol>
 </div>
 


### PR DESCRIPTION
Adds `Promise<Headers>` `trailers` properties to `Request` and `Response`

When sending... `trailers` resolves to an empty, immutable `Headers` since we're not dealing with sending trailers in this change.

When receiving... `trailers` resolves to an immutable, populated/filtered `Headers` resolved after the body is completed. This means the trailers promise will not resolve if the body is not consumed.

```js
const trailers = await response.trailers;
```

The minimal conformance requirement here is the presence of the `.trailers` property. An implementation which chooses not to actually support trailers would need only return a resolved promise with an immutable empty `Headers`. Nothing in this should be interpreted as requiring any implementation to *actually* implement trailers support.

Refs: https://github.com/whatwg/fetch/issues/981

---

- [ ] At least two implementers are interested (and none opposed):
   * Node.js
   * Cloudflare Workers
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 11, 2026, 5:40 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fjasnell%2Ffetch%2F3cbc60740ab0eb7c07f13ee868cc1943df2b690e%2Ffetch.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201940)

**Error output:**

```json
[
    {
        "lineNum": "1675:17",
        "messageType": "link",
        "text": "Multiple possible 'dfn' local refs for 'trailer state'.\nRandomly chose one of them; other instances might get a different random choice."
    },
    {
        "lineNum": "1679:51",
        "messageType": "link",
        "text": "Multiple possible 'dfn' local refs for 'trailer state'.\nRandomly chose one of them; other instances might get a different random choice."
    },
    {
        "lineNum": "1699:48",
        "messageType": "link",
        "text": "Multiple possible 'dfn' local refs for 'trailer state'.\nRandomly chose one of them; other instances might get a different random choice."
    },
    {
        "lineNum": "2652:4",
        "messageType": "link",
        "text": "Multiple possible 'dfn' local refs for 'trailer state'.\nRandomly chose one of them; other instances might get a different random choice."
    },
    {
        "lineNum": "2652:63",
        "messageType": "link",
        "text": "Multiple possible 'dfn' local refs for 'trailer state'.\nRandomly chose one of them; other instances might get a different random choice."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/fetch%231940.)._

</details>
