### PR TITLE
Meta: export a response's redirect taint/timing allow passed flag

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -2612,8 +2612,8 @@ of the attack.
 (a boolean), which is initially true.
 
 <p>A <a for=/>response</a> has an associated
-<dfn for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>, which is
-initially unset.
+<dfn export for=response id=concept-response-timing-allow-passed>timing allow passed flag</dfn>,
+which is initially unset.
 
 <p class=note>This is used so that the caller to a fetch can determine if sensitive timing data is
 allowed on the resource fetched by looking at the flag of the response returned. Because the flag on
@@ -2638,7 +2638,7 @@ in the redirect chain.
 <dfn export for=response>service worker timing info</dfn> (null or a
 <a for=/>service worker timing info</a>), which is initially null.
 
-<p>A <a for=/>response</a> has an associated <dfn for=response>redirect taint</dfn>
+<p>A <a for=/>response</a> has an associated <dfn export for=response>redirect taint</dfn>
 ("<code>same-origin</code>", "<code>same-site</code>", or "<code>cross-site</code>"), which is
 initially "<code>same-origin</code>".
 


### PR DESCRIPTION
These are referenced by HTML.