### PR TITLE
Add getStructured/setStructured to Headers

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -8057,14 +8057,15 @@ if (purpose?.value === "prefetch") { /* ... */ }  // direct string comparison
   whether the number is an integer), booleans serialize as structured field
   booleans, {{Uint8Array}} serializes as a byte sequence, and strings
   serialize as tokens if they conform to <a>structured field token</a> syntax
-  or as quoted structured field strings otherwise. Item objects can include an
-  <!--grammar-check-override--><code>sfType</code> property to override the auto-detected structured field
-  type &mdash; for example, <code>{ value: "foo", sfType: "string" }</code>
-  forces a quoted string even when the value matches token syntax. Supported
-  <code>sfType</code> values are "<code>boolean</code>",
-  "<code>integer</code>", "<code>decimal</code>", "<code>date</code>",
-  "<code>string</code>", "<code>token</code>",
-  "<code>displaystring</code>", and "<code>bytesequence</code>".
+  or as quoted structured field strings otherwise. To override the
+  auto-detected structured field type, set the <code>sfType</code> property
+  on the item object &mdash; for example,
+  <code>{ value: "foo", sfType: "string" }</code> forces a quoted string even
+  when the value matches token syntax. Supported <code>sfType</code> values
+  are "<code>boolean</code>", "<code>integer</code>",
+  "<code>decimal</code>", "<code>date</code>", "<code>string</code>",
+  "<code>token</code>", "<code>displaystring</code>", and
+  "<code>bytesequence</code>".
 
   <div class=example id=example-setstructured>
    <pre><code class=lang-javascript>

--- a/fetch.bs
+++ b/fetch.bs
@@ -8057,7 +8057,7 @@ if (purpose?.value === "prefetch") { /* ... */ }  // direct string comparison
   whether the number is an integer), booleans serialize as structured field
   booleans, {{Uint8Array}} serializes as a byte sequence, and strings
   serialize as tokens if they conform to <a>structured field token</a> syntax
-  or as quoted structured field strings otherwise. Item objects may include an
+  or as quoted structured field strings otherwise. Item objects can include an
   <code>sfType</code> property to override the auto-detected structured field
   type &mdash; for example, <code>{ value: "foo", sfType: "string" }</code>
   forces a quoted string even when the value matches token syntax. Supported

--- a/fetch.bs
+++ b/fetch.bs
@@ -7991,16 +7991,18 @@ new Headers(meta2);
  <dd><p>Replaces the value of the first header whose name is <var>name</var> with <var>value</var>
  and removes any remaining headers whose name is <var>name</var>.
 
- <dt><code><var>result</var> = <var>headers</var> . <a method for=Headers lt=getStructured()>getStructured</a>(<var>name</var>, <var>type</var>)</code>
+ <dt><code><var>headers</var> . <a method for=Headers lt=getStructured()>getStructured</a>(<var>name</var>, <var>type</var>)</code>
  <dd>
   <p>Parses the value of the header named <var>name</var> as a structured field
   ([[RFC9651]]) of the given <var>type</var> and returns the result as a
   JavaScript value.
 
-  <p>Returns null if the header is not present or its value fails to parse as
-  the specified structured field type.
+  <p>Returns null if the header is not present, or if its value does not
+  strictly conform to the specified structured field type as defined in
+  [[RFC9651]]. No partial or lenient parsing is performed; any
+  deviation from the grammar causes an immediate null return.
 
-  <p>The <var>type</var> must be one of "<code>item</code>",
+  <p>The <var>type</var> argument is one of "<code>item</code>",
   "<code>list</code>", or "<code>dictionary</code>".
 
   <p>Structured field values are converted to JavaScript as follows:
@@ -8015,9 +8017,13 @@ new Headers(meta2);
   <p class=note>Tokens are represented as plain strings, following the same
   pattern as {{DOMString}}, {{USVString}}, and {{ByteString}} &mdash; they are a
   constrained profile of string rather than a separate type. When serializing
-  via {{Headers/setStructured()}}, strings that conform to
-  <a>structured field token</a> syntax are serialized as tokens; all other
-  strings are serialized as quoted structured field strings.
+  via {{Headers/setStructured()}}, strings are serialized as tokens or quoted
+  strings by default (auto-detected from syntax). To override the type, set
+  <code>sfType</code> on the item object (e.g.,
+  <code>{ value: "foo", sfType: "string" }</code> forces a quoted string).
+  The <code>sfType</code> property can also be used to produce
+  <a>structured field date</a> and <a>structured field display string</a>
+  values that cannot be expressed through auto-detection.
 
   <div class=example id=example-getstructured>
    <pre><code class=lang-javascript>
@@ -8047,11 +8053,18 @@ if (purpose?.value === "prefetch") { /* ... */ }  // direct string comparison
   <p>Throws a {{TypeError}} if <var>value</var> cannot be serialized as the
   specified structured field type or if the headers are immutable.
 
-  <p>For serialization, numbers serialize as integers or decimals (determined
-  by whether the number is an integer), booleans serialize as structured field
+  <p>By default, numbers serialize as integers or decimals (determined by
+  whether the number is an integer), booleans serialize as structured field
   booleans, {{Uint8Array}} serializes as a byte sequence, and strings
   serialize as tokens if they conform to <a>structured field token</a> syntax
-  or as quoted structured field strings otherwise.
+  or as quoted structured field strings otherwise. Item objects may include an
+  <code>sfType</code> property to override the auto-detected structured field
+  type &mdash; for example, <code>{ value: "foo", sfType: "string" }</code>
+  forces a quoted string even when the value matches token syntax. Supported
+  <code>sfType</code> values are "<code>boolean</code>",
+  "<code>integer</code>", "<code>decimal</code>", "<code>date</code>",
+  "<code>string</code>", "<code>token</code>",
+  "<code>displaystring</code>", and "<code>bytesequence</code>".
 
   <div class=example id=example-setstructured>
    <pre><code class=lang-javascript>
@@ -8075,6 +8088,21 @@ headers.setStructured("Priority", "dictionary", new Map([
   ["u", { value: 0 }],
   ["i", { value: true }]
 ]));
+
+// sfType overrides auto-detection of the structured field type:
+// Force a quoted string even though "foo" matches token syntax
+headers.setStructured("Example", "item", { value: "foo", sfType: "string" });
+// Result: Example: "foo"
+
+// Without sfType, "foo" would serialize as an unquoted token:
+headers.setStructured("Example", "item", { value: "foo" });
+// Result: Example: foo
+
+// Produce a Date value (not possible without sfType)
+headers.setStructured("Deprecation", "item", {
+  value: 1659578233, sfType: "date"
+});
+// Result: Deprecation: @1659578233
 </code></pre>
   </div>
 
@@ -8288,7 +8316,7 @@ given a structured field item <var>sfItem</var>:
 </ol>
 
 <p class=note>The returned object has the shape
-<code>{ value: <var>bareItem</var>, params: Map }</code>.
+<code>{ value, params: Map }</code>.
 </div>
 
 <div algorithm>
@@ -8423,9 +8451,123 @@ values for use with {{Headers/setStructured()}}.
 <div algorithm>
 <p>To
 <dfn>convert a JavaScript value to a structured field bare item</dfn>
-given a JavaScript value <var>jsValue</var>:
+given a JavaScript value <var>jsValue</var> and an optional string
+<var>sfType</var>:
 
 <ol>
+ <li>
+  <p>If <var>sfType</var> is given:
+
+  <ol>
+   <li>
+    <p>If <var>sfType</var> is "<code>boolean</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not Boolean, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field boolean</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>integer</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not Number, or <var>jsValue</var> is not an
+     <a href="https://tc39.es/ecma262/#sec-isinteger">integral number</a>,
+     then <a>throw</a> a {{TypeError}}.
+
+     <li><p>If <var>jsValue</var> is less than &minus;999,999,999,999,999
+     or greater than 999,999,999,999,999, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field integer</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>decimal</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not Number, or <var>jsValue</var> is NaN, +&infin;, or &minus;&infin;,
+     then <a>throw</a> a {{TypeError}}.
+
+     <li><p>If the absolute value of the integer component of
+     <var>jsValue</var> (i.e.,
+     <a href="https://tc39.es/ecma262/#eqn-truncate">truncate</a>(<var>jsValue</var>))
+     is greater than 999,999,999,999, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field decimal</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>date</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not Number, or <var>jsValue</var> is not an
+     <a href="https://tc39.es/ecma262/#sec-isinteger">integral number</a>,
+     then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field date</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>string</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not String, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field string</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>token</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not String, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>If <var>jsValue</var> does not conform to the
+     <a>structured field token</a> syntax defined in [[RFC9651]]
+     (<a href="https://httpwg.org/specs/rfc9651.html#token">Section 3.3.4</a>),
+     then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field token</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>displaystring</code>":
+
+    <ol>
+     <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+     is not String, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field display string</a> with
+     <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>If <var>sfType</var> is "<code>bytesequence</code>":
+
+    <ol>
+     <li><p>If <var>jsValue</var> is not a {{Uint8Array}}, then
+     <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field byte sequence</a> whose
+     contents are a copy of <var>jsValue</var>'s buffer.
+    </ol>
+
+   <li><p><a>Throw</a> a {{TypeError}}.
+  </ol>
+
  <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
  is Boolean, return a <a>structured field boolean</a> with <var>jsValue</var>'s value.
 
@@ -8437,13 +8579,37 @@ given a JavaScript value <var>jsValue</var>:
    <li><p>If <var>jsValue</var> is NaN, +&infin;, or &minus;&infin;,
    then <a>throw</a> a {{TypeError}}.
 
-   <li><p>If <var>jsValue</var> is an
-   <a href="https://tc39.es/ecma262/#sec-isinteger">integral number</a>,
-   return a <a>structured field integer</a> with <var>jsValue</var>'s value.
+   <li>
+    <p>If <var>jsValue</var> is an
+    <a href="https://tc39.es/ecma262/#sec-isinteger">integral number</a>:
 
-   <li><p>Otherwise, return a <a>structured field decimal</a> with
-   <var>jsValue</var>'s value.
+    <ol>
+     <li><p>If <var>jsValue</var> is less than &minus;999,999,999,999,999 or
+     greater than 999,999,999,999,999, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field integer</a> with <var>jsValue</var>'s value.
+    </ol>
+
+   <li>
+    <p>Otherwise:
+
+    <ol>
+     <li><p>If the absolute value of the integer component of
+     <var>jsValue</var> (i.e.,
+     <a href="https://tc39.es/ecma262/#eqn-truncate">truncate</a>(<var>jsValue</var>))
+     is greater than 999,999,999,999, then <a>throw</a> a {{TypeError}}.
+
+     <li><p>Return a <a>structured field decimal</a> with <var>jsValue</var>'s value.
+    </ol>
   </ol>
+
+  <p class=note>The integer range (15 digits) and decimal integer-component
+  limit (12 digits) match the constraints defined in [[RFC9651]]
+  (<a href="https://httpwg.org/specs/rfc9651.html#integer">Section 3.3.1</a>,
+  <a href="https://httpwg.org/specs/rfc9651.html#decimal">Section 3.3.2</a>).
+  Decimals are rounded to at most three fractional digits during
+  serialization per
+  <a href="https://httpwg.org/specs/rfc9651.html#ser-decimal">Section 4.1.5</a>.
 
  <li>
   <p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
@@ -8462,11 +8628,13 @@ given a JavaScript value <var>jsValue</var>:
    <var>jsValue</var>'s value.
   </ol>
 
-  <p class=note>Strings that match token syntax are serialized as
-  unquoted tokens; all other strings are serialized as quoted structured
-  field strings. This follows the pattern of treating tokens as a
-  constrained profile of string, similar to {{DOMString}} vs
-  {{ByteString}}.
+  <p class=note>When <var>sfType</var> is not provided, strings that match
+  token syntax are serialized as unquoted tokens; all other strings are
+  serialized as quoted structured field strings. Use
+  <code>sfType: "string"</code> to force a quoted string even
+  when the value matches token syntax, or
+  <code>sfType: "token"</code> to validate and serialize
+  explicitly as a token.
 
  <li><p>If <var>jsValue</var> is a {{Uint8Array}}, return a
  <a>structured field byte sequence</a> whose contents are a copy of
@@ -8568,9 +8736,13 @@ given a JavaScript value <var>jsObj</var>:
  is not Object, or <var>jsObj</var> does not have a property "<code>value</code>",
  then <a>throw</a> a {{TypeError}}.
 
+ <li><p>Let <var>sfType</var> be <var>jsObj</var>["<code>sfType</code>"]
+ if <var>jsObj</var> has a "<code>sfType</code>" property, or undefined
+ otherwise.
+
  <li><p>Let <var>bareItem</var> be the result of
  <a>converting a JavaScript value to a structured field bare item</a>
- given <var>jsObj</var>["<code>value</code>"].
+ given <var>jsObj</var>["<code>value</code>"] and <var>sfType</var>.
 
  <li><p>Let <var>jsParams</var> be <var>jsObj</var>["<code>params</code>"]
  if <var>jsObj</var> has a "<code>params</code>" property, or undefined
@@ -8759,7 +8931,7 @@ sequence of key-value pairs, or a plain object (record). This allows the
 ergonomic form
 <code>{ u: { value: 3 }, i: { value: true } }</code>
 in addition to
-<code>new Map([["u", { value: 3 }], ["i", { value: true }]])</code>.
+<code>new Map(&#91;["u", { value: 3 }], ["i", { value: true }]])</code>.
 </div>
 
 <hr>
@@ -8882,13 +9054,13 @@ method steps are:
 </ol>
 </div>
 
-<p class=note>Parsing structured fields and converting the result to
+<p class="note allow-2119">Parsing structured fields and converting the result to
 JavaScript objects is entirely optional. Implementations that do not
 support structured field parsing are fully compliant with this
 specification by having <a for="header list">get a structured field value</a>
 return null. Returning null matches the behavior when the header is absent or
-malformed, ensuring no feature-detection breakage. The presence of the
-{{Headers/getStructured()}} method itself is required.
+malformed, ensuring no feature-detection breakage. The
+{{Headers/getStructured()}} method itself must be present.
 
 <div algorithm>
 <p>The <dfn export for=Headers method><code>setStructured(<var>name</var>, <var>type</var>, <var>value</var>)</code></dfn>
@@ -8925,14 +9097,6 @@ method steps are:
  no-CORS request-headers</a> from <a>this</a>.
 </ol>
 </div>
-
-<p class=note>Serializing structured fields is entirely optional.
-Implementations that do not support structured field serialization are
-fully compliant with this specification. The minimum conformance
-requirement is that {{Headers/setStructured()}} does not throw for valid
-inputs &mdash; an implementation that silently ignores the call is compliant.
-Whether to actually serialize and set the header is an implementation
-decision.
 
 <p>The <a>value pairs to iterate over</a> are the return value of running
 <a for="header list">sort and combine</a> with <a>this</a>'s <a for=Headers>header list</a>.

--- a/fetch.bs
+++ b/fetch.bs
@@ -8058,7 +8058,7 @@ if (purpose?.value === "prefetch") { /* ... */ }  // direct string comparison
   booleans, {{Uint8Array}} serializes as a byte sequence, and strings
   serialize as tokens if they conform to <a>structured field token</a> syntax
   or as quoted structured field strings otherwise. Item objects can include an
-  <code>sfType</code> property to override the auto-detected structured field
+  <!--grammar-check-override--><code>sfType</code> property to override the auto-detected structured field
   type &mdash; for example, <code>{ value: "foo", sfType: "string" }</code>
   forces a quoted string even when the value matches token syntax. Supported
   <code>sfType</code> values are "<code>boolean</code>",

--- a/fetch.bs
+++ b/fetch.bs
@@ -23,6 +23,15 @@ urlPrefix:https://httpwg.org/specs/rfc9651.html#;type:dfn;spec:rfc9651
     url:text-parse;text:parsing structured fields
     url:;text:structured header
     url:token;text:structured field token
+    url:integer;text:structured field integer
+    url:decimal;text:structured field decimal
+    url:string;text:structured field string
+    url:boolean;text:structured field boolean
+    url:byte-sequence;text:structured field byte sequence
+    url:date;text:structured field date
+    url:displaystring;text:structured field display string
+    url:inner-list;text:structured field inner list
+    url:param;text:structured field parameters
 
 urlPrefix:https://httpwg.org/specs/rfc9110.html#;type:dfn;spec:http
     url:method.overview;text:method
@@ -7897,6 +7906,16 @@ fetch("/music/pk/altes-kamuffel.flac")
 </div>
 
 
+<h3 id=structured-field-type-enum>StructuredFieldType enum</h3>
+
+<pre class=idl>
+enum StructuredFieldType { "item", "list", "dictionary" };
+</pre>
+
+<p>The {{StructuredFieldType}} enum identifies the top-level type of a
+structured field value as defined in [[RFC9651]].
+
+
 <h3 id=headers-class>Headers class</h3>
 
 <pre class=idl>
@@ -7912,6 +7931,8 @@ interface Headers {
   sequence&lt;ByteString> getSetCookie();
   boolean has(ByteString name);
   undefined set(ByteString name, ByteString value);
+  any getStructured(ByteString name, StructuredFieldType type);
+  undefined setStructured(ByteString name, StructuredFieldType type, any value);
   iterable&lt;ByteString, ByteString>;
 };
 </pre>
@@ -7969,6 +7990,93 @@ new Headers(meta2);
  <dt><code><var>headers</var> . <a method for=Headers lt=set()>set</a>(<var>name</var>, <var>value</var>)</code>
  <dd><p>Replaces the value of the first header whose name is <var>name</var> with <var>value</var>
  and removes any remaining headers whose name is <var>name</var>.
+
+ <dt><code><var>result</var> = <var>headers</var> . <a method for=Headers lt=getStructured()>getStructured</a>(<var>name</var>, <var>type</var>)</code>
+ <dd>
+  <p>Parses the value of the header named <var>name</var> as a structured field
+  ([[RFC9651]]) of the given <var>type</var> and returns the result as a
+  JavaScript value.
+
+  <p>Returns null if the header is not present or its value fails to parse as
+  the specified structured field type.
+
+  <p>The <var>type</var> must be one of "<code>item</code>",
+  "<code>list</code>", or "<code>dictionary</code>".
+
+  <p>Structured field values are converted to JavaScript as follows:
+  integers, decimals, and dates become numbers (dates as seconds since the
+  Unix epoch), strings and tokens both become strings, booleans become
+  booleans, and byte sequences become {{Uint8Array}}. Items are returned as
+  objects with <code>value</code> and <code>params</code> properties. Inner
+  lists are returned as objects with <code>items</code> and <code>params</code>
+  properties. Lists are returned as arrays. Dictionaries and parameters are
+  returned as {{Map}} objects.
+
+  <p class=note>Tokens are represented as plain strings, following the same
+  pattern as {{DOMString}}, {{USVString}}, and {{ByteString}} &mdash; they are a
+  constrained profile of string rather than a separate type. When serializing
+  via {{Headers/setStructured()}}, strings that conform to
+  <a>structured field token</a> syntax are serialized as tokens; all other
+  strings are serialized as quoted structured field strings.
+
+  <div class=example id=example-getstructured>
+   <pre><code class=lang-javascript>
+// Priority: u=3, i
+const p = headers.getStructured("Priority", "dictionary");
+// p is Map { "u" => { value: 3, params: Map {} },
+//             "i" => { value: true, params: Map {} } }
+const urgency = p?.get("u")?.value ?? 3;
+
+// Cache-Status: cdn; hit; ttl=3600
+const cs = headers.getStructured("Cache-Status", "list");
+const cacheName = cs?.[0]?.value;           // "cdn" (token, as a string)
+const ttl = cs?.[0]?.params.get("ttl");     // 3600
+
+// Sec-Purpose: prefetch
+const purpose = headers.getStructured("Sec-Purpose", "item");
+if (purpose?.value === "prefetch") { /* ... */ }  // direct string comparison
+</code></pre>
+  </div>
+
+ <dt><code><var>headers</var> . <a method for=Headers lt=setStructured()>setStructured</a>(<var>name</var>, <var>type</var>, <var>value</var>)</code>
+ <dd>
+  <p>Serializes <var>value</var> as a structured field ([[RFC9651]]) of the
+  given <var>type</var> and replaces the header named <var>name</var> with the
+  result.
+
+  <p>Throws a {{TypeError}} if <var>value</var> cannot be serialized as the
+  specified structured field type or if the headers are immutable.
+
+  <p>For serialization, numbers serialize as integers or decimals (determined
+  by whether the number is an integer), booleans serialize as structured field
+  booleans, {{Uint8Array}} serializes as a byte sequence, and strings
+  serialize as tokens if they conform to <a>structured field token</a> syntax
+  or as quoted structured field strings otherwise.
+
+  <div class=example id=example-setstructured>
+   <pre><code class=lang-javascript>
+// Set Priority header — plain object, no params needed
+headers.setStructured("Priority", "dictionary", {
+  u: { value: 0 },
+  i: { value: true }
+});
+// Result: Priority: u=0, i
+
+// Token values are just strings
+headers.setStructured("Cache-Status", "list", [
+  { value: "MyProxy", params: { hit: true, ttl: 7200 } }
+]);
+// Result: Cache-Status: MyProxy;hit;ttl=7200
+// "MyProxy" matches token syntax, so it serializes unquoted.
+// params accepts a plain object, Map, or sequence of pairs.
+
+// Map and sequence forms also work (same as HeadersInit):
+headers.setStructured("Priority", "dictionary", new Map([
+  ["u", { value: 0 }],
+  ["i", { value: true }]
+]));
+</code></pre>
+  </div>
 
  <dt><code>for(const [<var>name</var>, <var>value</var>] of <var>headers</var>)</code>
  <dd><p><var>headers</var> can be iterated over.
@@ -8075,6 +8183,587 @@ from a {{Headers}} object (<var>headers</var>), run these steps:
 <p class=note>This is called when headers are modified by unprivileged code.
 </div>
 
+<hr>
+
+<h4 id=structured-field-conversion>Structured field conversion</h4>
+
+<p class=note>The following algorithms convert between JavaScript values and the
+abstract data types defined in [[RFC9651]]. They are used by
+{{Headers/getStructured()}} and {{Headers/setStructured()}}.
+
+<div algorithm>
+<p>To
+<dfn>convert a structured field bare item to a JavaScript value</dfn>
+given a bare item <var>bareItem</var>:
+
+<ol>
+ <li><p>If <var>bareItem</var> is a <a>structured field integer</a>,
+ then return <var>bareItem</var>'s value as a Number.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field decimal</a>,
+ then return <var>bareItem</var>'s value as a Number.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field string</a>,
+ then return <var>bareItem</var>'s value as a String.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field token</a>,
+ then return <var>bareItem</var>'s value as a String.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field boolean</a>,
+ then return <var>bareItem</var>'s value as a Boolean.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field byte sequence</a>,
+ then return a new {{Uint8Array}} in the <a>current realm</a> whose
+ contents are <var>bareItem</var>'s byte sequence.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field date</a>,
+ then return <var>bareItem</var>'s value (seconds since the Unix epoch)
+ as a Number.
+
+ <li><p>If <var>bareItem</var> is a <a>structured field display string</a>,
+ then return <var>bareItem</var>'s value as a String.
+</ol>
+
+<p class=note>Both <a>structured field tokens</a> and
+<a>structured field strings</a> are returned as JavaScript Strings.
+Tokens are a constrained profile of string &mdash; they conform to the
+token syntax defined in [[RFC9651]]
+(<a href="https://httpwg.org/specs/rfc9651.html#token">Section 3.3.4</a>)
+&mdash; and are represented as plain strings rather than a distinct type,
+following the pattern of {{DOMString}}, {{USVString}}, and {{ByteString}}.
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert structured field parameters to a JavaScript Map</dfn>
+given <a>structured field parameters</a> <var>params</var>:
+
+<ol>
+ <li><p>Let <var>result</var> be a new {{Map}} object in the
+ <a>current realm</a>.
+
+ <li>
+  <p><a for=map>For each</a> <var>key</var> &rarr; <var>bareItem</var> of
+  <var>params</var>:
+
+  <ol>
+   <li><p>Let <var>jsValue</var> be the result of
+   <a>converting a structured field bare item to a JavaScript value</a>
+   given <var>bareItem</var>.
+
+   <li><p>Perform <a href="https://tc39.es/ecma262/#sec-map.prototype.set">%Map.prototype.set%</a>
+   on <var>result</var> with arguments <var>key</var> and <var>jsValue</var>.
+  </ol>
+
+ <li><p>Return <var>result</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a structured field item to a JavaScript object</dfn>
+given a structured field item <var>sfItem</var>:
+
+<ol>
+ <li><p>Let <var>value</var> be the result of
+ <a>converting a structured field bare item to a JavaScript value</a>
+ given <var>sfItem</var>'s bare item.
+
+ <li><p>Let <var>params</var> be the result of
+ <a>converting structured field parameters to a JavaScript Map</a>
+ given <var>sfItem</var>'s <a>structured field parameters</a>.
+
+ <li><p>Let <var>result</var> be
+ <a href="https://tc39.es/ecma262/#sec-ordinaryobjectcreate">OrdinaryObjectCreate</a>({{%Object.prototype%}}).
+
+ <li><p>Perform
+ <a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataPropertyOrThrow</a>(<var>result</var>,
+ "<code>value</code>", <var>value</var>).
+
+ <li><p>Perform
+ <a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataPropertyOrThrow</a>(<var>result</var>,
+ "<code>params</code>", <var>params</var>).
+
+ <li><p>Return <var>result</var>.
+</ol>
+
+<p class=note>The returned object has the shape
+<code>{ value: <var>bareItem</var>, params: Map }</code>.
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a structured field inner list to a JavaScript object</dfn>
+given a <a>structured field inner list</a> <var>innerList</var>:
+
+<ol>
+ <li><p>Let <var>items</var> be an empty <a for=/>list</a>.
+
+ <li>
+  <p>For each <var>sfItem</var> of <var>innerList</var>'s members:
+
+  <ol>
+   <li><p>Let <var>converted</var> be the result of
+   <a>converting a structured field item to a JavaScript object</a>
+   given <var>sfItem</var>.
+
+   <li><p><a for=list>Append</a> <var>converted</var> to <var>items</var>.
+  </ol>
+
+ <li><p>Let <var>params</var> be the result of
+ <a>converting structured field parameters to a JavaScript Map</a>
+ given <var>innerList</var>'s <a>structured field parameters</a>.
+
+ <li><p>Let <var>jsArray</var> be
+ <a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a>(<var>items</var>).
+
+ <li><p>Let <var>result</var> be
+ <a href="https://tc39.es/ecma262/#sec-ordinaryobjectcreate">OrdinaryObjectCreate</a>({{%Object.prototype%}}).
+
+ <li><p>Perform
+ <a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataPropertyOrThrow</a>(<var>result</var>,
+ "<code>items</code>", <var>jsArray</var>).
+
+ <li><p>Perform
+ <a href="https://tc39.es/ecma262/#sec-createdataproperty">CreateDataPropertyOrThrow</a>(<var>result</var>,
+ "<code>params</code>", <var>params</var>).
+
+ <li><p>Return <var>result</var>.
+</ol>
+
+<p class=note>The returned object has the shape
+<code>{ items: [{ value, params }, ...], params: Map }</code>.
+An inner list is distinguished from an item by the presence of
+<code>items</code> rather than <code>value</code>.
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a structured field member to a JavaScript value</dfn>
+given a structured field member <var>member</var>:
+
+<ol>
+ <li><p>If <var>member</var> is a structured field item, return
+ the result of <a>converting a structured field item to a JavaScript object</a>
+ given <var>member</var>.
+
+ <li><p>If <var>member</var> is a <a>structured field inner list</a>, return
+ the result of <a>converting a structured field inner list to a JavaScript object</a>
+ given <var>member</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a structured field to a JavaScript value</dfn>
+given a <a>structured field value</a> <var>sfValue</var> and a
+{{StructuredFieldType}} <var>type</var>:
+
+<ol>
+ <li>
+  <p>If <var>type</var> is "<code>item</code>":
+
+  <ol>
+   <li><p>Return the result of
+   <a>converting a structured field item to a JavaScript object</a>
+   given <var>sfValue</var>.
+  </ol>
+
+ <li>
+  <p>If <var>type</var> is "<code>list</code>":
+
+  <ol>
+   <li><p>Let <var>result</var> be an empty <a for=/>list</a>.
+
+   <li>
+    <p>For each <var>member</var> of <var>sfValue</var>'s members:
+
+    <ol>
+     <li><p>Let <var>converted</var> be the result of
+     <a>converting a structured field member to a JavaScript value</a>
+     given <var>member</var>.
+
+     <li><p><a for=list>Append</a> <var>converted</var> to <var>result</var>.
+    </ol>
+
+   <li><p>Return
+   <a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a>(<var>result</var>).
+  </ol>
+
+ <li>
+  <p>If <var>type</var> is "<code>dictionary</code>":
+
+  <ol>
+   <li><p>Let <var>result</var> be a new {{Map}} object in the
+   <a>current realm</a>.
+
+   <li>
+    <p><a for=map>For each</a> <var>key</var> &rarr; <var>member</var> of
+    <var>sfValue</var>'s members (in order):
+
+    <ol>
+     <li><p>Let <var>converted</var> be the result of
+     <a>converting a structured field member to a JavaScript value</a>
+     given <var>member</var>.
+
+     <li><p>Perform <a href="https://tc39.es/ecma262/#sec-map.prototype.set">%Map.prototype.set%</a>
+     on <var>result</var> with arguments <var>key</var> and <var>converted</var>.
+    </ol>
+
+   <li><p>Return <var>result</var>.
+  </ol>
+</ol>
+</div>
+
+<hr>
+
+<p>The following algorithms convert JavaScript values to structured field
+values for use with {{Headers/setStructured()}}.
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript value to a structured field bare item</dfn>
+given a JavaScript value <var>jsValue</var>:
+
+<ol>
+ <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+ is Boolean, return a <a>structured field boolean</a> with <var>jsValue</var>'s value.
+
+ <li>
+  <p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+  is Number:
+
+  <ol>
+   <li><p>If <var>jsValue</var> is NaN, +&infin;, or &minus;&infin;,
+   then <a>throw</a> a {{TypeError}}.
+
+   <li><p>If <var>jsValue</var> is an
+   <a href="https://tc39.es/ecma262/#sec-isinteger">integral number</a>,
+   return a <a>structured field integer</a> with <var>jsValue</var>'s value.
+
+   <li><p>Otherwise, return a <a>structured field decimal</a> with
+   <var>jsValue</var>'s value.
+  </ol>
+
+ <li>
+  <p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+  is String:
+
+  <ol>
+   <li><p>If <var>jsValue</var> conforms to the <a>structured field token</a>
+   syntax defined in [[RFC9651]]
+   (<a href="https://httpwg.org/specs/rfc9651.html#token">Section 3.3.4</a>)
+   &mdash; i.e., it matches the production
+   <code>( ALPHA / "*" ) *( tchar / ":" / "/" )</code>
+   &mdash; then return a <a>structured field token</a> with
+   <var>jsValue</var>'s value.
+
+   <li><p>Otherwise, return a <a>structured field string</a> with
+   <var>jsValue</var>'s value.
+  </ol>
+
+  <p class=note>Strings that match token syntax are serialized as
+  unquoted tokens; all other strings are serialized as quoted structured
+  field strings. This follows the pattern of treating tokens as a
+  constrained profile of string, similar to {{DOMString}} vs
+  {{ByteString}}.
+
+ <li><p>If <var>jsValue</var> is a {{Uint8Array}}, return a
+ <a>structured field byte sequence</a> whose contents are a copy of
+ <var>jsValue</var>'s buffer.
+
+ <li><p><a>Throw</a> a {{TypeError}}.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript value to structured field parameters</dfn>
+given a JavaScript value <var>jsParams</var>:
+
+<ol>
+ <li><p>Let <var>params</var> be an empty ordered map of
+ <a>structured field parameters</a>.
+
+ <li><p>If <var>jsParams</var> is undefined or null, then return
+ <var>params</var>.
+
+ <li>
+  <p>If <var>jsParams</var> is a {{Map}}:
+
+  <ol>
+   <li>
+    <p>For each <var>key</var> &rarr; <var>jsValue</var> of <var>jsParams</var>
+    (in insertion order):
+
+    <ol>
+     <li><p>If <var>key</var> is not a String, then <a>throw</a> a
+     {{TypeError}}.
+
+     <li><p>Let <var>bareItem</var> be the result of
+     <a>converting a JavaScript value to a structured field bare item</a>
+     given <var>jsValue</var>.
+
+     <li><p>Set <var>params</var>[<var>key</var>] to <var>bareItem</var>.
+    </ol>
+
+   <li><p>Return <var>params</var>.
+  </ol>
+
+ <li>
+  <p>If <var>jsParams</var> is a <a>sequence</a>:
+
+  <ol>
+   <li>
+    <p><a for=list>For each</a> <var>pair</var> of <var>jsParams</var>:
+
+    <ol>
+     <li><p>If <var>pair</var>'s <a for=list>size</a> is not 2, then
+     <a>throw</a> a {{TypeError}}.
+
+     <li><p>Let <var>bareItem</var> be the result of
+     <a>converting a JavaScript value to a structured field bare item</a>
+     given <var>pair</var>[1].
+
+     <li><p>Set <var>params</var>[<var>pair</var>[0]] to <var>bareItem</var>.
+    </ol>
+
+   <li><p>Return <var>params</var>.
+  </ol>
+
+ <li>
+  <p>Otherwise, <var>jsParams</var> is a <a for=/>record</a>:
+
+  <ol>
+   <li>
+    <p><a for=map>For each</a> <var>key</var> &rarr; <var>jsValue</var> of
+    <var>jsParams</var>:
+
+    <ol>
+     <li><p>Let <var>bareItem</var> be the result of
+     <a>converting a JavaScript value to a structured field bare item</a>
+     given <var>jsValue</var>.
+
+     <li><p>Set <var>params</var>[<var>key</var>] to <var>bareItem</var>.
+    </ol>
+
+   <li><p>Return <var>params</var>.
+  </ol>
+</ol>
+
+<p class=note>This accepts the same input shapes as {{HeadersInit}}: a
+{{Map}}, a sequence of key-value pairs, or a plain object (record).
+Additionally, undefined or null is accepted and treated as empty
+parameters, allowing the <code>params</code> property to be omitted from
+item and inner list objects passed to {{Headers/setStructured()}}.
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript object to a structured field item</dfn>
+given a JavaScript value <var>jsObj</var>:
+
+<ol>
+ <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsObj</var>)
+ is not Object, or <var>jsObj</var> does not have a property "<code>value</code>",
+ then <a>throw</a> a {{TypeError}}.
+
+ <li><p>Let <var>bareItem</var> be the result of
+ <a>converting a JavaScript value to a structured field bare item</a>
+ given <var>jsObj</var>["<code>value</code>"].
+
+ <li><p>Let <var>jsParams</var> be <var>jsObj</var>["<code>params</code>"]
+ if <var>jsObj</var> has a "<code>params</code>" property, or undefined
+ otherwise.
+
+ <li><p>Let <var>params</var> be the result of
+ <a>converting a JavaScript value to structured field parameters</a>
+ given <var>jsParams</var>.
+
+ <li><p>Return a structured field item whose bare item is
+ <var>bareItem</var> and whose <a>structured field parameters</a> are
+ <var>params</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript object to a structured field inner list</dfn>
+given a JavaScript value <var>jsObj</var>:
+
+<ol>
+ <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsObj</var>)
+ is not Object, or <var>jsObj</var> does not have a property "<code>items</code>",
+ then <a>throw</a> a {{TypeError}}.
+
+ <li><p>Let <var>jsItems</var> be <var>jsObj</var>["<code>items</code>"].
+
+ <li><p>If <var>jsItems</var> is not <a>iterable</a>, then <a>throw</a> a
+ {{TypeError}}.
+
+ <li><p>Let <var>members</var> be an empty <a for=/>list</a>.
+
+ <li>
+  <p>For each <var>jsItem</var> of <var>jsItems</var>:
+
+  <ol>
+   <li><p>Let <var>sfItem</var> be the result of
+   <a>converting a JavaScript object to a structured field item</a>
+   given <var>jsItem</var>.
+
+   <li><p><a for=list>Append</a> <var>sfItem</var> to <var>members</var>.
+  </ol>
+
+ <li><p>Let <var>jsParams</var> be <var>jsObj</var>["<code>params</code>"]
+ if <var>jsObj</var> has a "<code>params</code>" property, or undefined
+ otherwise.
+
+ <li><p>Let <var>params</var> be the result of
+ <a>converting a JavaScript value to structured field parameters</a>
+ given <var>jsParams</var>.
+
+ <li><p>Return a <a>structured field inner list</a> whose members are
+ <var>members</var> and whose <a>structured field parameters</a> are
+ <var>params</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript object to a structured field member</dfn>
+given a JavaScript value <var>jsObj</var>:
+
+<ol>
+ <li><p>If <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsObj</var>)
+ is Object and <var>jsObj</var> has a property "<code>items</code>",
+ return the result of
+ <a>converting a JavaScript object to a structured field inner list</a>
+ given <var>jsObj</var>.
+
+ <li><p>Otherwise, return the result of
+ <a>converting a JavaScript object to a structured field item</a>
+ given <var>jsObj</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To
+<dfn>convert a JavaScript value to a structured field</dfn>
+given a JavaScript value <var>jsValue</var> and a {{StructuredFieldType}}
+<var>type</var>:
+
+<ol>
+ <li>
+  <p>If <var>type</var> is "<code>item</code>":
+
+  <ol>
+   <li><p>Return the result of
+   <a>converting a JavaScript object to a structured field item</a>
+   given <var>jsValue</var>.
+  </ol>
+
+ <li>
+  <p>If <var>type</var> is "<code>list</code>":
+
+  <ol>
+   <li><p>If <var>jsValue</var> is not <a>iterable</a>, then
+   <a>throw</a> a {{TypeError}}.
+
+   <li><p>Let <var>members</var> be an empty <a for=/>list</a>.
+
+   <li>
+    <p>For each <var>jsItem</var> of <var>jsValue</var>:
+
+    <ol>
+     <li><p>Let <var>member</var> be the result of
+     <a>converting a JavaScript object to a structured field member</a>
+     given <var>jsItem</var>.
+
+     <li><p><a for=list>Append</a> <var>member</var> to <var>members</var>.
+    </ol>
+
+   <li><p>Return a structured field list whose members are <var>members</var>.
+  </ol>
+
+ <li>
+  <p>If <var>type</var> is "<code>dictionary</code>":
+
+  <ol>
+   <li><p>Let <var>dict</var> be an empty structured field dictionary.
+
+   <li>
+    <p>If <var>jsValue</var> is a {{Map}}:
+
+    <ol>
+     <li>
+      <p>For each <var>key</var> &rarr; <var>jsMember</var> of <var>jsValue</var>
+      (in insertion order):
+
+      <ol>
+       <li><p>If <var>key</var> is not a String, then <a>throw</a> a
+       {{TypeError}}.
+
+       <li><p>Let <var>member</var> be the result of
+       <a>converting a JavaScript object to a structured field member</a>
+       given <var>jsMember</var>.
+
+       <li><p>Set <var>dict</var>[<var>key</var>] to <var>member</var>.
+      </ol>
+    </ol>
+
+   <li>
+    <p>Otherwise, if <var>jsValue</var> is a <a>sequence</a>:
+
+    <ol>
+     <li>
+      <p><a for=list>For each</a> <var>pair</var> of <var>jsValue</var>:
+
+      <ol>
+       <li><p>If <var>pair</var>'s <a for=list>size</a> is not 2, then
+       <a>throw</a> a {{TypeError}}.
+
+       <li><p>Let <var>member</var> be the result of
+       <a>converting a JavaScript object to a structured field member</a>
+       given <var>pair</var>[1].
+
+       <li><p>Set <var>dict</var>[<var>pair</var>[0]] to <var>member</var>.
+      </ol>
+    </ol>
+
+   <li>
+    <p>Otherwise, if <a href="https://tc39.es/ecma262/#sec-typeof-operator">Type</a>(<var>jsValue</var>)
+    is Object:
+
+    <ol>
+     <li>
+      <p><a for=map>For each</a> <var>key</var> &rarr; <var>jsMember</var> of
+      <var>jsValue</var>:
+
+      <ol>
+       <li><p>Let <var>member</var> be the result of
+       <a>converting a JavaScript object to a structured field member</a>
+       given <var>jsMember</var>.
+
+       <li><p>Set <var>dict</var>[<var>key</var>] to <var>member</var>.
+      </ol>
+    </ol>
+
+   <li><p>Otherwise, <a>throw</a> a {{TypeError}}.
+
+   <li><p>Return <var>dict</var>.
+  </ol>
+</ol>
+
+<p class=note>Like {{HeadersInit}}, dictionaries accept a {{Map}}, a
+sequence of key-value pairs, or a plain object (record). This allows the
+ergonomic form
+<code>{ u: { value: 3 }, i: { value: true } }</code>
+in addition to
+<code>new Map([["u", { value: 3 }], ["i", { value: true }]])</code>.
+</div>
+
+<hr>
+
 <div algorithm>
 <p>The
 <dfn id=dom-headers export for=Headers constructor lt="Headers(init)"><code>new Headers(<var>init</var>)</code></dfn>
@@ -8173,6 +8862,77 @@ method steps are:
  <a for=Headers>remove privileged no-CORS request-headers</a> from <a>this</a>.
 </ol>
 </div>
+
+<div algorithm>
+<p>The <dfn export for=Headers method><code>getStructured(<var>name</var>, <var>type</var>)</code></dfn>
+method steps are:
+
+<ol>
+ <li><p>If <var>name</var> is not a <a for=/>header name</a>, then <a>throw</a>
+ a {{TypeError}}.
+
+ <li><p>Let <var>sfValue</var> be the result of <a for="header list">getting
+ a structured field value</a> given <var>name</var> and <var>type</var> from
+ <a>this</a>'s <a for=Headers>header list</a>.
+
+ <li><p>If <var>sfValue</var> is null, then return null.
+
+ <li><p>Return the result of <a>converting a structured field to a
+ JavaScript value</a> given <var>sfValue</var> and <var>type</var>.
+</ol>
+</div>
+
+<p class=note>Parsing structured fields and converting the result to
+JavaScript objects is entirely optional. Implementations that do not
+support structured field parsing are fully compliant with this
+specification by having <a for="header list">get a structured field value</a>
+return null. Returning null matches the behavior when the header is absent or
+malformed, ensuring no feature-detection breakage. The presence of the
+{{Headers/getStructured()}} method itself is required.
+
+<div algorithm>
+<p>The <dfn export for=Headers method><code>setStructured(<var>name</var>, <var>type</var>, <var>value</var>)</code></dfn>
+method steps are:
+
+<ol>
+ <li><p>If <var>name</var> is not a <a for=/>header name</a>, then <a>throw</a>
+ a {{TypeError}}.
+
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is "<code>immutable</code>",
+ then <a>throw</a> a {{TypeError}}.
+
+ <li><p>Let <var>sfValue</var> be the result of
+ <a>converting a JavaScript value to a structured field</a> given
+ <var>value</var> and <var>type</var>.
+
+ <li><p>Let <var>serialized</var> be the result of
+ <a>serializing structured fields</a> on <var>sfValue</var>.
+
+ <li><p>If serialization fails, then <a>throw</a> a {{TypeError}}.
+
+ <li><p>If <a for=Headers>validating</a> (<var>name</var>, <var>serialized</var>)
+ for <a>this</a> returns false, then return.
+
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is
+ "<code>request-no-cors</code>" and (<var>name</var>, <var>serialized</var>)
+ is not a <a>no-CORS-safelisted request-header</a>, then return.
+
+ <li><p><a for="header list">Set</a> (<var>name</var>, <var>serialized</var>)
+ in <a>this</a>'s <a for=Headers>header list</a>.
+
+ <li><p>If <a>this</a>'s <a for=Headers>guard</a> is
+ "<code>request-no-cors</code>", then <a for=Headers>remove privileged
+ no-CORS request-headers</a> from <a>this</a>.
+</ol>
+</div>
+
+<p class=note>Serializing structured fields is entirely optional.
+Implementations that do not support structured field serialization are
+fully compliant with this specification. The minimum conformance
+requirement is that {{Headers/setStructured()}} does not throw for valid
+inputs &mdash; an implementation that silently ignores the call is compliant.
+Whether to actually serialize and set the header is an implementation
+decision.
 
 <p>The <a>value pairs to iterate over</a> are the return value of running
 <a for="header list">sort and combine</a> with <a>this</a>'s <a for=Headers>header list</a>.


### PR DESCRIPTION
Adds new APIs to the Headers class for getting/setting structured header fields.

Structured fields are defined in RFC 8941. Newer HTTP header definitions build on it. Fetch's handling of all header values as strings works but loses some of the utility. This commit adds new `getStructured/setStructured` APIS to `Headers` for getting/setting header field values as structured fields. The existing `get`/`set`/`append`/etc are left untouched. Header iteration is left untouched. It remains possible to get all fields as strings.

There are currently ~36 standard headers that use structured header fields:

#### Dictionary

| Header              | Spec                                                               | Description                                                        |
| ------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
| `Priority`            | [RFC 9218](https://www.rfc-editor.org/rfc/rfc9218)                  | HTTP response prioritization (urgency, incremental delivery)       |
| `Signature`           | [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)                  | HTTP message signatures                                            |
| `Signature-Input`     | [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)                  | Metadata for message signatures (covered components, key ID, etc.) |
| `Accept-Signature`    | [RFC 9421 §5.1](https://www.rfc-editor.org/rfc/rfc9421#section-5.1) | Requests that recipient apply a signature                          |
| `Content-Digest`      | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530)                  | Integrity digest over HTTP message content                         |
| `Repr-Digest`         | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530)                  | Integrity digest over HTTP representation                          |
| `Want-Content-Digest` | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530)                  | Requests `Content-Digest` with algorithm preferences                 |
| `Want-Repr-Digest`    | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530)                  | Requests `Repr-Digest` with algorithm preferences                    |
| `CDN-Cache-Control`   | [RFC 9213](https://www.rfc-editor.org/rfc/rfc9213)                  | Targeted cache directives for CDN caches                           |
| `Use-As-Dictionary`   | [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842)                  | Marks a response as a compression dictionary                       |

#### List

| Header                   | Spec                                                | Description                                         |
| ------------------------ | --------------------------------------------------- | --------------------------------------------------- |
| `Cache-Status`             | [RFC 9211](https://www.rfc-editor.org/rfc/rfc9211)   | Per-cache handling report (`hit`, `fwd`, `ttl`, etc.)     |
| `Proxy-Status`             | [RFC 9209](https://www.rfc-editor.org/rfc/rfc9209)   | Per-intermediary handling report with error details |
| `Accept-CH`                | [RFC 8942](https://www.rfc-editor.org/rfc/rfc8942)   | Advertises server support for Client Hints          |
| `Client-Cert-Chain`        | [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)   | Client certificate chain from TLS-terminating proxy |
| `Accept-Query`             | [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008) | Accepted media types for HTTP QUERY body            |
| `Cache-Groups`             | [RFC 9875](https://www.rfc-editor.org/rfc/rfc9875)   | Associates cached responses with named groups       |
| `Cache-Group-Invalidation` | [RFC 9875](https://www.rfc-editor.org/rfc/rfc9875)   | Invalidates all responses in named cache groups     |

#### Item

| Header                                   | Spec                                                                                              | Description                                              |
| ---------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| `Client-Cert`                              | [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)                                                 | End-entity client certificate (Byte Sequence)            |
| `Capsule-Protocol`                         | [RFC 9297](https://www.rfc-editor.org/rfc/rfc9297)                                                 | Enables the Capsule Protocol on an HTTP stream (Boolean) |
| `Deprecation`                              | [RFC 9745](https://www.rfc-editor.org/rfc/rfc9745)                                                 | Signals resource deprecation (Date)                      |
| `Available-Dictionary`                     | [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842)                                                 | Client has a compression dictionary available            |
| `Dictionary-ID`                            | [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842)                                                 | Assigns a stable ID to a compression dictionary response |
| `Concealed-Auth-Export`                    | [RFC 9729](https://www.rfc-editor.org/rfc/rfc9729)                                                 | Exported keying material for concealed HTTP auth         |
| `Cross-Origin-Embedder-Policy`             | [HTML Standard](https://html.spec.whatwg.org/multipage/origin.html#coep)                           | Controls cross-origin resource loading policy            |
| `Cross-Origin-Embedder-Policy-Report-Only` | [HTML Standard](https://html.spec.whatwg.org/multipage/origin.html#coep)                           | COEP in report-only mode                                 |
| `Cross-Origin-Opener-Policy`               | [HTML Standard](https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies) | Controls browsing context group sharing                  |
| `Cross-Origin-Opener-Policy-Report-Only`   | [HTML Standard](https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies) | COOP in report-only mode                                 |
| `Origin-Agent-Cluster`                     | [HTML Standard](https://html.spec.whatwg.org/multipage/origin.html#origin-agent-cluster)           | Requests origin-keyed agent cluster (Boolean)            |
| `Sec-Fetch-Dest`                           | [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/)                                  | Request destination type (Token)                         |
| `Sec-Fetch-Mode`                           | [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/)                                  | Request mode (Token)                                     |
| `Sec-Fetch-Site`                           | [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/)                                  | Request-vs-target origin relationship (Token)            |
| `Sec-Fetch-User`                           | [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/)                                  | User activation (Boolean)                                |
| `Sec-Purpose`                              | [Fetch Standard](https://fetch.spec.whatwg.org/)                                                   | Request purpose, e.g. `prefetch` (Token)                   |

### Examples

#### Reading the `Priority` header (Dictionary)

```js
// Priority: u=0, i
const p = response.headers.getStructured("Priority", "dictionary");
const urgency = p?.get("u")?.value ?? 3;     // 0
const incremental = p?.get("i")?.value ?? false; // true
```

Compared with strings:

```js
const raw = response.headers.get("Priority"); // "u=0, i"
// ... now what? Split on comma? Parse key=value? Handle quoting?
// Every app rolls its own parser and gets edge cases wrong.
```

#### Reading Cache-Status (List)

```js
// Cache-Status: ReverseProxy;hit, CDN;fwd=miss;stored;ttl=3600
const cs = response.headers.getStructured("Cache-Status", "list");
for (const entry of cs) {
  console.log(entry.value);                    // "ReverseProxy", "CDN"
  console.log(entry.params.get("hit"));        // true, undefined
  console.log(entry.params.get("fwd"));        // undefined, "miss"
  console.log(entry.params.get("ttl"));        // undefined, 3600
}
```

#### Reading Content-Digest (Dictionary with Byte Sequences)

```js
// Content-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
const digest = response.headers.getStructured("Content-Digest", "dictionary");
const hash = digest?.get("sha-256")?.value;    // Uint8Array
```

#### Reading Sec-Purpose (Item)

```js
// Sec-Purpose: prefetch
const purpose = request.headers.getStructured("Sec-Purpose", "item");
if (purpose?.value === "prefetch") {
  // serve a lighter response
}
```

#### Writing Priority (Dictionary — plain object form)

```js
// Sets: Priority: u=0, i
request.headers.setStructured("Priority", "dictionary", {
  u: { value: 0 },
  i: { value: true }
});
```

#### Writing Cache-Status (List with parameters)

```js
// Sets: Cache-Status: MyProxy;hit;ttl=7200
response.headers.setStructured("Cache-Status", "list", [
  { value: "MyProxy", params: { hit: true, ttl: 7200 } }
]);
```

#### Writing Content-Digest (Dictionary with Byte Sequence)

```js
const body = await response.arrayBuffer();
const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", body));

// Sets: Content-Digest: sha-256=:base64encodedhash=:
response.headers.setStructured("Content-Digest", "dictionary", {
  "sha-256": { value: hash }
});
```

#### Graceful fallback when unsupported

```js
// getStructured returns null if the header is absent, malformed,
// or if the implementation doesn't support structured field parsing.
const priority = request.headers.getStructured("Priority", "dictionary");
const urgency = priority?.get("u")?.value ?? 3;  // always works, defaults to 3
```

#### Token vs String serialization

```js
// Strings matching token syntax serialize as unquoted tokens:
headers.setStructured("Example", "item", { value: "foo" });
// Sets: Example: foo

// Strings that don't match token syntax serialize as quoted strings:
headers.setStructured("Example", "item", { value: "hello world" });
// Sets: Example: "hello world"
```

#### All input forms for dictionaries and parameters (HeadersInit pattern)

```js
// Plain object (most ergonomic)
headers.setStructured("Priority", "dictionary", {
  u: { value: 3 },
  i: { value: true }
});

// Map (preserves insertion order explicitly)
headers.setStructured("Priority", "dictionary", new Map([
  ["u", { value: 3 }],
  ["i", { value: true }]
]));

// Sequence of pairs
headers.setStructured("Priority", "dictionary", [
  ["u", { value: 3 }],
  ["i", { value: true }]
]);

// Parameters accept the same forms:
headers.setStructured("Cache-Status", "list", [
  { value: "cdn", params: { hit: true, ttl: 3600 } },       // plain object
  { value: "origin", params: new Map([["fwd", "miss"]]) },   // Map
  { value: "edge", params: [["stored", true]] }              // sequence
]);
```

---

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (not for CORS changes): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1943.html" title="Last updated on Aug 7, 2026, 6:02 PM UTC (0b6bae3)">Preview</a> | <a href="https://whatpr.org/fetch/1943/586cd2a...0b6bae3.html" title="Last updated on Aug 7, 2026, 6:02 PM UTC (0b6bae3)">Diff</a>