### PR TITLE
Editorial: fix typos in deferred fetching quota section

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -7504,7 +7504,7 @@ using permissions policy.
 cross-origin nested documents, each reserving 8 kibibytes.
 
 <p>The top-level <a for=/>document</a>, and subsequently its nested documents, can control how much
-of their quota is delegates to cross-origin child documents, using permissions policy. By default,
+of their quota is delegated to cross-origin child documents, using permissions policy. By default,
 the "{{PermissionsPolicy/deferred-fetch-minimal}}" policy is enabled for any origin, while
 "{{PermissionsPolicy/deferred-fetch}}" is enabled for the top-level document's origin only. By
 relaxing the "{{PermissionsPolicy/deferred-fetch}}" policy for particular origins and nested
@@ -7567,7 +7567,7 @@ fetchLater("https://a.example.com", {body: a_12kb_body});
  <pre><code class=lang-http>Permissions-Policy: deferred-fetch=(self "https://fratop.example.com")</code></pre>
 
  <p>Each nested document reserves its own quota. So the following would work, because each frame
- reserve 8 kibibytes:
+ reserves 8 kibibytes:
 
  <pre><code class=lang-javascript>
 // In cross-origin nested document at https://fratop.example.com/frame-1
@@ -7687,8 +7687,8 @@ stated otherwise, it is 0.
    <dt><var>isTopLevel</var> is true
    <dd>
     <p>512 kibibytes
-    <p class=note>The default of 640 kibibytes, decremented By
-    <a>quota reserved for <code>deferred-fetch-minimal</code></a>)
+    <p class=note>The default of 640 kibibytes, decremented by
+    <a>quota reserved for <code>deferred-fetch-minimal</code></a>.
 
    <dt><var>deferredFetchAllowed</var> is true, and <var>navigable</var>'s
    <a>navigable container</a>'s <a>reserved deferred-fetch quota</a> is
@@ -10431,6 +10431,7 @@ Ehsan Akhgari,
 Emily Stark,
 Eric Lawrence,
 Eric Orth,
+Farel Hanafi,
 Feng Yu<!-- F3n67u; GitHub -->,
 François Marier,
 Frank Ellerman,


### PR DESCRIPTION
Editorial: fix typos in deferred fetching quota section
This PR fixes minor typographical and grammatical issues in the deferred fetching quota section:
- Changes "is delegates to" to "is delegated to"
- Fixes subject-verb agreement: "each frame reserve" -> "each frame reserves"
- Fixes capitalization of "decremented By" and removes stray unmatched closing parenthesis
- Adds my name to the Acknowledgments section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1949.html" title="Last updated on Aug 19, 2026, 9:27 AM UTC (a30b6bd)">Preview</a> | <a href="https://whatpr.org/fetch/1949/586cd2a...a30b6bd.html" title="Last updated on Aug 19, 2026, 9:27 AM UTC (a30b6bd)">Diff</a>