### PR TITLE
Include end time & render-blocking in opaque responses

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -403,7 +403,8 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
 <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
 <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
-<a for="fetch timing info">start time</a>.
+<a for="fetch timing info">start time</a>, and whose <a for="fetch timing info">end time</a> is
+<var>timingInfo</var>'s <a for"fetch timing info">end time</a>.
 </div>
 
 <div algorithm>

--- a/fetch.bs
+++ b/fetch.bs
@@ -404,7 +404,7 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
 <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
 <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
 <a for="fetch timing info">start time</a>, <a for="fetch timing info">end time</a> is
-<var>timingInfo</var>'s <a for="fetch timing info">end time</a>, and whose
+<var>timingInfo</var>'s <a for="fetch timing info">end time</a>, and
 <a for="fetch timing info">render-blocking</a> is <var>timingInfo</var>'s
 <a for="fetch timing info">render-blocking</a>.
 </div>

--- a/fetch.bs
+++ b/fetch.bs
@@ -404,7 +404,7 @@ given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
 <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
 <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
 <a for="fetch timing info">start time</a>, and whose <a for="fetch timing info">end time</a> is
-<var>timingInfo</var>'s <a for"fetch timing info">end time</a>.
+<var>timingInfo</var>'s <a for="fetch timing info">end time</a>.
 </div>
 
 <div algorithm>

--- a/fetch.bs
+++ b/fetch.bs
@@ -403,8 +403,10 @@ following <a for=struct>items</a>: [[RESOURCE-TIMING]] [[NAVIGATION-TIMING]]
 given a <a for=/>fetch timing info</a> <var>timingInfo</var>, return a new
 <a for=/>fetch timing info</a> whose <a for="fetch timing info">start time</a> and
 <a for="fetch timing info">post-redirect start time</a> are <var>timingInfo</var>'s
-<a for="fetch timing info">start time</a>, and whose <a for="fetch timing info">end time</a> is
-<var>timingInfo</var>'s <a for="fetch timing info">end time</a>.
+<a for="fetch timing info">start time</a>, <a for="fetch timing info">end time</a> is
+<var>timingInfo</var>'s <a for="fetch timing info">end time</a>, and whose
+<a for="fetch timing info">render-blocking</a> is <var>timingInfo</var>'s
+<a for="fetch timing info">render-blocking</a>.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Resource timing always includes `responseEnd` and `renderBlocking`, even when TAO is omitted.

Closes #1945

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fetch/1953.html" title="Last updated on Aug 25, 2026, 6:34 AM UTC (2c494ea)">Preview</a> | <a href="https://whatpr.org/fetch/1953/4a2b67d...2c494ea.html" title="Last updated on Aug 25, 2026, 6:34 AM UTC (2c494ea)">Diff</a>