### PR TITLE
Editorial: update embedder policy link text for html rename

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4435,7 +4435,7 @@ Cross-Origin-Resource-Policy     = %s"same-origin" / %s"same-site" / %s"cross-or
   Cross-Origin Embedder Policy below.
 
  <li><p>If the <a>cross-origin resource policy internal check</a> with <var>origin</var>,
- <var>embedderPolicy</var>'s <a for="embedder policy">report only value</a>, <var>response</var>,
+ <var>embedderPolicy</var>'s <a for="embedder policy">report-only value</a>, <var>response</var>,
  and <var>forNavigation</var> returns <b>blocked</b>, then
  <a>queue a cross-origin embedder policy CORP violation report</a> with <var>response</var>,
  <var>settingsObject</var>, <var>destination</var>, and true.
@@ -4551,7 +4551,7 @@ run these steps:
  <li><p>Let <var>endpoint</var> be <var>settingsObject</var>'s
  <a for="environment settings object">policy container</a>'s
  <a for="policy container">embedder policy</a>'s
- <a for="embedder policy">report only reporting endpoint</a> if <var>reportOnly</var> is true and
+ <a for="embedder policy">report-only reporting endpoint</a> if <var>reportOnly</var> is true and
  <var>settingsObject</var>'s <a for="environment settings object">policy container</a>'s
  <a for="policy container">embedder policy</a>'s
  <a for="embedder policy">reporting endpoint</a> otherwise.


### PR DESCRIPTION
For whatwg/html commit 8ad51e24 hyphenating the "report-only value" and "report-only reporting endpoint" dfns.