### PR TITLE
Add the "speculationrules" destination

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -1940,7 +1940,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>speculationrules</code>"
    <td><code>speculation-rules-src</code>
-   <td>The [:Speculation-Rules:] header
+   <td>HTML's <code>&lt;script type=speculationrules src></code>, the [:Speculation-Rules:] header
   <tr>
    <td>"<code>serviceworker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1883,14 +1883,11 @@ not always relevant and might require different behavior.
   <tr>
    <td rowspan=23>""
    <td>"<code>report</code>"
-   <td rowspan=3>&mdash;
+   <td rowspan=2>&mdash;
    <td>CSP, NEL reports.
   <tr>
    <td>"<code>document</code>"
    <td>HTML's navigate algorithm (top-level only).
-  <tr>
-   <td>"<code>speculationrules</code>"
-   <td>The [:Speculation-Rules:] header
   <tr>
    <td>"<code>frame</code>"
    <td><code>child-src</code>
@@ -1940,6 +1937,10 @@ not always relevant and might require different behavior.
    <td>"<code>script</code>"
    <td><code>script-src</code>
    <td>HTML's <code>&lt;script></code>, <code>importScripts()</code>
+  <tr>
+   <td>"<code>speculationrules</code>"
+   <td><code>speculation-rules-src</code>
+   <td>The [:Speculation-Rules:] header
   <tr>
    <td>"<code>serviceworker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>

--- a/fetch.bs
+++ b/fetch.bs
@@ -1838,6 +1838,7 @@ the empty string,
 "<code>script</code>",
 "<code>serviceworker</code>",
 "<code>sharedworker</code>",
+"<code>speculationrules</code>",
 "<code>style</code>",
 "<code>text</code>",
 "<code>track</code>",
@@ -1882,11 +1883,14 @@ not always relevant and might require different behavior.
   <tr>
    <td rowspan=22>""
    <td>"<code>report</code>"
-   <td rowspan=2>&mdash;
+   <td rowspan=3>&mdash;
    <td>CSP, NEL reports.
   <tr>
    <td>"<code>document</code>"
    <td>HTML's navigate algorithm (top-level only).
+  <tr>
+   <td>"<code>speculationrules</code>"
+   <td>The [:Speculation-Rules:] header
   <tr>
    <td>"<code>frame</code>"
    <td><code>child-src</code>
@@ -1947,7 +1951,7 @@ not always relevant and might require different behavior.
   <tr>
    <td>"<code>webidentity</code>"
    <td><code>connect-src</code>
-   <td><code>Federated Credential Management requests</code>
+   <td>Federated Credential Management requests
   <tr>
    <td>"<code>worker</code>"
    <td><code>child-src</code>, <code>script-src</code>, <code>worker-src</code>
@@ -8639,7 +8643,7 @@ dictionary RequestInit {
   any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "speculationrules", "style", "text", "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/fetch.bs
+++ b/fetch.bs
@@ -1881,7 +1881,7 @@ not always relevant and might require different behavior.
    <th>CSP directive
    <th>Features
   <tr>
-   <td rowspan=22>""
+   <td rowspan=23>""
    <td>"<code>report</code>"
    <td rowspan=3>&mdash;
    <td>CSP, NEL reports.


### PR DESCRIPTION
This destination is used when fetching speculation rule sets, whether via the
`Speculation-Rules` HTTP response header or an external
`<script type=speculationrules src>` element. It is governed by the
`speculation-rules-src` CSP directive.

---

Supersedes #1841, whose commit is included here unchanged and with its
authorship preserved. On top of it, this PR:

* fixes the illustrative destination table's `""` initiator `rowspan`, which was
  not grown when the new row was added, leaving the table a cell short
  (editorial);
* moves `"speculationrules"` out of the "no CSP directive" grouping and gives it
  the `speculation-rules-src` directive; and
* notes that the destination also covers external
  `<script type=speculationrules src>` elements, not just the header.

Note that HTML's "process the `Speculation-Rules` header" already creates
requests whose destination is `"speculationrules"`, so this value is referenced
today without being defined here.

### Related pull requests

* whatwg/html#11426 (merged) - defines the `Speculation-Rules` header, and
  creates requests with this destination.
* w3c/webappsec-csp#808 - defines `speculation-rules-src` and maps this
  destination to it.
* whatwg/html#11697 - makes an external `<script type=speculationrules src>`
  fetch its rule set using this destination.

<!--
Thank you for contributing to the Fetch Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * See https://github.com/whatwg/html/pull/11426
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The header is covered by https://github.com/web-platform-tests/wpt/blob/c669bcf970fe50b56e0ee53de9c2097a012dafc7/speculation-rules/prefetch/resources/ruleset.py#L40-L43
   * CSP integration is covered alongside w3c/webappsec-csp#808
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * See https://github.com/whatwg/html/pull/11426
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/40289
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1952.html" title="Last updated on Aug 21, 2026, 12:04 AM UTC (9d2f96e)">Preview</a> | <a href="https://whatpr.org/fetch/1952/4a2b67d...9d2f96e.html" title="Last updated on Aug 21, 2026, 12:04 AM UTC (9d2f96e)">Diff</a>